### PR TITLE
Add multi-DB support to cluster mode constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+## Unreleased
+
+#### Changes
+
+* PHP: Add Multi-Database Support for Cluster Mode Valkey 9.0 - Added `database_id` parameter to `ValkeyGlideCluster` constructor to enable database selection in cluster mode. This feature requires Valkey 9.0+ with `cluster-databases > 1` configuration.
+
+#### Documentation
+
+* PHP: Updated README with multi-database cluster examples and inline documentation for database selection requirements and best practices
+
+## 0.9.0

--- a/README.md
+++ b/README.md
@@ -267,11 +267,20 @@ try {
         ['host' => 'localhost', 'port' => 7003]
     ];
     
-    // Create ValkeyGlideCluster client
+    // Create ValkeyGlideCluster client with multi-database support (Valkey 9.0+)
     $client = new ValkeyGlideCluster(
         $addresses,                          // addresses
         false,                               // use_tls
         null,                                // credentials
+        ValkeyGlide::READ_FROM_PREFER_REPLICA, // read_from
+        null,                                // request_timeout
+        null,                                // reconnect_strategy
+        null,                                // client_name
+        null,                                // periodic_checks
+        null,                                // client_az
+        null,                                // advanced_config
+        null,                                // lazy_connect
+        1                                    // database_id (requires Valkey 9.0+ with cluster-databases > 1)
     );
     
     // Basic operations

--- a/common.h
+++ b/common.h
@@ -110,12 +110,8 @@ typedef struct {
     char*                                              client_az;       /* NULL if not set */
     valkey_glide_advanced_base_client_configuration_t* advanced_config; /* NULL if not set */
     bool                                               lazy_connect;    /* false if not set */
+    int                                                database_id;     /* -1 if not set */
 } valkey_glide_base_client_configuration_t;
