### PR TITLE
Implement whitebox testing of constructor arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,12 +88,15 @@ valkey_glide_arginfo.h
 valkey_glide_cluster_arginfo.h
 valkey_glide_cluster_legacy_arginfo.h
 valkey_glide_legacy_arginfo.h
+logger_arginfo.h
+logger_legacy_arginfo.h
 run-tests.php
 modules/valkey_glide.so
 libtool
 cluster_scan_cursor_legacy_arginfo.h
 cluster_scan_cursor_arginfo.h
 tests/valkey_data/*/valkey.log
+composer.lock
 configure
 configure.ac
 config.h.in
@@ -106,3 +109,6 @@ Makefile.objects
 autom4te.cache
 config.h.in~
 configure~
+tests/Connection_request/**
+tests/GPBMetadata/**
+vendor/**

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ src/**
 include/**
 lib/**
 .libs/**
+tests/.libs/**
 *.dep
 *.lo
 valkey_glide.la
@@ -111,4 +112,6 @@ config.h.in~
 configure~
 tests/Connection_request/**
 tests/GPBMetadata/**
+tests/client_constructor_mock_arginfo.h
+tests/client_constructor_mock_legacy_arginfo.h
 vendor/**

--- a/Makefile.frag
+++ b/Makefile.frag
@@ -74,13 +74,17 @@ cluster_scan_cursor_arginfo.h: cluster_scan_cursor.stub.php
 	@echo "Generating arginfo from cluster_scan_cursor.stub.php"
 	$(PHP_EXECUTABLE) build/gen_stub.php --no-legacy-arginfo cluster_scan_cursor.stub.php
 
-ARGINFO_HEADERS = valkey_glide_arginfo.h valkey_glide_cluster_arginfo.h cluster_scan_cursor_arginfo.h logger_arginfo.h
+tests/client_constructor_mock_arginfo.h: tests/client_constructor_mock.stub.php
+	@echo "Generating arginfo from tests/client_constructor_mock_arginfo.stub.php"
+	$(PHP_EXECUTABLE) build/gen_stub.php --no-legacy-arginfo tests/client_constructor_mock.stub.php
+
+ARGINFO_HEADERS = valkey_glide_arginfo.h valkey_glide_cluster_arginfo.h cluster_scan_cursor_arginfo.h logger_arginfo.h tests/client_constructor_mock_arginfo.h
 
 all: $(ARGINFO_HEADERS)
 
 .PHONY: build-modules-pre
 
-build-modules-pre: valkey_glide_arginfo.h valkey_glide_cluster_arginfo.h cluster_scan_cursor_arginfo.h logger_arginfo.h
+build-modules-pre: valkey_glide_arginfo.h valkey_glide_cluster_arginfo.h cluster_scan_cursor_arginfo.h logger_arginfo.h tests/client_constructor_mock_arginfo.h
 	@$(MAKE) generate-proto
 	@$(MAKE) generate-bindings
 

--- a/common.h
+++ b/common.h
@@ -80,7 +80,7 @@ typedef struct {
 } valkey_glide_tls_advanced_configuration_t;
 
 typedef struct {
-    int                                        connection_timeout; /* -1 if not set */
+    int                                        connection_timeout; /* In milliseconds. Default 250ms */
     valkey_glide_tls_advanced_configuration_t* tls_config;         /* NULL if not set */
 } valkey_glide_advanced_base_client_configuration_t;
 

