### PR TITLE
Revert command error handling to be return codes instead of exceptions

### DIFF
--- a/command_response.c
+++ b/command_response.c
@@ -15,8 +15,6 @@
 
 #include "command_response.h"
 
-#include <zend_exceptions.h>
-
 #include "ext/standard/php_var.h"
 #include "include/glide/command_request.pb-c.h"
 #include "include/glide/response.pb-c.h"
@@ -354,10 +352,10 @@ CommandResult* execute_command_with_route(const void*          glide_client,
     if (!result) {
         printf("Error: Command execution returned NULL result\n");
     } else if (result->command_error) {
-        zend_throw_exception(
-            get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
-        free_command_result(result);
-        return NULL;
+        printf("Error: Command execution failed: %s\n",
+               result->command_error->command_error_message
+                   ? result->command_error->command_error_message
+                   : "Unknown error");
     }
 
     return result;
@@ -386,12 +384,6 @@ CommandResult* execute_command(const void*          glide_client,
                                     0             /* span pointer */
     );
 
-    if (result->command_error) {
-        zend_throw_exception(
-            get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
-        free_command_result(result);
-        return NULL;
-    }
     return result;
 }
 
@@ -404,8 +396,10 @@ long handle_int_response(CommandResult* result, long* output_value) {
 
     /* Check if there was an error */
     if (result->command_error) {
-        zend_throw_exception(
-            get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+        printf("%s:%d - Error executing command: %s\n",
+               __FILE__,
+               __LINE__,
+               result->command_error->command_error_message);
         free_command_result(result);
         return 0; /* False - failure */
     }
@@ -436,8 +430,10 @@ int handle_string_response(CommandResult* result, char** output, size_t* output_
 
     /* Check if there was an error */
     if (result->command_error) {
-        zend_throw_exception(
-            get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+        printf("%s:%d - Error executing command: %s\n",
+               __FILE__,
+               __LINE__,
+               result->command_error->command_error_message);
         free_command_result(result);
         return -1;
     }
@@ -503,8 +499,10 @@ int handle_bool_response(CommandResult* result) {
 
     /* Check if there was an error */
     if (result->command_error) {
-        zend_throw_exception(
-            get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+        printf("%s:%d - Error executing command: %s\n",
+               __FILE__,
+               __LINE__,
+               result->command_error->command_error_message);
         free_command_result(result);
         return -1;
     }
@@ -530,8 +528,10 @@ int handle_ok_response(CommandResult* result) {
 
     /* Check if there was an error */
     if (result->command_error) {
-        zend_throw_exception(
-            get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+        printf("%s:%d - Error executing command: %s\n",
+               __FILE__,
+               __LINE__,
+               result->command_error->command_error_message);
         free_command_result(result);
         return -1;
     }
@@ -765,8 +765,10 @@ int handle_array_response(CommandResult* result, zval* output) {
 
     /* Check if there was an error */
     if (result->command_error) {
-        zend_throw_exception(
-            get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+        printf("%s:%d - Error executing command: %s\n",
+               __FILE__,
+               __LINE__,
+               result->command_error->command_error_message);
         free_command_result(result);
         return -1;
     }
@@ -800,8 +802,10 @@ int handle_map_response(CommandResult* result, zval* output) {
 
     /* Check if there was an error */
     if (result->command_error) {
-        zend_throw_exception(
-            get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+        printf("%s:%d - Error executing command: %s\n",
+               __FILE__,
+               __LINE__,
+               result->command_error->command_error_message);
         free_command_result(result);
         return -1;
     }
@@ -835,8 +839,10 @@ int handle_set_response(CommandResult* result, zval* output) {
 
     /* Check if there was an error */
     if (result->command_error) {
-        zend_throw_exception(
-            get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+        printf("%s:%d - Error executing command: %s\n",
+               __FILE__,
+               __LINE__,
+               result->command_error->command_error_message);
         free_command_result(result);
         return -1;
     }

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -882,7 +882,7 @@ class TestSuite
                 if ($e instanceof TestSkippedException) {
                     $result = self::makeWarning('SKIPPED');
                 } else {
-                    $class_name::$errors[] = "Uncaught exception '" . $e->getMessage() . "' ($name)\n";
+                    $class_name::$errors[] = "Uncaught exception '" . $e->getMessage() . "' ($name)\n" . $e->getTraceAsString() . "\n";
                     $result = self::makeFail('FAILED');
                 }
             }


### PR DESCRIPTION
Change handling of command response errors to return true/false instead of throwing exceptions for
consistency with PHPRedis. Update tests expecting exceptions to instead expect false return values.

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): [#18]

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