-
-typedef struct {
-    valkey_glide_base_client_configuration_t base;
-    int                                      database_id; /* -1 if not set */
-} valkey_glide_client_configuration_t;
 
 typedef struct {
     valkey_glide_base_client_configuration_t base;
@@ -125,11 +121,11 @@ typedef struct {
 } valkey_glide_cluster_client_configuration_t;
 
 /* Configuration parsing functions */
-int parse_valkey_glide_client_configuration(zval*                                config_obj,
-                                            valkey_glide_client_configuration_t* config);
+int parse_valkey_glide_client_configuration(zval*                                     config_obj,
+                                            valkey_glide_base_client_configuration_t* config);
 int parse_valkey_glide_cluster_client_configuration(
     zval* config_obj, valkey_glide_cluster_client_configuration_t* config);
-void free_valkey_glide_client_configuration(valkey_glide_client_configuration_t* config);
+void free_valkey_glide_client_configuration(valkey_glide_base_client_configuration_t* config);
 void free_valkey_glide_cluster_client_configuration(
     valkey_glide_cluster_client_configuration_t* config);
 
@@ -148,6 +144,8 @@ typedef struct {
     zval*     advanced_config;
     zend_bool lazy_connect;
     zend_bool lazy_connect_is_null;
+    zend_long database_id;
+    zend_bool database_id_is_null;
 } valkey_glide_php_common_constructor_params_t;
 
 void valkey_glide_init_common_constructor_params(

--- a/src/client_constructor_mock.c
+++ b/src/client_constructor_mock.c
@@ -107,34 +107,39 @@ PHP_METHOD(ClientConstructorMock, simulate_standalone_constructor) {
     }
 
     /* Build client configuration from individual parameters */
-    valkey_glide_client_configuration_t client_config;
+    valkey_glide_base_client_configuration_t client_config;
     memset(&client_config, 0, sizeof(client_config));
-    client_config.database_id = database_id_is_null ? -1 : database_id; /* -1 means not set */
-
-    /* Validate database_id range */
-    if (client_config.database_id != -1 &&
-        (client_config.database_id < 0 || client_config.database_id > 15)) {
+    /* Validate database_id range before setting */
+    if (!database_id_is_null && database_id < 0) {
+        const char* error_message = "Database ID must be non-negative.";
+        zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+        valkey_glide_cleanup_client_config(&client_config);
+        return;
+    }
+    if (!database_id_is_null && database_id > 15) {
         const char* error_message = "Database ID must be between 0 and 15 inclusive.";
         zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
-        valkey_glide_cleanup_client_config(&client_config.base);
+        valkey_glide_cleanup_client_config(&client_config);
         return;
     }
 
+    client_config.database_id = database_id_is_null ? -1 : database_id; /* -1 means not set */
+
     /* Populate configuration parameters shared between client and cluster connections. */
-    valkey_glide_build_client_config_base(&common_params, &client_config.base, false);
+    valkey_glide_build_client_config_base(&common_params, &client_config, false);
 
     /* Build the connection request. */
     size_t   protobuf_message_len;
     uint8_t* request_bytes = create_connection_request("localhost",
                                                        6379,
                                                        &protobuf_message_len,
-                                                       &client_config.base,
+                                                       &client_config,
                                                        client_config.database_id,
                                                        0,
                                                        false);
 
     zval* php_request =
-        build_php_connection_request(request_bytes, protobuf_message_len, &client_config.base);
+        build_php_connection_request(request_bytes, protobuf_message_len, &client_config);
     RETURN_ZVAL(php_request, 1, 1);
 }
 
@@ -145,7 +150,7 @@ PHP_METHOD(ClientConstructorMock, simulate_cluster_constructor) {
     valkey_glide_php_common_constructor_params_t common_params;
     valkey_glide_init_common_constructor_params(&common_params);
 
-    ZEND_PARSE_PARAMETERS_START(1, 11)
+    ZEND_PARSE_PARAMETERS_START(1, 12)
     Z_PARAM_ARRAY(common_params.addresses)
     Z_PARAM_OPTIONAL
     Z_PARAM_BOOL(common_params.use_tls)
@@ -158,6 +163,7 @@ PHP_METHOD(ClientConstructorMock, simulate_cluster_constructor) {
     Z_PARAM_STRING_OR_NULL(common_params.client_az, common_params.client_az_len)
     Z_PARAM_ARRAY_OR_NULL(common_params.advanced_config)
     Z_PARAM_BOOL_OR_NULL(common_params.lazy_connect, common_params.lazy_connect_is_null)
+    Z_PARAM_LONG_OR_NULL(common_params.database_id, common_params.database_id_is_null)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_THROWS());
 
     /* Build cluster client configuration from individual parameters */

--- a/src/client_constructor_mock.stub.php
+++ b/src/client_constructor_mock.stub.php
@@ -128,6 +128,10 @@ class ClientConstructorMock
      *                                                'tls_config' => ['use_insecure_tls' => false]].
      *                                                connection_timeout is in milliseconds.
      * @param bool|null $lazy_connect                 Whether to use lazy connection.
+     * @param int|null $database_id                   Index of the logical database to connect to. Must be non-negative 
+     *                                                and within the range supported by the server configuration. 
+     *                                                For cluster mode, requires Valkey 9.0+ with cluster-databases > 1.
+     *                                                If not specified, defaults to database 0.
      */
     public static function simulate_cluster_constructor(
         array $addresses,
@@ -140,6 +144,7 @@ class ClientConstructorMock
         ?int $periodic_checks = ValkeyGlideCluster::PERIODIC_CHECK_ENABLED_DEFAULT_CONFIGS,
         ?string $client_az = null,
         ?array $advanced_config = null,
-        ?bool $lazy_connect = null
+        ?bool $lazy_connect = null,
+        ?int $database_id = null
     ): \Connection_request\ConnectionRequest;
 }

--- a/tests/ConnectionRequestTest.php
+++ b/tests/ConnectionRequestTest.php
@@ -394,6 +394,58 @@ class ConnectionRequestTest extends \TestSuite
         $this->assertEquals(7, $request->getDatabaseId());
     }
 