--- a/common.h
+++ b/common.h
@@ -68,10 +68,11 @@ typedef struct {
 } valkey_glide_server_credentials_t;
 
 typedef struct {
-    int num_of_retries;
-    int factor;
-    int exponent_base;
-    int jitter_percent; /* -1 if not set */
+    /* Defaults taken from retry_strategies.rs */
+    int num_of_retries; /* 5 if not set */
+    int factor;         /* 100 if not set */
+    int exponent_base;  /* 2 if not set */
+    int jitter_percent; /* 20 if not set */
 } valkey_glide_backoff_strategy_t;
 
 typedef struct {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,9 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.7",
-        "phpstan/phpstan": "^1.10"
+        "phpstan/phpstan": "^1.10",
+        "google/protobuf": "^v4.31.1",
+        "protobuf-php/protobuf-plugin": "^0.1.3"
     },
     "autoload": {
         "psr-4": {
@@ -24,7 +26,9 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "ValkeyGlide\\Tests\\": "tests/"
+            "ValkeyGlide\\Tests\\": "tests/",
+            "ValkeyGlide\\Tests\\GeneratedMetadata": "tests/GPBMetadata",
+            "ValkeyGlide\\Tests\\ConnectionRequest": "tests/Connection_request"
         }
     },
     "scripts": {

--- a/config.m4
+++ b/config.m4
@@ -52,7 +52,7 @@ if test "$PHP_VALKEY_GLIDE" != "no"; then
     LDFLAGS="$LDFLAGS $PHP_VALKEY_GLIDE_LDFLAGS"
   fi
   PHP_NEW_EXTENSION(valkey_glide,
-    valkey_glide.c valkey_glide_cluster.c cluster_scan_cursor.c command_response.c logger.c valkey_glide_commands.c valkey_glide_commands_2.c valkey_glide_commands_3.c valkey_glide_core_commands.c valkey_glide_core_common.c valkey_glide_expire_commands.c valkey_glide_geo_commands.c valkey_glide_geo_common.c valkey_glide_hash_common.c valkey_glide_list_common.c valkey_glide_s_common.c valkey_glide_str_commands.c valkey_glide_x_commands.c valkey_glide_x_common.c valkey_glide_z.c valkey_glide_z_common.c valkey_z_php_methods.c src/command_request.pb-c.c src/connection_request.pb-c.c src/response.pb-c.c,
+    valkey_glide.c valkey_glide_cluster.c cluster_scan_cursor.c command_response.c logger.c valkey_glide_commands.c valkey_glide_commands_2.c valkey_glide_commands_3.c valkey_glide_core_commands.c valkey_glide_core_common.c valkey_glide_expire_commands.c valkey_glide_geo_commands.c valkey_glide_geo_common.c valkey_glide_hash_common.c valkey_glide_list_common.c valkey_glide_s_common.c valkey_glide_str_commands.c valkey_glide_x_commands.c valkey_glide_x_common.c valkey_glide_z.c valkey_glide_z_common.c valkey_z_php_methods.c src/command_request.pb-c.c src/connection_request.pb-c.c src/response.pb-c.c tests/client_constructor_mock.c,
     $ext_shared)
 
   EXTRA_DIST="$EXTRA_DIST valkey_glide.stub.php valkey_glide_cluster.stub.php logger.stub.php"

--- a/php_build.sh
+++ b/php_build.sh
@@ -7,6 +7,8 @@ cd valkey-glide/ffi
 cargo build --release
 cd ../../
 
+protoc --proto_path=./valkey-glide/glide-core/src/protobuf --php_out=./tests/generated ./valkey-glide/glide-core/src/protobuf/connection_request.proto
+
 phpize
 ./configure --enable-valkey-glide
 make -j4 build-modules-pre

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,8 @@ parameters:
         - examples
     excludePaths:
         - tests/generated
+        - tests/Connection_request
+        - tests/GPBMetadata
         - vendor
         - autom4te.cache
         - build

--- a/tests/ConnectionRequestTest.php
+++ b/tests/ConnectionRequestTest.php
@@ -108,10 +108,255 @@ class ConnectionRequestTest extends \TestSuite
 
     public function testStandaloneBasicConstructor() {
         $request = ClientConstructorMock::simulate_standalone_constructor([['host' => 'localhost', 'port' => 8080]]);
+        $this->assertFalse($request->getClusterModeEnabled());
         $addresses = $request->getAddresses();
         $this->assertEquals(1, count($addresses));
         $address = $addresses[0];
         $this->assertEquals('localhost', $address->getHost());
         $this->assertEquals(8080, $address->getPort());
+    }
+
+    public function testStandaloneMultipleAddresses() {
+        $request = ClientConstructorMock::simulate_standalone_constructor([
+            ['host' => 'localhost', 'port' => 8080],
+            ['host' => '172.0.1.24', 'port' => 9000]]);
+        $addresses = $request->getAddresses();
+        $this->assertEquals(2, count($addresses));
+        $address = $addresses[0];
+        $this->assertEquals('localhost', $address->getHost());
+        $this->assertEquals(8080, $address->getPort());
+        $address = $addresses[1];
+        $this->assertEquals('172.0.1.24', $address->getHost());
+        $this->assertEquals(9000, $address->getPort());
+    }
+
+    public function testClusterBasicConstructor() {
+        $request = ClientConstructorMock::simulate_cluster_constructor([['host' => 'localhost', 'port' => 8080]]);
+        $this->assertTrue($request->getClusterModeEnabled());
+        $addresses = $request->getAddresses();
+        $this->assertEquals(1, count($addresses));
+        $address = $addresses[0];
+        $this->assertEquals('localhost', $address->getHost());
+        $this->assertEquals(8080, $address->getPort());
+    }
+
+    public function testClusterMultipleAddresses() {
+        $request = ClientConstructorMock::simulate_cluster_constructor([
+            ['host' => 'localhost', 'port' => 8080],
+            ['host' => '172.0.1.24', 'port' => 9000]]);
+        $addresses = $request->getAddresses();
+        $this->assertEquals(2, count($addresses));
+        $address = $addresses[0];
+        $this->assertEquals('localhost', $address->getHost());
+        $this->assertEquals(8080, $address->getPort());
+        $address = $addresses[1];
+        $this->assertEquals('172.0.1.24', $address->getHost());
+        $this->assertEquals(9000, $address->getPort());
+    }
+
+    public function testStandaloneUseTlsOn() {
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            use_tls: true);
+        $this->assertEquals(\Connection_request\TlsMode::SecureTls, $request->getTlsMode());
+    }
+
+    public function testClusterUseTlsOn() {
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            use_tls: true);
+        $this->assertEquals(\Connection_request\TlsMode::SecureTls, $request->getTlsMode());
+    }
+
+    public function testStandaloneUseTlsOff() {
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            use_tls: false);
+        $this->assertEquals(\Connection_request\TlsMode::NoTls, $request->getTlsMode());
+    }
+
+    public function testClusterUseTlsOff() {
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            use_tls: false);
+        $this->assertEquals(\Connection_request\TlsMode::NoTls, $request->getTlsMode());
+    }
+
+    public function testStandaloneCredentials() {
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            credentials: ['username' => 'user', 'password' => 'pass']);
+        $this->assertEquals('user', $request->getAuthenticationInfo()->getUsername());
+        $this->assertEquals('pass', $request->getAuthenticationInfo()->getPassword());
+    }
+
+    public function testClusterCredentials() {
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            credentials: ['username' => 'user', 'password' => 'pass']);
+        $this->assertEquals('user', $request->getAuthenticationInfo()->getUsername());
+        $this->assertEquals('pass', $request->getAuthenticationInfo()->getPassword());
+    }
+
+    public function testStandaloneReadFrom() {
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            read_from: ValkeyGlide::READ_FROM_AZ_AFFINITY);
+
+        $this->assertEquals(\Connection_request\ReadFrom::AZAffinity, $request->getReadFrom());
+    }
+
+    public function testClusterReadFrom() {
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            read_from: ValkeyGlide::READ_FROM_AZ_AFFINITY_REPLICAS_AND_PRIMARY);
+
+        $this->assertEquals(\Connection_request\ReadFrom::AZAffinityReplicasAndPrimary, $request->getReadFrom());
+    }
+
+    public function testStandaloneRequestTimeout() {
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            request_timeout: 999);
+
+        $this->assertEquals(999, $request->getRequestTimeout());
+    }
+
+    public function testClusterRequestTimeout() {
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            request_timeout: 999);
+
+        $this->assertEquals(999, $request->getRequestTimeout());
+    }
+
+    public function testStandaloneReconnectStrategy() {
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            reconnect_strategy: ['num_of_retries' => 2, 'factor' => 3, 'exponent_base' => 7, 'jitter_percent' => 15]);
+
+        $this->assertEquals(2, $request->getConnectionRetryStrategy()->getNumberOfRetries());
+        $this->assertEquals(3, $request->getConnectionRetryStrategy()->getFactor());
+        $this->assertEquals(7, $request->getConnectionRetryStrategy()->getExponentBase());
+        $this->assertEquals(15, $request->getConnectionRetryStrategy()->getJitterPercent());
+    }
+
+    public function testClusterReconnectStrategy() {
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            reconnect_strategy: ['num_of_retries' => 2, 'factor' => 3, 'exponent_base' => 7, 'jitter_percent' => 15]);
+
+        $this->assertEquals(2, $request->getConnectionRetryStrategy()->getNumberOfRetries());
+        $this->assertEquals(3, $request->getConnectionRetryStrategy()->getFactor());
+        $this->assertEquals(7, $request->getConnectionRetryStrategy()->getExponentBase());
+        $this->assertEquals(15, $request->getConnectionRetryStrategy()->getJitterPercent());
+    }
+
+    public function testStandaloneClientName() {
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            client_name: 'foobar');
+
+        $this->assertEquals('foobar', $request->getClientName());
+    }
+
+    public function testClusterClientName() {
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            client_name: 'foobar');
+
+        $this->assertEquals('foobar', $request->getClientName());
+    }
+
+    public function testStandaloneClientAz() {
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            client_az: 'us-east-1');
+
+        $this->assertEquals('us-east-1', $request->getClientAz());
+    }
+
+    public function testClusterClientAz() {
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            client_az: 'us-east-1');
+
+        $this->assertEquals('us-east-1', $request->getClientAz());
+    }
+
+    public function testStandaloneAdvancedConfig() {
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            advanced_config: ['connection_timeout' => 999]);
+
+        $this->assertEquals(999, $request->getConnectionTimeout());
+    }
+
+    public function testClusterAdvancedConfig() {
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            advanced_config: ['connection_timeout' => 999]);
+
+        $this->assertEquals(999, $request->getConnectionTimeout());
+    }
+
+    public function testStandaloneInsecureTls() {
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            use_tls: true,
+            advanced_config: ['tls_config' => ['use_insecure_tls' => true]]);
+
+        $this->assertEquals(\Connection_request\TlsMode::InsecureTls, $request->getTlsMode());
+    }
+
+    public function testClusterInsecureTls() {
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            use_tls: true,
+            advanced_config: ['tls_config' => ['use_insecure_tls' => true]]);
+
+        $this->assertEquals(\Connection_request\TlsMode::InsecureTls, $request->getTlsMode());
+    }
+
+    public function testStandaloneLazyConnect() {
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            lazy_connect: true);
+
+        $this->assertEquals(true, $request->getLazyConnect());
+    }
+
+    public function testClusterLazyConnect() {
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            lazy_connect: true);
+
+        $this->assertEquals(true, $request->getLazyConnect());
+    }
+
+    public function testStandaloneDatabaseId() {
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            database_id: 7);
+
+        $this->assertEquals(7, $request->getDatabaseId());
+    }
+
+    public function testClusterPeriodicChecksDisabled() {
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            periodic_checks: ValkeyGlideCluster::PERIODIC_CHECK_DISABLED);
+
+        $this->assertTrue($request->hasPeriodicChecksDisabled());
+        $this->assertFalse($request->hasPeriodicChecksManualInterval());
+    }
+
+    public function testClusterPeriodicChecksDefault() {
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            periodic_checks: ValkeyGlideCluster::PERIODIC_CHECK_ENABLED_DEFAULT_CONFIGS);
+
+        $this->assertFalse($request->hasPeriodicChecksDisabled());
+        $this->assertTrue($request->hasPeriodicChecksManualInterval());
     }
 }

--- a/tests/client_constructor_mock.c
+++ b/tests/client_constructor_mock.c
@@ -1,0 +1,188 @@
+/*
+  +----------------------------------------------------------------------+
+  +----------------------------------------------------------------------+
+  | Copyright (c) 2023-2025 The PHP Group                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+*/
+
+#include "common.h"
+#include "ext/standard/info.h"
+#include "php.h"
+#include "zend_exceptions.h"
+
+#if PHP_VERSION_ID < 80000
+#include "tests/client_constructor_mock_legacy_arginfo.h"
+#else
+#include "tests/client_constructor_mock_arginfo.h"
+#include "zend_attributes.h"
+#endif
+
+#include "valkey_glide_commands_common.h"
+#include "zend_API.h"
+#include "zend_interfaces.h"
+
+/* Global variables */
+zend_class_entry* mock_constructor_ce;
+
+void register_mock_constructor_class(void) {
+    /* Use the generated registration function */
+    mock_constructor_ce = register_class_ClientConstructorMock();
+}
+
+static zval* build_php_connection_request(uint8_t*                                  request_bytes,
+                                          size_t                                    request_len,
+                                          valkey_glide_base_client_configuration_t* base_config) {
+    if (!request_bytes) {
+        const char* error_message = "Protobuf memory allocation error.";
+        zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+        valkey_glide_cleanup_client_config(base_config);
+        return NULL;
+    }
+
+    zval buffer_param, callable, retval;
+    ZVAL_UNDEF(&retval);
+    ZVAL_STRINGL(&buffer_param, (char*) request_bytes, request_len);
+
+    zval params[1];
+    params[0] = buffer_param;
+    array_init(&callable);
+    add_next_index_string(&callable, "ConnectionRequestTest");
+    add_next_index_string(&callable, "deserialize");
+
+    zval* result = NULL;
+    if (call_user_function(NULL, NULL, &callable, &retval, 1, params) == SUCCESS) {
+        // Allocate return value
+        result = emalloc(sizeof(zval));
+        ZVAL_COPY(result, &retval);
+    }
+
+    zval_ptr_dtor(&callable);
+    zval_ptr_dtor(&retval);
+    zval_ptr_dtor(&buffer_param);
+
+    efree(request_bytes);
+    valkey_glide_cleanup_client_config(base_config);
+    return result;
+}
+
+/*
+ * PHP Methods
+ */
+
+PHP_METHOD(ClientConstructorMock, simulate_standalone_constructor) {
+    valkey_glide_php_common_constructor_params_t common_params;
+    valkey_glide_init_common_constructor_params(&common_params);
+    zend_long database_id         = 0;
+    zend_bool database_id_is_null = 1;
+
+    ZEND_PARSE_PARAMETERS_START(1, 11)
+    Z_PARAM_ARRAY(common_params.addresses)
+    Z_PARAM_OPTIONAL
+    Z_PARAM_BOOL(common_params.use_tls)
+    Z_PARAM_ARRAY_OR_NULL(common_params.credentials)
+    Z_PARAM_LONG(common_params.read_from)
+    Z_PARAM_LONG_OR_NULL(common_params.request_timeout, common_params.request_timeout_is_null)
+    Z_PARAM_ARRAY_OR_NULL(common_params.reconnect_strategy)
+    Z_PARAM_LONG_OR_NULL(database_id, database_id_is_null)
+    Z_PARAM_STRING_OR_NULL(common_params.client_name, common_params.client_name_len)
+    Z_PARAM_STRING_OR_NULL(common_params.client_az, common_params.client_az_len)
+    Z_PARAM_ARRAY_OR_NULL(common_params.advanced_config)
+    Z_PARAM_BOOL_OR_NULL(common_params.lazy_connect, common_params.lazy_connect_is_null)
+    ZEND_PARSE_PARAMETERS_END_EX(RETURN_THROWS());
+
+    /* Validate addresses array */
+    if (!common_params.addresses ||
+        zend_hash_num_elements(Z_ARRVAL_P(common_params.addresses)) == 0) {
+        const char* error_message = "Addresses array cannot be empty";
+        zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+        return;
+    }
+
+    /* Build client configuration from individual parameters */
+    valkey_glide_client_configuration_t client_config;
+    memset(&client_config, 0, sizeof(client_config));
+    client_config.database_id = database_id_is_null ? -1 : database_id; /* -1 means not set */
+
+    /* Validate database_id range */
+    if (client_config.database_id != -1 &&
+        (client_config.database_id < 0 || client_config.database_id > 15)) {
+        const char* error_message = "Database ID must be between 0 and 15 inclusive.";
+        zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+        valkey_glide_cleanup_client_config(&client_config.base);
+        return;
+    }
+
+    /* Populate configuration parameters shared between client and cluster connections. */
+    valkey_glide_build_client_config_base(&common_params, &client_config.base, false);
+
+    /* Build the connection request. */
+    size_t   protobuf_message_len;
+    uint8_t* request_bytes = create_connection_request("localhost",
+                                                       6379,
+                                                       &protobuf_message_len,
+                                                       &client_config.base,
+                                                       client_config.database_id,
+                                                       0,
+                                                       false);
+
+    zval* php_request =
+        build_php_connection_request(request_bytes, protobuf_message_len, &client_config.base);
+    RETURN_ZVAL(php_request, 1, 1);
+}
+
+/* Simulates a ValkeyGlideCluster constructor */
+PHP_METHOD(ClientConstructorMock, simulate_cluster_constructor) {
+    zend_long                                    periodic_checks         = 0;
+    zend_bool                                    periodic_checks_is_null = 1;
+    valkey_glide_php_common_constructor_params_t common_params;
+    valkey_glide_init_common_constructor_params(&common_params);
+
+    ZEND_PARSE_PARAMETERS_START(1, 11)
+    Z_PARAM_ARRAY(common_params.addresses)
+    Z_PARAM_OPTIONAL
+    Z_PARAM_BOOL(common_params.use_tls)
+    Z_PARAM_ARRAY_OR_NULL(common_params.credentials)
+    Z_PARAM_LONG(common_params.read_from)
+    Z_PARAM_LONG_OR_NULL(common_params.request_timeout, common_params.request_timeout_is_null)
+    Z_PARAM_ARRAY_OR_NULL(common_params.reconnect_strategy)
+    Z_PARAM_STRING_OR_NULL(common_params.client_name, common_params.client_name_len)
+    Z_PARAM_LONG_OR_NULL(periodic_checks, periodic_checks_is_null)
+    Z_PARAM_STRING_OR_NULL(common_params.client_az, common_params.client_az_len)
+    Z_PARAM_ARRAY_OR_NULL(common_params.advanced_config)
+    Z_PARAM_BOOL_OR_NULL(common_params.lazy_connect, common_params.lazy_connect_is_null)
+    ZEND_PARSE_PARAMETERS_END_EX(RETURN_THROWS());
+
+    /* Build cluster client configuration from individual parameters */
+    valkey_glide_cluster_client_configuration_t client_config;
+    memset(&client_config, 0, sizeof(client_config));
+
+    /* Set periodic checks */
+    client_config.periodic_checks_status =
+        periodic_checks_is_null ? VALKEY_GLIDE_PERIODIC_CHECKS_ENABLED_DEFAULT : periodic_checks;
+    client_config.periodic_checks_manual = NULL;
+
+    /* Populate configuration parameters shared between client and cluster connections. */
+    valkey_glide_build_client_config_base(&common_params, &client_config.base, true);
+
+    /* Build the connection request. */
+    size_t   protobuf_message_len;
+    uint8_t* request_bytes = create_connection_request("localhost",
+                                                       6379,
+                                                       &protobuf_message_len,
+                                                       &client_config.base,
+                                                       0,
+                                                       client_config.periodic_checks_status,
+                                                       true);
+
+    zval* php_request =
+        build_php_connection_request(request_bytes, protobuf_message_len, &client_config.base);
+    RETURN_ZVAL(php_request, 1, 1);
+}