+    public function testClusterDatabaseId()
+    {
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            database_id: 5
+        );
+
+        $this->assertEquals(5, $request->getDatabaseId());
+    }
+
+    public function testClusterDatabaseIdDefault()
+    {
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]]
+        );
+
+        $this->assertEquals(0, $request->getDatabaseId());
+    }
+
+    public function testStandaloneDatabaseIdNegative()
+    {
+        $this->expectException(ValkeyGlideException::class);
+        $this->expectExceptionMessage('Database ID must be non-negative');
+        
+        ClientConstructorMock::simulate_standalone_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            database_id: -1
+        );
+    }
+
+    public function testStandaloneDatabaseIdTooHigh()
+    {
+        $this->expectException(ValkeyGlideException::class);
+        $this->expectExceptionMessage('Database ID must be between 0 and 15 inclusive');
+        
+        ClientConstructorMock::simulate_standalone_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            database_id: 16
+        );
+    }
+
+    public function testClusterDatabaseIdNegative()
+    {
+        $this->expectException(ValkeyGlideException::class);
+        $this->expectExceptionMessage('Database ID must be non-negative');
+        
+        ClientConstructorMock::simulate_cluster_constructor(
+            addresses: [['host' => 'localhost', 'port' => 8080]],
+            database_id: -1
+        );
+    }
+
     public function testClusterPeriodicChecksDisabled()
     {
         $request = ClientConstructorMock::simulate_cluster_constructor(

--- a/tests/ValkeyGlideClusterFeaturesTest.php
+++ b/tests/ValkeyGlideClusterFeaturesTest.php
@@ -558,6 +558,147 @@ class ValkeyGlideClusterFeaturesTest extends ValkeyGlideClusterBaseTest
         $valkey_glide->close();
     }
 
+    // ==============================================
+    // DATABASE_ID PARAMETER TESTS
+    // ==============================================
+
+    /**
+     * Test that cluster constructor accepts database_id parameter
+     */
+    public function testClusterConstructorAcceptsDatabaseId(): void
+    {
+        $addresses = [['host' => 'localhost', 'port' => 7001]];
+        
+        // Test that constructor accepts all 12 parameters including database_id
+        try {
+            $client = new ValkeyGlideCluster(
+                $addresses,                          // addresses
+                false,                               // use_tls
+                null,                                // credentials
+                ValkeyGlide::READ_FROM_PRIMARY,     // read_from
+                null,                                // request_timeout
+                null,                                // reconnect_strategy
+                null,                                // client_name
+                null,                                // periodic_checks
+                null,                                // client_az
+                null,                                // advanced_config
+                null,                                // lazy_connect
+                0                                    // database_id
+            );
+            
+            // We expect this to fail with connection error, not parameter error
+            $this->fail('Expected connection error');
+            
+        } catch (ArgumentCountError $e) {
+            $this->fail('Constructor should accept database_id parameter: ' . $e->getMessage());
+        } catch (Exception $e) {
+            // Connection error is expected since no cluster is running
+            $this->assertStringContains('Failed to create initial connections', $e->getMessage());
+        }
+    }
+
+    /**
+     * Test that cluster constructor works with null database_id (default)
+     */
+    public function testClusterConstructorWithNullDatabaseId(): void
+    {
+        $addresses = [['host' => 'localhost', 'port' => 7001]];
+        
+        try {
+            $client = new ValkeyGlideCluster(
+                $addresses,                          // addresses
+                false,                               // use_tls
+                null,                                // credentials
+                ValkeyGlide::READ_FROM_PRIMARY,     // read_from
+                null,                                // request_timeout
+                null,                                // reconnect_strategy
+                null,                                // client_name
+                null,                                // periodic_checks
+                null,                                // client_az
+                null,                                // advanced_config
+                null,                                // lazy_connect
+                null                                 // database_id = null (default)
+            );
+            
+            $this->fail('Expected connection error');
+            
+        } catch (ArgumentCountError $e) {
+            $this->fail('Constructor should accept null database_id: ' . $e->getMessage());
+        } catch (Exception $e) {
+            // Connection error is expected since no cluster is running
+            $this->assertStringContains('Failed to create initial connections', $e->getMessage());
+        }
+    }
+
+    /**
+     * Test backward compatibility - constructor should work without database_id
+     */
+    public function testClusterConstructorBackwardCompatibility(): void
+    {
+        $addresses = [['host' => 'localhost', 'port' => 7001]];
+        
+        try {
+            // Test with 11 parameters (without database_id) - should still work
+            $client = new ValkeyGlideCluster(
+                $addresses,                          // addresses
+                false,                               // use_tls
+                null,                                // credentials
+                ValkeyGlide::READ_FROM_PRIMARY,     // read_from
+                null,                                // request_timeout
+                null,                                // reconnect_strategy
+                null,                                // client_name
+                null,                                // periodic_checks
+                null,                                // client_az
+                null,                                // advanced_config
+                null                                 // lazy_connect
+                // database_id omitted - should default to null/0
+            );
+            
+            $this->fail('Expected connection error');
+            
+        } catch (ArgumentCountError $e) {
+            $this->fail('Constructor should work without database_id for backward compatibility: ' . $e->getMessage());
+        } catch (Exception $e) {
+            // Connection error is expected since no cluster is running
+            $this->assertStringContains('Failed to create initial connections', $e->getMessage());
+        }
+    }
+
+    /**
+     * Test that constructor parameter count is correct
+     */
+    public function testClusterConstructorParameterCount(): void
+    {
+        $addresses = [['host' => 'localhost', 'port' => 7001]];
+        
+        // Test with too many parameters (13) - should fail
+        try {
+            $client = new ValkeyGlideCluster(
+                $addresses,                          // 1
+                false,                               // 2
+                null,                                // 3
+                ValkeyGlide::READ_FROM_PRIMARY,     // 4
+                null,                                // 5
+                null,                                // 6
+                null,                                // 7
+                null,                                // 8
+                null,                                // 9
+                null,                                // 10
+                null,                                // 11
+                0,                                   // 12 - database_id
+                'extra_param'                        // 13 - should cause error
+            );
+            
+            $this->fail('Expected ArgumentCountError for too many parameters');
+            
+        } catch (ArgumentCountError $e) {
+            // This is expected - too many parameters
+            $this->assertStringContains('expects at most 12 arguments', $e->getMessage());
+        } catch (Exception $e) {
+            $this->fail('Expected ArgumentCountError, got: ' . $e->getMessage());
+        }
+    }
+
     public function testClusterClientCreateDeleteLoop()
     {
         // Simple test that creates and deletes ValkeyGlideCluster clients in a loop

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -89,7 +89,166 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         ValkeyGlide::VALKEY_GLIDE_HASH
     ];
 
+    /**
+     * Test multi-database support for cluster mode (Valkey 9.0+)
+     */
+    public function testClusterMultiDatabaseSupport(): void
+    {
+        // Skip if not Valkey 9.0+ or cluster-databases not configured
+        if (version_compare($this->version, '9.0.0') < 0) {
+            $this->markTestSkipped('Multi-database cluster support requires Valkey 9.0+');
+        }
 
+        $key = $this->createRandomString(10);
+        
+        try {
+            // Test database 1 (requires cluster-databases > 1 configuration)
+            $addresses = [
+                ['host' => 'localhost', 'port' => 7001],
+                ['host' => 'localhost', 'port' => 7002],
+                ['host' => 'localhost', 'port' => 7003]
+            ];
+            
+            $client_db1 = new ValkeyGlideCluster(
+                $addresses,
+                false,                               // use_tls
+                null,                                // credentials
+                ValkeyGlide::READ_FROM_PREFER_REPLICA, // read_from
+                null,                                // request_timeout
+                null,                                // reconnect_strategy
+                null,                                // client_name
+                null,                                // periodic_checks
+                null,                                // client_az
+                null,                                // advanced_config
+                null,                                // lazy_connect
+                1                                    // database_id = 1
+            );
+            
+            // Set value in database 1
+            $this->assertTrue($client_db1->set($key, 'db1_value'));
+            $this->assertEquals('db1_value', $client_db1->get($key));
+            
+            // Create client for database 0 (default)
+            $client_db0 = new ValkeyGlideCluster(
+                $addresses,
+                false,                               // use_tls
+                null,                                // credentials
+                ValkeyGlide::READ_FROM_PREFER_REPLICA, // read_from
+                null,                                // request_timeout
+                null,                                // reconnect_strategy
+                null,                                // client_name
+                null,                                // periodic_checks
+                null,                                // client_az
+                null,                                // advanced_config
+                null,                                // lazy_connect
+                0                                    // database_id = 0 (default)
+            );
+            
+            // Key should not exist in database 0
+            $this->assertNull($client_db0->get($key));
+            
+            // Set different value in database 0
+            $this->assertTrue($client_db0->set($key, 'db0_value'));
+            $this->assertEquals('db0_value', $client_db0->get($key));
+            
+            // Verify database 1 still has its value
+            $this->assertEquals('db1_value', $client_db1->get($key));
+            
+            // Clean up
+            $client_db0->del($key);
+            $client_db1->del($key);
+            $client_db0->close();
+            $client_db1->close();
+            
+        } catch (Exception $e) {
+            // If cluster-databases is not configured, skip the test
+            if (strpos($e->getMessage(), 'database') !== false) {
+                $this->markTestSkipped('Cluster multi-database not configured (requires cluster-databases > 1)');
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Test cluster constructor with database ID parameter
+     */
+    public function testClusterConstructorWithDatabaseId(): void
+    {
+        $addresses = [
+            ['host' => $this->getHost(), 'port' => 7001],
+            ['host' => $this->getHost(), 'port' => 7002],
+            ['host' => $this->getHost(), 'port' => 7003]
+        ];
+
+        // Test with database 0 (default)
+        $client = new ValkeyGlideCluster(
+            $addresses,
+            false,                               // use_tls
+            null,                                // credentials
+            ValkeyGlide::READ_FROM_PRIMARY,     // read_from
+            null,                                // request_timeout
+            null,                                // reconnect_strategy
+            null,                                // client_name
+            null,                                // periodic_checks
+            null,                                // client_az
+            null,                                // advanced_config
+            null,                                // lazy_connect
+            0                                    // database_id = 0
+        );
+        
+        $this->assertTrue($client->ping());
+        $client->close();
+
+        // Test with null database_id (should default to 0)
+        $client = new ValkeyGlideCluster(
+            $addresses,
+            false,                               // use_tls
+            null,                                // credentials
+            ValkeyGlide::READ_FROM_PRIMARY,     // read_from
+            null,                                // request_timeout
+            null,                                // reconnect_strategy
+            null,                                // client_name
+            null,                                // periodic_checks
+            null,                                // client_az
+            null,                                // advanced_config
+            null,                                // lazy_connect
+            null                                 // database_id = null (default)
+        );
+        
+        $this->assertTrue($client->ping());
+        $client->close();
+    }
+
+    /**
+     * Test cluster constructor with invalid database ID
+     */
+    public function testClusterConstructorWithInvalidDatabaseId(): void
+    {
+        $addresses = [
+            ['host' => $this->getHost(), 'port' => 7001],
+            ['host' => $this->getHost(), 'port' => 7002],
+            ['host' => $this->getHost(), 'port' => 7003]
+        ];
+
+        // Test with negative database_id
+        $this->expectException(ValkeyGlideException::class);
+        $this->expectExceptionMessage('Database ID must be non-negative');
+        
+        new ValkeyGlideCluster(
+            $addresses,
+            false,                               // use_tls
+            null,                                // credentials
+            ValkeyGlide::READ_FROM_PRIMARY,     // read_from
+            null,                                // request_timeout
+            null,                                // reconnect_strategy
+            null,                                // client_name
+            null,                                // periodic_checks
+            null,                                // client_az
+            null,                                // advanced_config
+            null,                                // lazy_connect
+            -1                                   // database_id = -1 (invalid)
+        );
+    }
 
     protected static array $seeds = [];
     private static string $seed_source = '';

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -28,9 +28,10 @@
 #include <ext/standard/info.h>
 
 /* Include configuration parsing */
-extern int  parse_valkey_glide_client_configuration(zval*                                config_obj,
-                                                    valkey_glide_client_configuration_t* config);
-extern void free_valkey_glide_client_configuration(valkey_glide_client_configuration_t* config);
+extern int parse_valkey_glide_client_configuration(
+    zval* config_obj, valkey_glide_base_client_configuration_t* config);
+extern void free_valkey_glide_client_configuration(
+    valkey_glide_base_client_configuration_t* config);
 
 void register_mock_constructor_class(void);
 
@@ -115,6 +116,8 @@ void valkey_glide_init_common_constructor_params(
     params->advanced_config         = NULL;
     params->lazy_connect            = 0;
     params->lazy_connect_is_null    = 1;
+    params->database_id             = 0;
+    params->database_id_is_null     = 1;
 }
 
 void valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_params_t* params,
@@ -135,6 +138,10 @@ void valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_p
 
     /* Set lazy connect option */
     config->lazy_connect = params->lazy_connect_is_null ? false : params->lazy_connect;
+
+    /* Set database_id */
+    config->database_id =
+        params->database_id_is_null ? -1 : params->database_id; /* -1 means not set */
 
     /* Map read_from enum value to client's ReadFrom enum */
     switch (params->read_from) {
@@ -437,8 +444,6 @@ PHP_MINFO_FUNCTION(redis)
 PHP_METHOD(ValkeyGlide, __construct) {
     valkey_glide_php_common_constructor_params_t common_params;
     valkey_glide_init_common_constructor_params(&common_params);
-    zend_long            database_id         = 0;
-    zend_bool            database_id_is_null = 1;
     valkey_glide_object* valkey_glide;
 
     ZEND_PARSE_PARAMETERS_START(1, 11)
@@ -449,7 +454,7 @@ PHP_METHOD(ValkeyGlide, __construct) {
     Z_PARAM_LONG(common_params.read_from)
     Z_PARAM_LONG_OR_NULL(common_params.request_timeout, common_params.request_timeout_is_null)
     Z_PARAM_ARRAY_OR_NULL(common_params.reconnect_strategy)
-    Z_PARAM_LONG_OR_NULL(database_id, database_id_is_null)
+    Z_PARAM_LONG_OR_NULL(common_params.database_id, common_params.database_id_is_null)
     Z_PARAM_STRING_OR_NULL(common_params.client_name, common_params.client_name_len)
     Z_PARAM_STRING_OR_NULL(common_params.client_az, common_params.client_az_len)
     Z_PARAM_ARRAY_OR_NULL(common_params.advanced_config)
@@ -460,6 +465,20 @@ PHP_METHOD(ValkeyGlide, __construct) {
 
     VALKEY_LOG_DEBUG("php_construct", "Starting ValkeyGlide construction");
 
+    /* Validate database_id range early */
+    if (!common_params.database_id_is_null) {
+        if (common_params.database_id < 0) {
+            const char* error_message = "Database ID must be non-negative.";
+            zend_throw_exception(valkey_glide_exception_ce, error_message, 0);
+            return;
+        }
+        if (common_params.database_id > 15) {
+            const char* error_message = "Database ID must be between 0 and 15 inclusive.";
+            zend_throw_exception(valkey_glide_exception_ce, error_message, 0);
+            return;
+        }
+    }
+
     /* Validate addresses array */
     if (!common_params.addresses ||
         zend_hash_num_elements(Z_ARRVAL_P(common_params.addresses)) == 0) {
@@ -469,21 +488,11 @@ PHP_METHOD(ValkeyGlide, __construct) {
     }
 
     /* Build client configuration from individual parameters */
-    valkey_glide_client_configuration_t client_config;
+    valkey_glide_base_client_configuration_t client_config;
     memset(&client_config, 0, sizeof(client_config));
-    client_config.database_id = database_id_is_null ? -1 : database_id; /* -1 means not set */
-
-    /* Validate database_id range */
-    if (client_config.database_id != -1 &&
-        (client_config.database_id < 0 || client_config.database_id > 15)) {
-        const char* error_message = "Database ID must be between 0 and 15 inclusive.";
-        zend_throw_exception(valkey_glide_exception_ce, error_message, 0);
-        valkey_glide_cleanup_client_config(&client_config.base);
-        return;
-    }
 
     /* Populate configuration parameters shared between client and cluster connections. */
-    valkey_glide_build_client_config_base(&common_params, &client_config.base, false);
+    valkey_glide_build_client_config_base(&common_params, &client_config, false);
 
     /* Issue the connection request. */
     const ConnectionResponse* conn_resp = create_glide_client(&client_config);
@@ -499,7 +508,7 @@ PHP_METHOD(ValkeyGlide, __construct) {
     free_connection_response((ConnectionResponse*) conn_resp);
 
     /* Clean up temporary configuration structures */
-    valkey_glide_cleanup_client_config(&client_config.base);
+    valkey_glide_cleanup_client_config(&client_config);
 }
 /* }}} */
 

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -39,7 +39,7 @@ PHP_METHOD(ValkeyGlideCluster, __construct) {
     valkey_glide_init_common_constructor_params(&common_params);
     valkey_glide_object* valkey_glide;
 
-    ZEND_PARSE_PARAMETERS_START(1, 11)
+    ZEND_PARSE_PARAMETERS_START(1, 12)
     Z_PARAM_ARRAY(common_params.addresses)
     Z_PARAM_OPTIONAL
     Z_PARAM_BOOL(common_params.use_tls)
@@ -52,9 +52,17 @@ PHP_METHOD(ValkeyGlideCluster, __construct) {
     Z_PARAM_STRING_OR_NULL(common_params.client_az, common_params.client_az_len)
     Z_PARAM_ARRAY_OR_NULL(common_params.advanced_config)
     Z_PARAM_BOOL_OR_NULL(common_params.lazy_connect, common_params.lazy_connect_is_null)
+    Z_PARAM_LONG_OR_NULL(common_params.database_id, common_params.database_id_is_null)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_THROWS());
 
     valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, getThis());
+
+    /* Validate database_id range early */
+    if (!common_params.database_id_is_null && common_params.database_id < 0) {
+        const char* error_message = "Database ID must be non-negative.";
+        zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+        return;
+    }
 
     /* Build cluster client configuration from individual parameters */
     valkey_glide_cluster_client_configuration_t client_config;

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -110,6 +110,10 @@ class ValkeyGlideCluster
      *                                          'tls_config' => ['use_insecure_tls' => false]].
      *                                           connection_timeout is in milliseconds.
      * @param bool|null $lazy_connect           Whether to use lazy connection.
+     * @param int|null $database_id             Index of the logical database to connect to. Must be non-negative 
+     *                                          and within the range supported by the server configuration. 
+     *                                          For cluster mode, requires Valkey 9.0+ with cluster-databases > 1.
+     *                                          If not specified, defaults to database 0.
      */
     public function __construct(
         array $addresses,
@@ -122,8 +126,9 @@ class ValkeyGlideCluster
         ?int $periodic_checks = ValkeyGlideCluster::PERIODIC_CHECK_ENABLED_DEFAULT_CONFIGS,
         ?string $client_az = null,
         ?array $advanced_config = null,
-        ?bool $lazy_connect = null
-    );
+        ?bool $lazy_connect = null,
+        ?int $database_id = null
+    ) {}
 
 
 

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -58,7 +58,7 @@ void free_command_response(CommandResponse* command_response_ptr);
 void free_command_result(CommandResult* command_result_ptr);
 
 /* Helper functions for Valkey Glide integration */
-const ConnectionResponse* create_glide_client(valkey_glide_client_configuration_t* config);
+const ConnectionResponse* create_glide_client(valkey_glide_base_client_configuration_t* config);
 
 const ConnectionResponse* create_glide_cluster_client(
     valkey_glide_cluster_client_configuration_t* config);

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -224,14 +224,15 @@ static const ConnectionResponse* create_base_glide_client(
 }
 
 /* Create a Valkey Glide client */
-const ConnectionResponse* create_glide_client(valkey_glide_client_configuration_t* config) {
+const ConnectionResponse* create_glide_client(valkey_glide_base_client_configuration_t* config) {
     return create_base_glide_client(
-        &config->base, config->database_id, VALKEY_GLIDE_PERIODIC_CHECKS_DISABLED, false);
+        config, config->database_id, VALKEY_GLIDE_PERIODIC_CHECKS_DISABLED, false);
 }
 
 const ConnectionResponse* create_glide_cluster_client(
     valkey_glide_cluster_client_configuration_t* config) {
-    return create_base_glide_client(&config->base, 0, config->periodic_checks_status, true);
+    return create_base_glide_client(
+        &config->base, config->base.database_id, config->periodic_checks_status, true);
 }
 
 /* Custom result processor for SET commands with GET option support */


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

- Support the database_id parameter when constructing ValkeyGlideCluster instances.
- Make the database_id field part of the base configuration instead of only standalone in the extension code.
- Simplify the extension code to eliminate the standalone-specific configuration object.
- Update unit tests to validate the database_id in cluster mode.
- Validate that the supplied database_id is between 0 and 15 inclusive.

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [ ] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [ ] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.