--- a/tests/client_constructor_mock.stub.php
+++ b/tests/client_constructor_mock.stub.php
@@ -83,17 +83,20 @@ class ClientConstructorMock
     /**
      * Mock creation of a standalone connection request instance with the provided configuration.
      *
-     * @param array $addresses                   Array of server addresses [['host' => 'localhost', 'port' => 6379], ...]
-     * @param bool $use_tls                      Whether to use TLS encryption
-     * @param array|null $credentials            Authentication credentials ['password' => 'xxx', 'username' => 'yyy']
-     * @param int $read_from                     Read strategy for the client (Not yet supported.)
-     * @param int|null $request_timeout          Request timeout in milliseconds
-     * @param array|null $reconnect_strategy     Reconnection strategy ['num_of_retries' => 3, 'factor' => 2, ...] (Not yet supported.)
+     * @param array $addresses                   Array of server addresses [['host' => 'localhost', 'port' => 6379], ...].
+     * @param bool $use_tls                      Whether to use TLS encryption.
+     * @param array|null $credentials            Authentication credentials ['password' => 'xxx', 'username' => 'yyy'].
+     * @param int $read_from                     Read strategy for the client.
+     * @param int|null $request_timeout          Request timeout in milliseconds.
+     * @param array|null $reconnect_strategy     Reconnection strategy ['num_of_retries' => 3, 'factor' => 2,
+     *                                           'exponent_base' => 10, 'jitter_percent' => 15].
      * @param int|null $database_id              Database ID to select (0-15)
-     * @param string|null $client_name           Client name identifier
-     * @param string|null $client_az             Client availability zone (Not yet supported.)
-     * @param array|null $advanced_config        Advanced configuration ['connection_timeout' => 5000, 'tls_config' => [...]]
-     * @param bool|null $lazy_connect            Whether to use lazy connection
+     * @param string|null $client_name           Client name identifier.
+     * @param string|null $client_az             Client availability zone.
+     * @param array|null $advanced_config        Advanced configuration ['connection_timeout' => 5000,
+     *                                           'tls_config' => ['use_insecure_tls' => false]].
+     *                                           connection_timeout is in milliseconds.
+     * @param bool|null $lazy_connect            Whether to use lazy connection.
      */
     public static function simulate_standalone_constructor(
         array $addresses,
@@ -112,17 +115,20 @@ class ClientConstructorMock
     /**
      * Mock creation of a cluster connection request instance with the provided configuration.
      *
-     * @param array $addresses                        Array of server addresses [['host' => '127.0.0.1', 'port' => 7001], ...]
-     * @param bool $use_tls                           Whether to use TLS encryption
-     * @param array|null $credentials                 Authentication credentials ['password' => 'xxx', 'username' => 'yyy']
-     * @param int $read_from                          Read strategy for the client
-     * @param int|null $request_timeout               Request timeout in milliseconds (Not yet supported.)
-     * @param array|null $reconnect_strategy          Reconnection strategy ['num_of_retries' => 3, 'factor' => 2, ...] (Not yet supported.)
-     * @param string|null $client_name                Client name identifier
-     * @param int|null $periodic_checks               Periodic checks configuration (Not yet supported.)
-     * @param string|null $client_az                  Client availability zone (Not yet supported.)
-     * @param array|null $advanced_config             Advanced configuration ['connection_timeout' => 5000, 'tls_config' => [...]]
-     * @param bool|null $lazy_connect                 Whether to use lazy connection
+     * @param array $addresses                        Array of server addresses [['host' => '127.0.0.1', 'port' => 7001], ...].
+     * @param bool $use_tls                           Whether to use TLS encryption.
+     * @param array|null $credentials                 Authentication credentials ['password' => 'xxx', 'username' => 'yyy'].
+     * @param int $read_from                          Read strategy for the client.
+     * @param int|null $request_timeout               Request timeout in milliseconds.
+     * @param array|null $reconnect_strategy          Reconnection strategy ['num_of_retries' => 3, 'factor' => 2,
+     *                                                'exponent_base' => 10, 'jitter_percent' => 15].
+     * @param string|null $client_name                Client name identifier.
+     * @param int|null $periodic_checks               Periodic checks configuration.
+     * @param string|null $client_az                  Client availability zone.
+     * @param array|null $advanced_config             Advanced configuration ['connection_timeout' => 5000,
+     *                                                'tls_config' => ['use_insecure_tls' => false]].
+     *                                                connection_timeout is in milliseconds.
+     * @param bool|null $lazy_connect                 Whether to use lazy connection.
      */
     public static function simulate_cluster_constructor(
         array $addresses,

--- a/tests/client_constructor_mock.stub.php
+++ b/tests/client_constructor_mock.stub.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * @generate-function-entries
+ * @generate-legacy-arginfo
+ * @generate-class-entries
+ */
+
+/*
+* --------------------------------------------------------------------
+*                   The PHP License, version 3.01
+* Copyright (c) 1999 - 2010 The PHP Group. All rights reserved.
+* --------------------------------------------------------------------
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, is permitted provided that the following conditions
+* are met:
+*
+*   1. Redistributions of source code must retain the above copyright
+*      notice, this list of conditions and the following disclaimer.
+*
+*  2. Redistributions in binary form must reproduce the above copyright
+*      notice, this list of conditions and the following disclaimer in
+*      the documentation and/or other materials provided with the
+*      distribution.
+*
+*   3. The name "PHP" must not be used to endorse or promote products
+*      derived from this software without prior written permission. For
+*      written permission, please contact group@php.net.
+*
+*   4. Products derived from this software may not be called "PHP", nor
+*      may "PHP" appear in their name, without prior written permission
+*      from group@php.net.  You may indicate that your software works in
+*      conjunction with PHP by saying "Foo for PHP" instead of calling
+*      it "PHP Foo" or "phpfoo"
+*
+*   5. The PHP Group may publish revised and/or new versions of the
+*      license from time to time. Each version will be given a
+*      distinguishing version number.
+*      Once covered code has been published under a particular version
+*      of the license, you may always continue to use it under the terms
+*      of that version. You may also choose to use such covered code
+*      under the terms of any subsequent version of the license
+*      published by the PHP Group. No one other than the PHP Group has
+*      the right to modify the terms applicable to covered code created
+*      under this License.
+*
+*   6. Redistributions of any form whatsoever must retain the following
+*      acknowledgment:
+*      "This product includes PHP software, freely available from
+*      <http://www.php.net/software/>".
+*
+* THIS SOFTWARE IS PROVIDED BY THE PHP DEVELOPMENT TEAM ``AS IS'' AND
+* ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+* PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE PHP
+* DEVELOPMENT TEAM OR ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+* STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+* OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* --------------------------------------------------------------------
+*
+* This software consists of voluntary contributions made by many
+* individuals on behalf of the PHP Group.
+*
+* The PHP Group can be contacted via Email at group@php.net.
+*
+* For more information on the PHP Group and the PHP project,
+* please see <http://www.php.net>.
+*
+* PHP includes the Zend Engine, freely available at
+* <http://www.zend.com>.
+*/
+
+class ClientConstructorMock
+{
+
+    /**
+     * Mock creation of a standalone connection request instance with the provided configuration.
+     *
+     * @param array $addresses                   Array of server addresses [['host' => 'localhost', 'port' => 6379], ...]
+     * @param bool $use_tls                      Whether to use TLS encryption
+     * @param array|null $credentials            Authentication credentials ['password' => 'xxx', 'username' => 'yyy']
+     * @param int $read_from                     Read strategy for the client (Not yet supported.)
+     * @param int|null $request_timeout          Request timeout in milliseconds
+     * @param array|null $reconnect_strategy     Reconnection strategy ['num_of_retries' => 3, 'factor' => 2, ...] (Not yet supported.)
+     * @param int|null $database_id              Database ID to select (0-15)
+     * @param string|null $client_name           Client name identifier
+     * @param string|null $client_az             Client availability zone (Not yet supported.)
+     * @param array|null $advanced_config        Advanced configuration ['connection_timeout' => 5000, 'tls_config' => [...]]
+     * @param bool|null $lazy_connect            Whether to use lazy connection
+     */
+    public static function simulate_standalone_constructor(
+        array $addresses,
+        bool $use_tls = false,
+        ?array $credentials = null,
+        int $read_from = ValkeyGlide::READ_FROM_PRIMARY,
+        ?int $request_timeout = null,
+        ?array $reconnect_strategy = null,
+        ?int $database_id = null,
+        ?string $client_name = null,
+        ?string $client_az = null,
+        ?array $advanced_config = null,
+        ?bool $lazy_connect = null
+    ) : \Connection_request\ConnectionRequest;
+
+    /**
+     * Mock creation of a cluster connection request instance with the provided configuration.
+     *
+     * @param array $addresses                        Array of server addresses [['host' => '127.0.0.1', 'port' => 7001], ...]
+     * @param bool $use_tls                           Whether to use TLS encryption
+     * @param array|null $credentials                 Authentication credentials ['password' => 'xxx', 'username' => 'yyy']
+     * @param int $read_from                          Read strategy for the client
+     * @param int|null $request_timeout               Request timeout in milliseconds (Not yet supported.)
+     * @param array|null $reconnect_strategy          Reconnection strategy ['num_of_retries' => 3, 'factor' => 2, ...] (Not yet supported.)
+     * @param string|null $client_name                Client name identifier
+     * @param int|null $periodic_checks               Periodic checks configuration (Not yet supported.)
+     * @param string|null $client_az                  Client availability zone (Not yet supported.)
+     * @param array|null $advanced_config             Advanced configuration ['connection_timeout' => 5000, 'tls_config' => [...]]
+     * @param bool|null $lazy_connect                 Whether to use lazy connection
+     */
+    public static function simulate_cluster_constructor(
+        array $addresses,
+        bool $use_tls = false,
+        ?array $credentials = null,
+        int $read_from = ValkeyGlide::READ_FROM_PREFER_REPLICA,
+        ?int $request_timeout = null,
+        ?array $reconnect_strategy = null,
+        ?string $client_name = null,
+        ?int $periodic_checks = ValkeyGlideCluster::PERIODIC_CHECK_ENABLED_DEFAULT_CONFIGS,
+        ?string $client_az = null,
+        ?array $advanced_config = null,
+        ?bool $lazy_connect = null
+    )  : \Connection_request\ConnectionRequest;
+}

--- a/tests/run_test
+++ b/tests/run_test
@@ -6,3 +6,5 @@ php TestValkeyGlide.php --class valkeyglidecluster
 # Run TLS-specific tests
 echo "Running TLS standalone tests"
 php TestValkeyGlide.php --class valkeyglideclientfeatures --tls --port 6400
+
+php TestValkeyGlide.php --class connectionrequest

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -32,6 +32,8 @@ extern int  parse_valkey_glide_client_configuration(zval*                       
                                                     valkey_glide_client_configuration_t* config);
 extern void free_valkey_glide_client_configuration(valkey_glide_client_configuration_t* config);
 
+void register_mock_constructor_class(void);
+
 zend_class_entry* valkey_glide_ce;
 zend_class_entry* valkey_glide_exception_ce;
 
@@ -342,6 +344,10 @@ PHP_MINIT_FUNCTION(valkey_glide) {
 
     /* Register ClusterScanCursor class */
     register_cluster_scan_cursor_class();
+
+    /* Register mock constructor class used for testing only. */
+    // TODO   Move test mock classes and code to a separate module.
+    register_mock_constructor_class();
 
     /* ValkeyGlideException class */
     // TODO   valkey_glide_exception_ce =

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -286,7 +286,7 @@ void valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_p
         if (conn_timeout_val && Z_TYPE_P(conn_timeout_val) == IS_LONG) {
             config->advanced_config->connection_timeout = Z_LVAL_P(conn_timeout_val);
         } else {
-            config->advanced_config->connection_timeout = -1; /* Not set */
+            config->advanced_config->connection_timeout = 250; /* Default 250ms from standalone_client.rs */
         }
 
         /* Check for TLS config */

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -243,26 +243,21 @@ void valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_p
         if (retries_val && Z_TYPE_P(retries_val) == IS_LONG) {
             config->reconnect_strategy->num_of_retries = Z_LVAL_P(retries_val);
         } else {
-            config->reconnect_strategy->num_of_retries = 3; /* Default */
+            config->reconnect_strategy->num_of_retries = 5; /* Default */
         }
 
         /* Check for factor */
         zval* factor_val = zend_hash_str_find(reconnect_ht, "factor", 6);
-        if (factor_val && (Z_TYPE_P(factor_val) == IS_DOUBLE || Z_TYPE_P(factor_val) == IS_LONG)) {
-            config->reconnect_strategy->factor = Z_TYPE_P(factor_val) == IS_DOUBLE
-                                                     ? Z_DVAL_P(factor_val)
-                                                     : (double) Z_LVAL_P(factor_val);
+        if (factor_val && Z_TYPE_P(factor_val) == IS_LONG) {
+            config->reconnect_strategy->factor = Z_LVAL_P(factor_val);
         } else {
-            config->reconnect_strategy->factor = 2.0; /* Default */
+            config->reconnect_strategy->factor = 100; /* Default */
         }
 
         /* Check for exponent_base */
         zval* exponent_val = zend_hash_str_find(reconnect_ht, "exponent_base", 13);
-        if (exponent_val &&
-            (Z_TYPE_P(exponent_val) == IS_DOUBLE || Z_TYPE_P(exponent_val) == IS_LONG)) {
-            config->reconnect_strategy->exponent_base = Z_TYPE_P(exponent_val) == IS_DOUBLE
-                                                            ? Z_DVAL_P(exponent_val)
-                                                            : (double) Z_LVAL_P(exponent_val);
+        if (exponent_val && Z_TYPE_P(exponent_val) == IS_LONG) {
+            config->reconnect_strategy->exponent_base = Z_LVAL_P(exponent_val);
         } else {
             config->reconnect_strategy->exponent_base = 2; /* Default */
         }
@@ -272,7 +267,7 @@ void valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_p
         if (jitter_val && Z_TYPE_P(jitter_val) == IS_LONG) {
             config->reconnect_strategy->jitter_percent = Z_LVAL_P(jitter_val);
         } else {
-            config->reconnect_strategy->jitter_percent = -1; /* Not set */
+            config->reconnect_strategy->jitter_percent = 20; /* Not set */
         }
     } else {
         config->reconnect_strategy = NULL;

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -221,17 +221,20 @@ class ValkeyGlide
     /**
      * Create a new ValkeyGlide instance with the provided configuration.
      *
-     * @param array $addresses                   Array of server addresses [['host' => 'localhost', 'port' => 6379], ...]
-     * @param bool $use_tls                      Whether to use TLS encryption
-     * @param array|null $credentials            Authentication credentials ['password' => 'xxx', 'username' => 'yyy']
-     * @param int $read_from                     Read strategy for the client (Not yet supported.)
-     * @param int|null $request_timeout          Request timeout in milliseconds
-     * @param array|null $reconnect_strategy     Reconnection strategy ['num_of_retries' => 3, 'factor' => 2, ...] (Not yet supported.)
-     * @param int|null $database_id              Database ID to select (0-15)
-     * @param string|null $client_name           Client name identifier
-     * @param string|null $client_az             Client availability zone (Not yet supported.)
-     * @param array|null $advanced_config        Advanced configuration ['connection_timeout' => 5000, 'tls_config' => [...]]
-     * @param bool|null $lazy_connect            Whether to use lazy connection
+     * @param array $addresses                  Array of server addresses [['host' => 'localhost', 'port' => 6379], ...].
+     * @param bool $use_tls                     Whether to use TLS encryption.
+     * @param array|null $credentials           Authentication credentials ['password' => 'xxx', 'username' => 'yyy'].
+     * @param int $read_from                    Read strategy for the client.
+     * @param int|null $request_timeout         Request timeout in milliseconds.
+     * @param array|null $reconnect_strategy    Reconnection strategy ['num_of_retries' => 3, 'factor' => 2,
+     *                                          'exponent_base' => 10, 'jitter_percent' => 15].
+     * @param int|null $database_id             Database ID to select (0-15)
+     * @param string|null $client_name          Client name identifier.
+     * @param string|null $client_az            Client availability zone.
+     * @param array|null $advanced_config       Advanced configuration ['connection_timeout' => 5000,
+     *                                          'tls_config' => ['use_insecure_tls' => false]].
+     *                                          connection_timeout is in milliseconds.
+     * @param bool|null $lazy_connect           Whether to use lazy connection.
      */
     public function __construct(
         array $addresses,

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -27,7 +27,7 @@
 #include "zend_attributes.h"
 #endif
 
-/*f
+/*
  * PHP Methods
  */
 

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -96,17 +96,20 @@ class ValkeyGlideCluster
     /**
      * Create a new ValkeyGlideCluster instance with the provided configuration.
      *
-     * @param array $addresses                        Array of server addresses [['host' => '127.0.0.1', 'port' => 7001], ...]
-     * @param bool $use_tls                           Whether to use TLS encryption
-     * @param array|null $credentials                 Authentication credentials ['password' => 'xxx', 'username' => 'yyy']
-     * @param int $read_from                          Read strategy for the client
-     * @param int|null $request_timeout               Request timeout in milliseconds (Not yet supported.)
-     * @param array|null $reconnect_strategy          Reconnection strategy ['num_of_retries' => 3, 'factor' => 2, ...] (Not yet supported.)
-     * @param string|null $client_name                Client name identifier
-     * @param int|null $periodic_checks               Periodic checks configuration (Not yet supported.)
-     * @param string|null $client_az                  Client availability zone (Not yet supported.)
-     * @param array|null $advanced_config             Advanced configuration ['connection_timeout' => 5000, 'tls_config' => [...]]
-     * @param bool|null $lazy_connect                 Whether to use lazy connection
+     * @param array $addresses                  Array of server addresses [['host' => '127.0.0.1', 'port' => 7001], ...].
+     * @param bool $use_tls                     Whether to use TLS encryption.
+     * @param array|null $credentials           Authentication credentials ['password' => 'xxx', 'username' => 'yyy'].
+     * @param int $read_from                    Read strategy for the client.
+     * @param int|null $request_timeout         Request timeout in milliseconds.
+     * @param array|null $reconnect_strategy    Reconnection strategy ['num_of_retries' => 3, 'factor' => 2,
+     *                                          'exponent_base' => 10, 'jitter_percent' => 15].
+     * @param string|null $client_name          Client name identifier.
+     * @param int|null $periodic_checks         Periodic checks configuration.
+     * @param string|null $client_az            Client availability zone.
+     * @param array|null $advanced_config       Advanced configuration ['connection_timeout' => 5000,
+     *                                          'tls_config' => ['use_insecure_tls' => false]].
+     *                                           connection_timeout is in milliseconds.
+     * @param bool|null $lazy_connect           Whether to use lazy connection.
      */
     public function __construct(
         array $addresses,

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -63,6 +63,16 @@ const ConnectionResponse* create_glide_client(valkey_glide_client_configuration_
 const ConnectionResponse* create_glide_cluster_client(
     valkey_glide_cluster_client_configuration_t* config);
 
+/* Return the protobuf message representing the connection request. Caller must free the result with
+ * efree() */
+uint8_t* create_connection_request(const char*                               host,
+                                   int                                       port,
+                                   size_t*                                   len,
+                                   valkey_glide_base_client_configuration_t* config,
+                                   int                                       database_id,
+                                   valkey_glide_periodic_checks_status_t     periodic_checks,
+                                   bool                                      is_cluster);
+
 /* Bit operations - UNIFIED SIGNATURES */
 int execute_bitcount_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_bitop_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -135,6 +135,17 @@ uint8_t* create_connection_request(const char*                               hos
 
     conn_req.protocol = CONNECTION_REQUEST__PROTOCOL_VERSION__RESP3;
 
+    /* Set the reconnect strategy */
+    ConnectionRequest__ConnectionRetryStrategy retry_strategy =
+        CONNECTION_REQUEST__CONNECTION_RETRY_STRATEGY__INIT;
+    if (config->reconnect_strategy) {
+        conn_req.connection_retry_strategy = &retry_strategy;
+        retry_strategy.number_of_retries   = config->reconnect_strategy->num_of_retries;
+        retry_strategy.factor              = config->reconnect_strategy->factor;
+        retry_strategy.exponent_base       = config->reconnect_strategy->exponent_base;
+        retry_strategy.jitter_percent      = config->reconnect_strategy->jitter_percent;
+    }
+
     /* Set client name */
     conn_req.client_name = config->client_name ? config->client_name : "valkey-glide-php";
 

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -40,8 +40,6 @@ extern char* double_to_string(double value, size_t* len);
 /* Create a connection request in protobuf format */
 static uint8_t* create_connection_request(const char*                               host,
                                           int                                       port,
-                                          const char*                               user,
-                                          const char*                               pass,
                                           size_t*                                   len,
                                           valkey_glide_base_client_configuration_t* config,
                                           int                                       database_id,
@@ -51,20 +49,46 @@ static uint8_t* create_connection_request(const char*                           
     ConnectionRequest__ConnectionRequest conn_req = CONNECTION_REQUEST__CONNECTION_REQUEST__INIT;
 
     /* Set up the node address */
+    ConnectionRequest__NodeAddress default_addr = CONNECTION_REQUEST__NODE_ADDRESS__INIT;
+    default_addr.host                           = (char*) host;
+    default_addr.port                           = port;
+    ConnectionRequest__NodeAddress* default_addr_list[1] = {&default_addr};
+
+    bool request_contains_addresses = config->addresses && config->addresses_count > 0;
+    size_t addresses_count = request_contains_addresses ? config->addresses_count : 0;
+    ConnectionRequest__NodeAddress request_addresses[addresses_count]; // Using a VLA to avoid memory management.
+    ConnectionRequest__NodeAddress* request_addresses_list[addresses_count];
+    for (size_t i = 0; i < addresses_count; ++i) {
+        // Initialize a temporary NodeAddress then copy it to request_addresses. This is not strictly necessary
+        // since we set all fields anyway, but follows the best practice of using protobuf initializers on new
+        // messages.
+        ConnectionRequest__NodeAddress temp_address = CONNECTION_REQUEST__NODE_ADDRESS__INIT;
+        request_addresses[i] = temp_address;
+
+        request_addresses[i].host = (char*) config->addresses[i].host;
+        request_addresses[i].port = config->addresses[i].port;
+        request_addresses_list[i] = &request_addresses[i];
+    }
+
     ConnectionRequest__NodeAddress node_addr = CONNECTION_REQUEST__NODE_ADDRESS__INIT;
     node_addr.host                           = (char*) host;
     node_addr.port                           = port;
 
-    /* Add the node address to the connection request */
-    ConnectionRequest__NodeAddress* addresses[1] = {&node_addr};
-    conn_req.n_addresses                         = 1;
-    conn_req.addresses                           = addresses;
+    /* Add the node address to the connection request. Use the default endpoint if the constructor call did not
+       supply any endpoints. */
+    if (request_contains_addresses) {
+        conn_req.n_addresses = addresses_count;
+        conn_req.addresses = request_addresses_list;
+    } else {
+        conn_req.n_addresses                         = 1;
+        conn_req.addresses                           = default_addr_list;
+    }
 
     /* Set up authentication if provided */
     ConnectionRequest__AuthenticationInfo auth_info = CONNECTION_REQUEST__AUTHENTICATION_INFO__INIT;
-    if (user && pass) {
-        auth_info.username           = (char*) user;
-        auth_info.password           = (char*) pass;
+    if (config->credentials) {
+        auth_info.username           = (char*) config->credentials->username;
+        auth_info.password           = (char*) config->credentials->password;
         conn_req.authentication_info = &auth_info;
     }
 
@@ -137,25 +161,11 @@ static const ConnectionResponse* create_base_glide_client(
     bool                                      is_cluster) {
     /* Create a connection request using first address or default */
     size_t      len;
-    const char* host     = "localhost";
-    int         port     = 6379;
-    const char* username = NULL;
-    const char* password = NULL;
-
-    /* Use first address if available */
-    if (config->addresses && config->addresses_count > 0) {
-        host = config->addresses[0].host;
-        port = config->addresses[0].port;
-    }
-
-    /* Use credentials if available */
-    if (config->credentials) {
-        username = config->credentials->username;
-        password = config->credentials->password;
-    }
+    const char* default_host     = "localhost";
+    int         default_port     = 6379;
 
     uint8_t* request_bytes = create_connection_request(
-        host, port, username, password, &len, config, database_id, periodic_checks, is_cluster);
+        default_host, default_port, &len, config, database_id, periodic_checks, is_cluster);
 
     if (!request_bytes) {
         return NULL;

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -133,8 +133,16 @@ uint8_t* create_connection_request(const char*                               hos
     /* Set the periodic checks for cluster clients. */
     ConnectionRequest__PeriodicChecksDisabled periodic_check_disabled_info =
         CONNECTION_REQUEST__PERIODIC_CHECKS_DISABLED__INIT;
+    ConnectionRequest__PeriodicChecksManualInterval periodic_checks_manual_interval_info =
+        CONNECTION_REQUEST__PERIODIC_CHECKS_MANUAL_INTERVAL__INIT;
     if (is_cluster && periodic_checks == VALKEY_GLIDE_PERIODIC_CHECKS_DISABLED) {
         conn_req.periodic_checks_disabled = &periodic_check_disabled_info;
+        conn_req.periodic_checks_case =
+            CONNECTION_REQUEST__CONNECTION_REQUEST__PERIODIC_CHECKS_PERIODIC_CHECKS_DISABLED;
+    } else {
+        conn_req.periodic_checks_manual_interval = &periodic_checks_manual_interval_info;
+        conn_req.periodic_checks_case =
+            CONNECTION_REQUEST__CONNECTION_REQUEST__PERIODIC_CHECKS_PERIODIC_CHECKS_MANUAL_INTERVAL;
     }
 
     conn_req.protocol = CONNECTION_REQUEST__PROTOCOL_VERSION__RESP3;

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -153,6 +153,11 @@ uint8_t* create_connection_request(const char*                               hos
     /* Set client name */
     conn_req.client_name = config->client_name ? config->client_name : "valkey-glide-php";
 
+    /* Set client AZ */
+    if (config->client_az) {
+        conn_req.client_az = config->client_az;
+    }
+
     /* Calculate the size of the serialized message */
     *len = connection_request__connection_request__get_packed_size(&conn_req);
 

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -107,6 +107,10 @@ uint8_t* create_connection_request(const char*                               hos
     conn_req.request_timeout =
         config->request_timeout > 0 ? config->request_timeout : 5000; /* Default 5 seconds */
 
+    if (config->advanced_config) {
+        conn_req.connection_timeout = config->advanced_config->connection_timeout;
+    }
+
     conn_req.lazy_connect = config->lazy_connect;
     /* Map read_from configuration */
     if (config->read_from == VALKEY_GLIDE_READ_FROM_PREFER_REPLICA) {


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

Implement a framework for retrieving the protobuf ConnectionRequest message
that the PHP ValkeyGlide and ValkeyGlideCluster constructors generate.

Add tests to validate various command inputs by examining the message
deserialized into PHP protobuf classes.

Fix various bugs:
- When using multiple addresses only the first address was used.
- Reconnection strategy was not being used.
- Client AZ was not being used.
- Connection timeout was not being used.
- Disabling periodic checks did not disable it correctly.

### Issue link

This Pull Request is linked to issue (URL): [#2]

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [ ] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [ ] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.
