### PR TITLE
PHP: implement client-side caching with TTL-based expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * PHP: Add FT.* (Vector Search) commands: ftCreate, ftDropIndex, ftList, ftSearch, ftAggregate, ftInfo, ftAliasAdd, ftAliasDel, ftAliasUpdate, ftAliasList for standalone and cluster clients ([#171](https://github.com/valkey-io/valkey-glide-php/pull/171))
 * PHP: Add JSON.SET and JSON.GET commands for standalone and cluster clients ([#184](https://github.com/valkey-io/valkey-glide-php/pull/184))
 * PHP: Add transparent compression support for string values ([#186](https://github.com/valkey-io/valkey-glide-php/pull/186))
+* PHP: implement client-side caching with TTL-based expiration ([#180](https://github.com/valkey-io/valkey-glide-php/pull/180))
 
 ## 1.0.0
 

--- a/ClientSideCache.php
+++ b/ClientSideCache.php
@@ -36,7 +36,7 @@ class ClientSideCache
 
     private string $cacheId;
     private int $maxCacheKb;
-    private ?int $entryTtlMs;
+    private int $entryTtlMs;
     private ?int $evictionPolicy;
     private bool $enableMetrics;
 
@@ -87,9 +87,9 @@ class ClientSideCache
     /**
      * Gets the entry TTL in milliseconds.
      *
-     * @return int|null The entry TTL in milliseconds, or null if not set.
+     * @return int The entry TTL in milliseconds (0 = no expiration).
      */
-    public function getEntryTtlMs(): ?int
+    public function getEntryTtlMs(): int
     {
         return $this->entryTtlMs;
     }
@@ -125,12 +125,9 @@ class ClientSideCache
         $result = [
             'cache_id' => $this->cacheId,
             'max_cache_kb' => $this->maxCacheKb,
+            'entry_ttl_ms' => $this->entryTtlMs,
             'enable_metrics' => $this->enableMetrics,
         ];
-
-        if ($this->entryTtlMs !== null) {
-            $result['entry_ttl_ms'] = $this->entryTtlMs;
-        }
 
         if ($this->evictionPolicy !== null) {
             $result['eviction_policy'] = $this->evictionPolicy;

--- a/ClientSideCache.php
+++ b/ClientSideCache.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ValkeyGlide\Cache;
+
+/**
+ * Configuration for client-side caching with TTL-based expiration.
+ *
+ * This class configures a local cache that stores read command responses
+ * on the client side to reduce network round-trips and server load. The cache
+ * uses Time-To-Live (TTL) based expiration, where entries are automatically
+ * removed after a specified duration.
+ *
+ * Cached entries expire based on TTL. Server-side key changes are not propagated
+ * to the cache, so values may become stale before TTL expires.
+ * Expiration is lazy — entries are removed when accessed after their TTL, not
+ * proactively in the background.
+ * Supported read commands: GET, HGETALL, SMEMBERS.
+ *
+ * In order for 2 clients to share the same cache, they must be created with the
+ * same ClientSideCache instance.
+ *
+ * Clients with different ClientSideCache instances will have separate caches,
+ * even if the configurations are identical.
+ * Clients using different DBs cannot share the same cache.
+ * Clients using different ACL users cannot share the same cache.
+ */
+class ClientSideCache
+{
+    /** @var int Eviction policy: Least Recently Used */
+    public const EVICTION_LRU = 0;
+
+    /** @var int Eviction policy: Least Frequently Used */
+    public const EVICTION_LFU = 1;
+
+    private string $cacheId;
+    private int $maxCacheKb;
+    private ?int $entryTtlSeconds;
+    private ?int $evictionPolicy;
+    private bool $enableMetrics;
+
+    /**
+     * Creates a new ClientSideCache from a builder.
+     *
+     * @param ClientSideCacheBuilder $builder The builder containing configuration values.
+     */
+    public function __construct(ClientSideCacheBuilder $builder)
+    {
+        $this->cacheId = $builder->getCacheId();
+        $this->maxCacheKb = $builder->getMaxCacheKb();
+        $this->entryTtlSeconds = $builder->getEntryTtlSeconds();
+        $this->evictionPolicy = $builder->getEvictionPolicy();
+        $this->enableMetrics = $builder->getEnableMetrics();
+    }
+
+    /**
+     * Creates a new ClientSideCache builder.
+     *
+     * @return ClientSideCacheBuilder A new builder instance.
+     */
+    public static function builder(): ClientSideCacheBuilder
+    {
+        return new ClientSideCacheBuilder();
+    }
+
+    /**
+     * Gets the unique cache identifier.
+     *
+     * @return string The cache ID.
+     */
+    public function getCacheId(): string
+    {
+        return $this->cacheId;
+    }
+
+    /**
+     * Gets the maximum cache size in kilobytes.
+     *
+     * @return int The maximum cache size in KB.
+     */
+    public function getMaxCacheKb(): int
+    {
+        return $this->maxCacheKb;
+    }
+
+    /**
+     * Gets the entry TTL in seconds.
+     *
+     * @return int|null The entry TTL in seconds, or null if not set.
+     */
+    public function getEntryTtlSeconds(): ?int
+    {
+        return $this->entryTtlSeconds;
+    }
+
+    /**
+     * Gets the eviction policy.
+     *
+     * @return int|null The eviction policy constant, or null for default (LRU).
+     */
+    public function getEvictionPolicy(): ?int
+    {
+        return $this->evictionPolicy;
+    }
+
+    /**
+     * Gets whether metrics collection is enabled.
+     *
+     * @return bool True if metrics are enabled.
+     */
+    public function getEnableMetrics(): bool
+    {
+        return $this->enableMetrics;
+    }
+
+    /**
+     * Converts the configuration to an associative array suitable for passing
+     * to ValkeyGlide::connect() or ValkeyGlideCluster::__construct().
+     *
+     * @return array The configuration as an associative array.
+     */
+    public function toArray(): array
+    {
+        $result = [
+            'cache_id' => $this->cacheId,
+            'max_cache_kb' => $this->maxCacheKb,
+            'enable_metrics' => $this->enableMetrics,
+        ];
+
+        if ($this->entryTtlSeconds !== null) {
+            $result['entry_ttl_seconds'] = $this->entryTtlSeconds;
+        }
+
+        if ($this->evictionPolicy !== null) {
+            $result['eviction_policy'] = $this->evictionPolicy;
+        }
+
+        return $result;
+    }
+}

--- a/ClientSideCache.php
+++ b/ClientSideCache.php
@@ -36,7 +36,7 @@ class ClientSideCache
 
     private string $cacheId;
     private int $maxCacheKb;
-    private ?int $entryTtlSeconds;
+    private ?int $entryTtlMs;
     private ?int $evictionPolicy;
     private bool $enableMetrics;
 
@@ -49,7 +49,7 @@ class ClientSideCache
     {
         $this->cacheId = $builder->getCacheId();
         $this->maxCacheKb = $builder->getMaxCacheKb();
-        $this->entryTtlSeconds = $builder->getEntryTtlSeconds();
+        $this->entryTtlMs = $builder->getEntryTtlMs();
         $this->evictionPolicy = $builder->getEvictionPolicy();
         $this->enableMetrics = $builder->getEnableMetrics();
     }
@@ -85,13 +85,13 @@ class ClientSideCache
     }
 
     /**
-     * Gets the entry TTL in seconds.
+     * Gets the entry TTL in milliseconds.
      *
-     * @return int|null The entry TTL in seconds, or null if not set.
+     * @return int|null The entry TTL in milliseconds, or null if not set.
      */
-    public function getEntryTtlSeconds(): ?int
+    public function getEntryTtlMs(): ?int
     {
-        return $this->entryTtlSeconds;
+        return $this->entryTtlMs;
     }
 
     /**
@@ -128,8 +128,8 @@ class ClientSideCache
             'enable_metrics' => $this->enableMetrics,
         ];
 
-        if ($this->entryTtlSeconds !== null) {
-            $result['entry_ttl_seconds'] = $this->entryTtlSeconds;
+        if ($this->entryTtlMs !== null) {
+            $result['entry_ttl_ms'] = $this->entryTtlMs;
         }
 
         if ($this->evictionPolicy !== null) {

--- a/ClientSideCacheBuilder.php
+++ b/ClientSideCacheBuilder.php
@@ -15,7 +15,7 @@ class ClientSideCacheBuilder
     private static int $counter = 0;
 
     private ?int $maxCacheKb = null;
-    private ?int $entryTtlSeconds = null;
+    private ?int $entryTtlMs = null;
     private ?int $evictionPolicy = null;
     private bool $enableMetrics = false;
 
@@ -38,20 +38,20 @@ class ClientSideCacheBuilder
     }
 
     /**
-     * Sets the Time-To-Live for cached entries in seconds.
+     * Sets the Time-To-Live for cached entries in milliseconds.
      *
      * After this duration, entries automatically expire and are removed
      * from the cache. If not specified, no expiration is applied.
      *
-     * @param int $entryTtlSeconds TTL in seconds (must be positive).
+     * @param int $entryTtlMs TTL in milliseconds (must be positive).
      * @return self This builder instance for method chaining.
      */
-    public function entryTtlSeconds(int $entryTtlSeconds): self
+    public function entryTtlMs(int $entryTtlMs): self
     {
-        if ($entryTtlSeconds <= 0) {
-            throw new ValkeyGlideException("entryTtlSeconds must be positive");
+        if ($entryTtlMs <= 0) {
+            throw new ValkeyGlideException("entryTtlMs must be positive");
         }
-        $this->entryTtlSeconds = $entryTtlSeconds;
+        $this->entryTtlMs = $entryTtlMs;
         return $this;
     }
 
@@ -101,13 +101,13 @@ class ClientSideCacheBuilder
     }
 
     /**
-     * Gets the entry TTL in seconds.
+     * Gets the entry TTL in milliseconds.
      *
-     * @return int|null The entry TTL in seconds, or null if not set.
+     * @return int|null The entry TTL in milliseconds, or null if not set.
      */
-    public function getEntryTtlSeconds(): ?int
+    public function getEntryTtlMs(): ?int
     {
-        return $this->entryTtlSeconds;
+        return $this->entryTtlMs;
     }
 
     /**

--- a/ClientSideCacheBuilder.php
+++ b/ClientSideCacheBuilder.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ValkeyGlide\Cache;
+
+use ValkeyGlideException;
+
+/**
+ * Builder for ClientSideCache.
+ */
+class ClientSideCacheBuilder
+{
+    private static string $uuidPrefix = '';
+    private static int $counter = 0;
+
+    private ?int $maxCacheKb = null;
+    private ?int $entryTtlSeconds = null;
+    private ?int $evictionPolicy = null;
+    private bool $enableMetrics = false;
+
+    /**
+     * Sets the maximum cache size in kilobytes.
+     *
+     * This limits the total memory used by cached keys and values.
+     * When this limit is reached, entries are evicted based on the eviction policy.
+     *
+     * @param int $maxCacheKb Maximum cache size in KB (must be positive).
+     * @return self This builder instance for method chaining.
+     */
+    public function maxCacheKb(int $maxCacheKb): self
+    {
+        if ($maxCacheKb <= 0) {
+            throw new ValkeyGlideException("maxCacheKb must be positive");
+        }
+        $this->maxCacheKb = $maxCacheKb;
+        return $this;
+    }
+
+    /**
+     * Sets the Time-To-Live for cached entries in seconds.
+     *
+     * After this duration, entries automatically expire and are removed
+     * from the cache. If not specified, no expiration is applied.
+     *
+     * @param int $entryTtlSeconds TTL in seconds (must be positive).
+     * @return self This builder instance for method chaining.
+     */
+    public function entryTtlSeconds(int $entryTtlSeconds): self
+    {
+        if ($entryTtlSeconds <= 0) {
+            throw new ValkeyGlideException("entryTtlSeconds must be positive");
+        }
+        $this->entryTtlSeconds = $entryTtlSeconds;
+        return $this;
+    }
+
+    /**
+     * Sets the eviction policy for when the cache reaches its maximum size.
+     *
+     * @param int $evictionPolicy One of ClientSideCache::EVICTION_LRU or ClientSideCache::EVICTION_LFU.
+     * @return self This builder instance for method chaining.
+     */
+    public function evictionPolicy(int $evictionPolicy): self
+    {
+        if (
+            $evictionPolicy !== ClientSideCache::EVICTION_LRU
+            && $evictionPolicy !== ClientSideCache::EVICTION_LFU
+        ) {
+            throw new ValkeyGlideException(
+                "evictionPolicy must be ClientSideCache::EVICTION_LRU or ClientSideCache::EVICTION_LFU"
+            );
+        }
+        $this->evictionPolicy = $evictionPolicy;
+        return $this;
+    }
+
+    /**
+     * Enables collection of cache metrics such as hit/miss rates.
+     *
+     * @param bool $enableMetrics Whether to enable metrics.
+     * @return self This builder instance for method chaining.
+     */
+    public function enableMetrics(bool $enableMetrics = true): self
+    {
+        $this->enableMetrics = $enableMetrics;
+        return $this;
+    }
+
+    /**
+     * Gets the maximum cache size in kilobytes.
+     *
+     * @return int The maximum cache size in KB.
+     */
+    public function getMaxCacheKb(): int
+    {
+        if ($this->maxCacheKb === null) {
+            throw new ValkeyGlideException("maxCacheKb is required");
+        }
+        return $this->maxCacheKb;
+    }
+
+    /**
+     * Gets the entry TTL in seconds.
+     *
+     * @return int|null The entry TTL in seconds, or null if not set.
+     */
+    public function getEntryTtlSeconds(): ?int
+    {
+        return $this->entryTtlSeconds;
+    }
+
+    /**
+     * Gets the eviction policy.
+     *
+     * @return int|null The eviction policy constant, or null for default.
+     */
+    public function getEvictionPolicy(): ?int
+    {
+        return $this->evictionPolicy;
+    }
+
+    /**
+     * Gets whether metrics collection is enabled.
+     *
+     * @return bool True if metrics are enabled.
+     */
+    public function getEnableMetrics(): bool
+    {
+        return $this->enableMetrics;
+    }
+
+    /**
+     * Gets the auto-generated unique cache ID.
+     *
+     * @return string The cache ID.
+     */
+    public function getCacheId(): string
+    {
+        if (self::$uuidPrefix === '') {
+            self::$uuidPrefix = substr(bin2hex(random_bytes(4)), 0, 8);
+        }
+        $id = self::$uuidPrefix . '-' . self::$counter;
+        self::$counter++;
+        return $id;
+    }
+
+    /**
+     * Builds the ClientSideCache configuration.
+     *
+     * @return ClientSideCache The immutable client-side cache configuration.
+     */
+    public function build(): ClientSideCache
+    {
+        if ($this->maxCacheKb === null) {
+            throw new ValkeyGlideException("maxCacheKb is required");
+        }
+
+        return new ClientSideCache($this);
+    }
+}

--- a/ClientSideCacheBuilder.php
+++ b/ClientSideCacheBuilder.php
@@ -11,9 +11,6 @@ use ValkeyGlideException;
  */
 class ClientSideCacheBuilder
 {
-    private static string $uuidPrefix = '';
-    private static int $counter = 0;
-
     private ?int $maxCacheKb = null;
     private ?int $entryTtlMs = null;
     private ?int $evictionPolicy = null;
@@ -137,16 +134,13 @@ class ClientSideCacheBuilder
     /**
      * Gets the auto-generated unique cache ID.
      *
+     * Each call to build() generates a new unique cache ID using a GUID.
+     *
      * @return string The cache ID.
      */
     public function getCacheId(): string
     {
-        if (self::$uuidPrefix === '') {
-            self::$uuidPrefix = substr(bin2hex(random_bytes(4)), 0, 8);
-        }
-        $id = self::$uuidPrefix . '-' . self::$counter;
-        self::$counter++;
-        return $id;
+        return bin2hex(random_bytes(16));
     }
 
     /**

--- a/ClientSideCacheBuilder.php
+++ b/ClientSideCacheBuilder.php
@@ -41,15 +41,16 @@ class ClientSideCacheBuilder
      * Sets the Time-To-Live for cached entries in milliseconds.
      *
      * After this duration, entries automatically expire and are removed
-     * from the cache. If not specified, no expiration is applied.
+     * from the cache. Set to 0 to disable TTL expiration (entries remain
+     * until evicted or invalidated).
      *
-     * @param int $entryTtlMs TTL in milliseconds (must be positive).
+     * @param int $entryTtlMs TTL in milliseconds (must be non-negative, 0 = no expiration).
      * @return self This builder instance for method chaining.
      */
     public function entryTtlMs(int $entryTtlMs): self
     {
-        if ($entryTtlMs <= 0) {
-            throw new ValkeyGlideException("entryTtlMs must be positive");
+        if ($entryTtlMs < 0) {
+            throw new ValkeyGlideException("entryTtlMs must be non-negative (0 = no expiration)");
         }
         $this->entryTtlMs = $entryTtlMs;
         return $this;
@@ -103,10 +104,13 @@ class ClientSideCacheBuilder
     /**
      * Gets the entry TTL in milliseconds.
      *
-     * @return int|null The entry TTL in milliseconds, or null if not set.
+     * @return int The entry TTL in milliseconds (0 = no expiration).
      */
-    public function getEntryTtlMs(): ?int
+    public function getEntryTtlMs(): int
     {
+        if ($this->entryTtlMs === null) {
+            throw new ValkeyGlideException("entryTtlMs is required");
+        }
         return $this->entryTtlMs;
     }
 
@@ -154,6 +158,9 @@ class ClientSideCacheBuilder
     {
         if ($this->maxCacheKb === null) {
             throw new ValkeyGlideException("maxCacheKb is required");
+        }
+        if ($this->entryTtlMs === null) {
+            throw new ValkeyGlideException("entryTtlMs is required");
         }
 
         return new ClientSideCache($this);

--- a/common.h
+++ b/common.h
@@ -152,12 +152,12 @@ typedef enum {
 
 /* Client-side cache configuration */
 typedef struct {
-    char*  cache_id;          /* Unique cache identifier */
-    size_t cache_id_len;      /* Length of cache_id */
-    long   max_cache_kb;      /* Maximum cache size in KB */
-    long   entry_ttl_ms;      /* TTL for entries in milliseconds, 0 = no expiration */
-    int    eviction_policy;   /* Eviction policy, -1 if not set */
-    bool   enable_metrics;    /* Whether to enable cache metrics */
+    char*  cache_id;        /* Unique cache identifier */
+    size_t cache_id_len;    /* Length of cache_id */
+    long   max_cache_kb;    /* Maximum cache size in KB */
+    long   entry_ttl_ms;    /* TTL for entries in milliseconds, 0 = no expiration */
+    int    eviction_policy; /* Eviction policy, -1 if not set */
+    bool   enable_metrics;  /* Whether to enable cache metrics */
 } valkey_glide_client_side_cache_config_t;
 
 typedef struct {

--- a/common.h
+++ b/common.h
@@ -155,7 +155,7 @@ typedef struct {
     char*  cache_id;          /* Unique cache identifier */
     size_t cache_id_len;      /* Length of cache_id */
     long   max_cache_kb;      /* Maximum cache size in KB */
-    long   entry_ttl_ms;      /* TTL for entries in milliseconds, -1 if not set */
+    long   entry_ttl_ms;      /* TTL for entries in milliseconds, 0 = no expiration */
     int    eviction_policy;   /* Eviction policy, -1 if not set */
     bool   enable_metrics;    /* Whether to enable cache metrics */
 } valkey_glide_client_side_cache_config_t;

--- a/common.h
+++ b/common.h
@@ -144,19 +144,13 @@ typedef struct {
     bool has_max_decompressed_size; /* true if user explicitly set max_decompressed_size */
 } valkey_glide_compression_config_t;
 
-/* Client-side cache eviction policies */
-typedef enum {
-    VALKEY_GLIDE_EVICTION_POLICY_LRU = 0,
-    VALKEY_GLIDE_EVICTION_POLICY_LFU = 1
-} valkey_glide_eviction_policy_t;
-
 /* Client-side cache configuration */
 typedef struct {
     char*  cache_id;     /* Unique cache identifier */
     size_t cache_id_len; /* Length of cache_id */
     long   max_cache_kb; /* Maximum cache size in KB */
     long   entry_ttl_ms; /* TTL for entries in milliseconds, 0 = no expiration */
-    valkey_glide_eviction_policy_t eviction_policy; /* Eviction policy (LRU or LFU) */
+    int eviction_policy; /* Eviction policy: use CONNECTION_REQUEST__EVICTION_POLICY__* constants */
     bool has_eviction_policy; /* true if user explicitly set eviction_policy */
     bool enable_metrics;      /* Whether to enable cache metrics */
 } valkey_glide_client_side_cache_config_t;

--- a/common.h
+++ b/common.h
@@ -222,8 +222,8 @@ typedef struct {
     zval*     credentials;
     zval*     reconnect_strategy;
     zval*     advanced_config;
-    zval*     context;     /* Stream context for TLS */
-    zval*     compression; /* Compression configuration */
+    zval*     context;           /* Stream context for TLS */
+    zval*     compression;       /* Compression configuration */
     zval*     client_side_cache; /* Client-side cache configuration */
     char*     client_name;
     char*     client_az;

--- a/common.h
+++ b/common.h
@@ -155,7 +155,7 @@ typedef struct {
     char*  cache_id;          /* Unique cache identifier */
     size_t cache_id_len;      /* Length of cache_id */
     long   max_cache_kb;      /* Maximum cache size in KB */
-    long   entry_ttl_seconds; /* TTL for entries in seconds, -1 if not set */
+    long   entry_ttl_ms;      /* TTL for entries in milliseconds, -1 if not set */
     int    eviction_policy;   /* Eviction policy, -1 if not set */
     bool   enable_metrics;    /* Whether to enable cache metrics */
 } valkey_glide_client_side_cache_config_t;

--- a/common.h
+++ b/common.h
@@ -152,12 +152,13 @@ typedef enum {
 
 /* Client-side cache configuration */
 typedef struct {
-    char*  cache_id;        /* Unique cache identifier */
-    size_t cache_id_len;    /* Length of cache_id */
-    long   max_cache_kb;    /* Maximum cache size in KB */
-    long   entry_ttl_ms;    /* TTL for entries in milliseconds, 0 = no expiration */
-    int    eviction_policy; /* Eviction policy, -1 if not set */
-    bool   enable_metrics;  /* Whether to enable cache metrics */
+    char*  cache_id;     /* Unique cache identifier */
+    size_t cache_id_len; /* Length of cache_id */
+    long   max_cache_kb; /* Maximum cache size in KB */
+    long   entry_ttl_ms; /* TTL for entries in milliseconds, 0 = no expiration */
+    valkey_glide_eviction_policy_t eviction_policy; /* Eviction policy (LRU or LFU) */
+    bool has_eviction_policy; /* true if user explicitly set eviction_policy */
+    bool enable_metrics;      /* Whether to enable cache metrics */
 } valkey_glide_client_side_cache_config_t;
 
 typedef struct {

--- a/common.h
+++ b/common.h
@@ -144,6 +144,22 @@ typedef struct {
     bool has_max_decompressed_size; /* true if user explicitly set max_decompressed_size */
 } valkey_glide_compression_config_t;
 
+/* Client-side cache eviction policies */
+typedef enum {
+    VALKEY_GLIDE_EVICTION_POLICY_LRU = 0,
+    VALKEY_GLIDE_EVICTION_POLICY_LFU = 1
+} valkey_glide_eviction_policy_t;
+
+/* Client-side cache configuration */
+typedef struct {
+    char*  cache_id;          /* Unique cache identifier */
+    size_t cache_id_len;      /* Length of cache_id */
+    long   max_cache_kb;      /* Maximum cache size in KB */
+    long   entry_ttl_seconds; /* TTL for entries in seconds, -1 if not set */
+    int    eviction_policy;   /* Eviction policy, -1 if not set */
+    bool   enable_metrics;    /* Whether to enable cache metrics */
+} valkey_glide_client_side_cache_config_t;
+
 typedef struct {
     int num_of_retries;
     int factor;
@@ -174,6 +190,7 @@ typedef struct {
     char*                                              client_az;          /* NULL if not set */
     valkey_glide_advanced_base_client_configuration_t* advanced_config;    /* NULL if not set */
     valkey_glide_compression_config_t*                 compression_config; /* NULL if not set */
+    valkey_glide_client_side_cache_config_t*           client_side_cache;  /* NULL if not set */
     valkey_glide_read_from_t                           read_from;
     int                                                addresses_count;
     int                                                request_timeout;         /* -1 if not set */
@@ -207,6 +224,7 @@ typedef struct {
     zval*     advanced_config;
     zval*     context;     /* Stream context for TLS */
     zval*     compression; /* Compression configuration */
+    zval*     client_side_cache; /* Client-side cache configuration */
     char*     client_name;
     char*     client_az;
     size_t    client_name_len;

--- a/src/client_constructor_mock.c
+++ b/src/client_constructor_mock.c
@@ -92,7 +92,7 @@ PHP_METHOD(ClientConstructorMock, simulate_standalone_constructor) {
     valkey_glide_php_common_constructor_params_t common_params;
     valkey_glide_init_common_constructor_params(&common_params);
 
-    ZEND_PARSE_PARAMETERS_START(0, 13)
+    ZEND_PARSE_PARAMETERS_START(0, 14)
     Z_PARAM_OPTIONAL
     Z_PARAM_ARRAY_OR_NULL(common_params.addresses)
     Z_PARAM_BOOL(common_params.use_tls)
@@ -108,6 +108,7 @@ PHP_METHOD(ClientConstructorMock, simulate_standalone_constructor) {
     Z_PARAM_RESOURCE_EX(
         common_params.context, 1, 0) /* Use Z_PARAM_RESOURCE_OR_NULL with PHP 8.5+ */
     Z_PARAM_ARRAY_OR_NULL(common_params.compression)
+    Z_PARAM_ARRAY_OR_NULL(common_params.client_side_cache)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_THROWS());
 
     /* Validate database_id range before setting */
@@ -157,7 +158,7 @@ PHP_METHOD(ClientConstructorMock, simulate_cluster_constructor) {
     valkey_glide_php_common_constructor_params_t common_params;
     valkey_glide_init_common_constructor_params(&common_params);
 
-    ZEND_PARSE_PARAMETERS_START(0, 14)
+    ZEND_PARSE_PARAMETERS_START(0, 15)
     Z_PARAM_OPTIONAL
     Z_PARAM_ARRAY_OR_NULL(common_params.addresses)
     Z_PARAM_BOOL(common_params.use_tls)
@@ -174,6 +175,7 @@ PHP_METHOD(ClientConstructorMock, simulate_cluster_constructor) {
     Z_PARAM_RESOURCE_EX(
         common_params.context, 1, 0) /* Use Z_PARAM_RESOURCE_OR_NULL with PHP 8.5+ */
     Z_PARAM_ARRAY_OR_NULL(common_params.compression)
+    Z_PARAM_ARRAY_OR_NULL(common_params.client_side_cache)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_THROWS());
 
     /* Validate database_id range before setting */

--- a/src/client_constructor_mock.stub.php
+++ b/src/client_constructor_mock.stub.php
@@ -99,6 +99,8 @@ class ClientConstructorMock
      * @param resource|null $context             Stream context for the connection.
      * @param array|null $compression            Compression configuration ['enabled' => true, 'backend' => ValkeyGlide::COMPRESSION_BACKEND_ZSTD,
      *                                           'compression_level' => 3, 'min_compression_size' => 256].
+     * @param array|null $client_side_cache      Client-side cache configuration ['cache_id' => string, 'max_cache_kb' => int,
+     *                                           'entry_ttl_seconds' => ?int, 'eviction_policy' => ?int, 'enable_metrics' => bool].
      */
     public static function simulate_standalone_constructor(
         ?array $addresses = null,
@@ -114,6 +116,7 @@ class ClientConstructorMock
         ?bool $lazy_connect = null,
         mixed $context = null,
         ?array $compression = null,
+        ?array $client_side_cache = null,
     ): \Connection_request\ConnectionRequest;
 
     /**
@@ -140,6 +143,8 @@ class ClientConstructorMock
      * @param resource|null $context                     Stream context for the connection.
      * @param array|null $compression                 Compression configuration ['enabled' => true, 'backend' => ValkeyGlide::COMPRESSION_BACKEND_ZSTD,
      *                                                'compression_level' => 3, 'min_compression_size' => 256].
+     * @param array|null $client_side_cache           Client-side cache configuration ['cache_id' => string, 'max_cache_kb' => int,
+     *                                                'entry_ttl_seconds' => ?int, 'eviction_policy' => ?int, 'enable_metrics' => bool].
      */
     public static function simulate_cluster_constructor(
         ?array $addresses = null,
@@ -156,5 +161,6 @@ class ClientConstructorMock
         ?int $database_id = null,
         mixed $context = null,
         ?array $compression = null,
+        ?array $client_side_cache = null,
     ): \Connection_request\ConnectionRequest;
 }

--- a/src/client_constructor_mock.stub.php
+++ b/src/client_constructor_mock.stub.php
@@ -100,7 +100,7 @@ class ClientConstructorMock
      * @param array|null $compression            Compression configuration ['enabled' => true, 'backend' => ValkeyGlide::COMPRESSION_BACKEND_ZSTD,
      *                                           'compression_level' => 3, 'min_compression_size' => 256].
      * @param array|null $client_side_cache      Client-side cache configuration ['cache_id' => string, 'max_cache_kb' => int,
-     *                                           'entry_ttl_seconds' => ?int, 'eviction_policy' => ?int, 'enable_metrics' => bool].
+     *                                           'entry_ttl_ms' => int, 'eviction_policy' => ?int, 'enable_metrics' => bool].
      */
     public static function simulate_standalone_constructor(
         ?array $addresses = null,
@@ -144,7 +144,7 @@ class ClientConstructorMock
      * @param array|null $compression                 Compression configuration ['enabled' => true, 'backend' => ValkeyGlide::COMPRESSION_BACKEND_ZSTD,
      *                                                'compression_level' => 3, 'min_compression_size' => 256].
      * @param array|null $client_side_cache           Client-side cache configuration ['cache_id' => string, 'max_cache_kb' => int,
-     *                                                'entry_ttl_seconds' => ?int, 'eviction_policy' => ?int, 'enable_metrics' => bool].
+     *                                                'entry_ttl_ms' => int, 'eviction_policy' => ?int, 'enable_metrics' => bool].
      */
     public static function simulate_cluster_constructor(
         ?array $addresses = null,

--- a/tests/ClientSideCacheTest.php
+++ b/tests/ClientSideCacheTest.php
@@ -228,6 +228,7 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
     {
         $cache = ClientSideCache::builder()
             ->maxCacheKb(1)
+            ->entryTtlMs(60000)
             ->evictionPolicy(ClientSideCache::EVICTION_LRU)
             ->enableMetrics()
             ->build();
@@ -264,6 +265,7 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
     {
         $cache = ClientSideCache::builder()
             ->maxCacheKb(1)
+            ->entryTtlMs(60000)
             ->evictionPolicy(ClientSideCache::EVICTION_LFU)
             ->enableMetrics()
             ->build();
@@ -310,19 +312,24 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
             ClientSideCache::builder()->maxCacheKb(0)->build();
         });
 
-        // entryTtlMs must be positive
+        // entryTtlMs must be non-negative
         $this->assertThrowsMatch(null, function () {
             ClientSideCache::builder()->maxCacheKb(1)->entryTtlMs(-1)->build();
         });
 
+        // entryTtlMs is required
+        $this->assertThrowsMatch(null, function () {
+            ClientSideCache::builder()->maxCacheKb(1)->build();
+        });
+
         // maxCacheKb is required
         $this->assertThrowsMatch(null, function () {
-            ClientSideCache::builder()->build();
+            ClientSideCache::builder()->entryTtlMs(60000)->build();
         });
 
         // Invalid eviction policy
         $this->assertThrowsMatch(null, function () {
-            ClientSideCache::builder()->maxCacheKb(1)->evictionPolicy(99)->build();
+            ClientSideCache::builder()->maxCacheKb(1)->entryTtlMs(60000)->evictionPolicy(99)->build();
         });
     }
 
@@ -331,8 +338,8 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
      */
     public function testUniqueCacheIds()
     {
-        $cache1 = ClientSideCache::builder()->maxCacheKb(1)->build();
-        $cache2 = ClientSideCache::builder()->maxCacheKb(1)->build();
+        $cache1 = ClientSideCache::builder()->maxCacheKb(1)->entryTtlMs(60000)->build();
+        $cache2 = ClientSideCache::builder()->maxCacheKb(1)->entryTtlMs(60000)->build();
 
         $id1 = $cache1->getCacheId();
         $id2 = $cache2->getCacheId();

--- a/tests/ClientSideCacheTest.php
+++ b/tests/ClientSideCacheTest.php
@@ -58,7 +58,7 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
     {
         $cache = ClientSideCache::builder()
             ->maxCacheKb(1)
-            ->entryTtlSeconds(60)
+            ->entryTtlMs(60000)
             ->enableMetrics()
             ->build();
 
@@ -93,7 +93,7 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
     {
         $cache = ClientSideCache::builder()
             ->maxCacheKb(1)
-            ->entryTtlSeconds(60)
+            ->entryTtlMs(60000)
             ->build(); // enableMetrics defaults to false
 
         $client = $this->newCachedInstance($cache->toArray());
@@ -120,7 +120,7 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
     {
         $cache = ClientSideCache::builder()
             ->maxCacheKb(1)
-            ->entryTtlSeconds(60)
+            ->entryTtlMs(60000)
             ->enableMetrics()
             ->build();
 
@@ -144,7 +144,7 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
     {
         $cache = ClientSideCache::builder()
             ->maxCacheKb(1)
-            ->entryTtlSeconds(2)
+            ->entryTtlMs(2000)
             ->enableMetrics()
             ->build();
 
@@ -175,7 +175,7 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
     {
         $cache = ClientSideCache::builder()
             ->maxCacheKb(1)
-            ->entryTtlSeconds(60)
+            ->entryTtlMs(60000)
             ->enableMetrics()
             ->build();
 
@@ -310,9 +310,9 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
             ClientSideCache::builder()->maxCacheKb(0)->build();
         });
 
-        // entryTtlSeconds must be positive
+        // entryTtlMs must be positive
         $this->assertThrowsMatch(null, function () {
-            ClientSideCache::builder()->maxCacheKb(1)->entryTtlSeconds(-1)->build();
+            ClientSideCache::builder()->maxCacheKb(1)->entryTtlMs(-1)->build();
         });
 
         // maxCacheKb is required
@@ -349,7 +349,7 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
     {
         $cache = ClientSideCache::builder()
             ->maxCacheKb(1024)
-            ->entryTtlSeconds(60)
+            ->entryTtlMs(60000)
             ->evictionPolicy(ClientSideCache::EVICTION_LFU)
             ->enableMetrics()
             ->build();
@@ -358,7 +358,7 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
 
         $this->assertArrayHasKey('cache_id', $arr);
         $this->assertEquals(1024, $arr['max_cache_kb']);
-        $this->assertEquals(60, $arr['entry_ttl_seconds']);
+        $this->assertEquals(60000, $arr['entry_ttl_ms']);
         $this->assertEquals(ClientSideCache::EVICTION_LFU, $arr['eviction_policy']);
         $this->assertTrue($arr['enable_metrics']);
     }

--- a/tests/ClientSideCacheTest.php
+++ b/tests/ClientSideCacheTest.php
@@ -14,6 +14,28 @@ use ValkeyGlide\Cache\ClientSideCache;
  */
 class ClientSideCacheTest extends ValkeyGlideBaseTest
 {
+    /* Default cache configuration values */
+    private const DEFAULT_MAX_CACHE_KB = 1;
+    private const DEFAULT_ENTRY_TTL_MS = 60000;
+    private const LARGE_MAX_CACHE_KB   = 1024;
+
+    /* TTL for expiration tests (short enough to test within sleep) */
+    private const SHORT_TTL_MS         = 2000;
+    private const TTL_EXPIRY_WAIT_SECS = 3;
+
+    /* Value size used to force eviction in a 1 KB cache */
+    private const EVICTION_VALUE_SIZE  = 250;
+
+    /* Frequency counts for LFU eviction test */
+    private const LFU_HIGH_FREQUENCY   = 5;
+    private const LFU_MEDIUM_FREQUENCY = 2;
+
+    /* Number of keys for multi-key tests */
+    private const MULTI_KEY_COUNT      = 3;
+
+    /* Invalid eviction policy value for validation test */
+    private const INVALID_EVICTION_POLICY = 99;
+
     public function __construct($host, $port, $auth, $tls)
     {
         parent::__construct($host, $port, $auth, $tls);
@@ -52,16 +74,61 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
     }
 
     /**
+     * Helper to build a ClientSideCache config with common defaults.
+     *
+     * @param int $maxCacheKb     Maximum cache size in KB.
+     * @param int $entryTtlMs     Entry TTL in milliseconds.
+     * @param bool $enableMetrics Whether to enable metrics.
+     * @param int|null $evictionPolicy Eviction policy constant, or null for default.
+     * @return ClientSideCache
+     */
+    protected function buildCache(
+        int $maxCacheKb = self::DEFAULT_MAX_CACHE_KB,
+        int $entryTtlMs = self::DEFAULT_ENTRY_TTL_MS,
+        bool $enableMetrics = true,
+        ?int $evictionPolicy = null
+    ): ClientSideCache {
+        $builder = ClientSideCache::builder()
+            ->maxCacheKb($maxCacheKb)
+            ->entryTtlMs($entryTtlMs)
+            ->enableMetrics($enableMetrics);
+
+        if ($evictionPolicy !== null) {
+            $builder->evictionPolicy($evictionPolicy);
+        }
+
+        return $builder->build();
+    }
+
+    /**
+     * Assert that all metrics-dependent methods throw on the given client.
+     *
+     * @param ValkeyGlide $client The client to test.
+     * @param string $pattern     Regex pattern to match against the exception message.
+     */
+    protected function assertAllMetricsThrow(ValkeyGlide $client, string $pattern): void
+    {
+        $metricsMethods = [
+            'getCacheHitRate',
+            'getCacheMissRate',
+            'getCacheTotalLookups',
+            'getCacheEvictions',
+            'getCacheExpirations',
+        ];
+
+        foreach ($metricsMethods as $method) {
+            $this->assertThrowsMatch(null, function () use ($client, $method) {
+                $client->$method();
+            }, $pattern);
+        }
+    }
+
+    /**
      * Test basic cache hit/miss behavior with metrics tracking.
      */
     public function testBasicCacheHitWithMetrics()
     {
-        $cache = ClientSideCache::builder()
-            ->maxCacheKb(1)
-            ->entryTtlMs(60000)
-            ->enableMetrics()
-            ->build();
-
+        $cache = $this->buildCache();
         $client = $this->newCachedInstance($cache->toArray());
 
         $this->assertTrue($client->set('cache_test_key', 'cache_test_value'));
@@ -77,11 +144,13 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
         // Verify metrics: 1 miss + 2 hits = 3 total, hit rate ~66.67%
         $hitRate = $client->getCacheHitRate();
         $missRate = $client->getCacheMissRate();
+        $totalLookups = $client->getCacheTotalLookups();
 
         $this->assertBetween($hitRate, 0.60, 0.70);
         $this->assertBetween($missRate, 0.30, 0.40);
         // Rates should sum to ~1.0
         $this->assertBetween($hitRate + $missRate, 0.99, 1.01);
+        $this->assertEquals(3, $totalLookups);
 
         $client->close();
     }
@@ -91,11 +160,7 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
      */
     public function testCacheWithoutMetrics()
     {
-        $cache = ClientSideCache::builder()
-            ->maxCacheKb(1)
-            ->entryTtlMs(60000)
-            ->build(); // enableMetrics defaults to false
-
+        $cache = $this->buildCache(enableMetrics: false);
         $client = $this->newCachedInstance($cache->toArray());
 
         $this->assertTrue($client->set('key', 'value'));
@@ -103,9 +168,7 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
         $this->assertEquals('value', $client->get('key'));
 
         // Metrics should throw
-        $this->assertThrowsMatch(null, function () use ($client) {
-            $client->getCacheHitRate();
-        }, '/metrics/i');
+        $this->assertAllMetricsThrow($client, '/metrics/i');
 
         // Entry count should still work
         $this->assertEquals(1, $client->getCacheEntryCount());
@@ -118,12 +181,7 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
      */
     public function testCacheNilValuesNotCached()
     {
-        $cache = ClientSideCache::builder()
-            ->maxCacheKb(1)
-            ->entryTtlMs(60000)
-            ->enableMetrics()
-            ->build();
-
+        $cache = $this->buildCache();
         $client = $this->newCachedInstance($cache->toArray());
 
         $this->assertFalse($client->get('nonexistent_key'));
@@ -133,6 +191,7 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
 
         $missRate = $client->getCacheMissRate();
         $this->assertBetween($missRate, 0.99, 1.01);
+        $this->assertEquals(2, $client->getCacheTotalLookups());
 
         $client->close();
     }
@@ -142,12 +201,7 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
      */
     public function testCacheTtlExpiration()
     {
-        $cache = ClientSideCache::builder()
-            ->maxCacheKb(1)
-            ->entryTtlMs(2000)
-            ->enableMetrics()
-            ->build();
-
+        $cache = $this->buildCache(entryTtlMs: self::SHORT_TTL_MS);
         $client = $this->newCachedInstance($cache->toArray());
 
         $this->assertTrue($client->set('ttl_key', 'ttl_value'));
@@ -158,12 +212,13 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
         $this->assertEquals('ttl_value', $client->get('ttl_key'));
 
         // Wait for TTL to expire
-        sleep(3);
+        sleep(self::TTL_EXPIRY_WAIT_SECS);
 
         // GET after expiration - should fetch from server again
         $this->assertEquals('ttl_value', $client->get('ttl_key'));
 
         $this->assertEquals(1, $client->getCacheExpirations());
+        $this->assertEquals(3, $client->getCacheTotalLookups());
 
         $client->close();
     }
@@ -173,29 +228,25 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
      */
     public function testCacheMultipleKeys()
     {
-        $cache = ClientSideCache::builder()
-            ->maxCacheKb(1)
-            ->entryTtlMs(60000)
-            ->enableMetrics()
-            ->build();
-
+        $cache = $this->buildCache();
         $client = $this->newCachedInstance($cache->toArray());
 
-        for ($i = 1; $i <= 3; $i++) {
+        for ($i = 1; $i <= self::MULTI_KEY_COUNT; $i++) {
             $this->assertTrue($client->set("key{$i}", "value{$i}"));
         }
 
         // GET each key twice (miss + hit)
-        for ($i = 1; $i <= 3; $i++) {
+        for ($i = 1; $i <= self::MULTI_KEY_COUNT; $i++) {
             $this->assertEquals("value{$i}", $client->get("key{$i}"));
             $this->assertEquals("value{$i}", $client->get("key{$i}"));
         }
 
-        $this->assertEquals(3, $client->getCacheEntryCount());
+        $this->assertEquals(self::MULTI_KEY_COUNT, $client->getCacheEntryCount());
 
-        // 3 misses + 3 hits = 50% hit rate
+        // MULTI_KEY_COUNT misses + MULTI_KEY_COUNT hits = 50% hit rate
         $hitRate = $client->getCacheHitRate();
         $this->assertBetween($hitRate, 0.45, 0.55);
+        $this->assertEquals(self::MULTI_KEY_COUNT * 2, $client->getCacheTotalLookups());
 
         $client->close();
     }
@@ -210,9 +261,8 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
         $this->assertTrue($client->set('key', 'value'));
         $this->assertEquals('value', $client->get('key'));
 
-        $this->assertThrowsMatch(null, function () use ($client) {
-            $client->getCacheHitRate();
-        }, '/not enabled/i');
+        // All metrics (including entry count) should throw when cache is not configured
+        $this->assertAllMetricsThrow($client, '/not enabled/i');
 
         $this->assertThrowsMatch(null, function () use ($client) {
             $client->getCacheEntryCount();
@@ -226,23 +276,17 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
      */
     public function testCacheEvictionPolicyLru()
     {
-        $cache = ClientSideCache::builder()
-            ->maxCacheKb(1)
-            ->entryTtlMs(60000)
-            ->evictionPolicy(ClientSideCache::EVICTION_LRU)
-            ->enableMetrics()
-            ->build();
-
+        $cache = $this->buildCache(evictionPolicy: ClientSideCache::EVICTION_LRU);
         $client = $this->newCachedInstance($cache->toArray());
 
-        $value = str_repeat('x', 250);
+        $value = str_repeat('x', self::EVICTION_VALUE_SIZE);
 
-        for ($i = 1; $i <= 3; $i++) {
+        for ($i = 1; $i <= self::MULTI_KEY_COUNT; $i++) {
             $this->assertTrue($client->set("lru_key{$i}", $value));
             $this->assertEquals($value, $client->get("lru_key{$i}"));
         }
 
-        $this->assertEquals(3, $client->getCacheEntryCount());
+        $this->assertEquals(self::MULTI_KEY_COUNT, $client->getCacheEntryCount());
 
         // Access key1 to make it recently used
         $this->assertEquals($value, $client->get('lru_key1'));
@@ -263,26 +307,20 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
      */
     public function testCacheEvictionPolicyLfu()
     {
-        $cache = ClientSideCache::builder()
-            ->maxCacheKb(1)
-            ->entryTtlMs(60000)
-            ->evictionPolicy(ClientSideCache::EVICTION_LFU)
-            ->enableMetrics()
-            ->build();
-
+        $cache = $this->buildCache(evictionPolicy: ClientSideCache::EVICTION_LFU);
         $client = $this->newCachedInstance($cache->toArray());
 
-        $value = str_repeat('x', 250);
+        $value = str_repeat('x', self::EVICTION_VALUE_SIZE);
 
         // key1: high frequency
         $this->assertTrue($client->set('key1', $value));
-        for ($j = 0; $j < 5; $j++) {
+        for ($j = 0; $j < self::LFU_HIGH_FREQUENCY; $j++) {
             $this->assertEquals($value, $client->get('key1'));
         }
 
         // key2: medium frequency
         $this->assertTrue($client->set('key2', $value));
-        for ($j = 0; $j < 2; $j++) {
+        for ($j = 0; $j < self::LFU_MEDIUM_FREQUENCY; $j++) {
             $this->assertEquals($value, $client->get('key2'));
         }
 
@@ -290,13 +328,13 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
         $this->assertTrue($client->set('key3', $value));
         $this->assertEquals($value, $client->get('key3'));
 
-        $this->assertEquals(3, $client->getCacheEntryCount());
+        $this->assertEquals(self::MULTI_KEY_COUNT, $client->getCacheEntryCount());
 
         // key4 should trigger eviction of key3 (lowest frequency)
         $this->assertTrue($client->set('key4', $value));
         $this->assertEquals($value, $client->get('key4'));
 
-        $this->assertEquals(3, $client->getCacheEntryCount());
+        $this->assertEquals(self::MULTI_KEY_COUNT, $client->getCacheEntryCount());
         $this->assertEquals(1, $client->getCacheEvictions());
 
         $client->close();
@@ -314,22 +352,26 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
 
         // entryTtlMs must be non-negative
         $this->assertThrowsMatch(null, function () {
-            ClientSideCache::builder()->maxCacheKb(1)->entryTtlMs(-1)->build();
+            ClientSideCache::builder()->maxCacheKb(self::DEFAULT_MAX_CACHE_KB)->entryTtlMs(-1)->build();
         });
 
         // entryTtlMs is required
         $this->assertThrowsMatch(null, function () {
-            ClientSideCache::builder()->maxCacheKb(1)->build();
+            ClientSideCache::builder()->maxCacheKb(self::DEFAULT_MAX_CACHE_KB)->build();
         });
 
         // maxCacheKb is required
         $this->assertThrowsMatch(null, function () {
-            ClientSideCache::builder()->entryTtlMs(60000)->build();
+            ClientSideCache::builder()->entryTtlMs(self::DEFAULT_ENTRY_TTL_MS)->build();
         });
 
         // Invalid eviction policy
         $this->assertThrowsMatch(null, function () {
-            ClientSideCache::builder()->maxCacheKb(1)->entryTtlMs(60000)->evictionPolicy(99)->build();
+            ClientSideCache::builder()
+                ->maxCacheKb(self::DEFAULT_MAX_CACHE_KB)
+                ->entryTtlMs(self::DEFAULT_ENTRY_TTL_MS)
+                ->evictionPolicy(self::INVALID_EVICTION_POLICY)
+                ->build();
         });
     }
 
@@ -338,15 +380,13 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
      */
     public function testUniqueCacheIds()
     {
-        $cache1 = ClientSideCache::builder()->maxCacheKb(1)->entryTtlMs(60000)->build();
-        $cache2 = ClientSideCache::builder()->maxCacheKb(1)->entryTtlMs(60000)->build();
+        $cache1 = $this->buildCache();
+        $cache2 = $this->buildCache();
 
         $id1 = $cache1->getCacheId();
         $id2 = $cache2->getCacheId();
 
-        if ($id1 === $id2) {
-            $this->assert('Cache IDs should be unique but got: %s and %s', $id1, $id2);
-        }
+        $this->assertNotEquals($id1, $id2);
     }
 
     /**
@@ -354,18 +394,16 @@ class ClientSideCacheTest extends ValkeyGlideBaseTest
      */
     public function testToArray()
     {
-        $cache = ClientSideCache::builder()
-            ->maxCacheKb(1024)
-            ->entryTtlMs(60000)
-            ->evictionPolicy(ClientSideCache::EVICTION_LFU)
-            ->enableMetrics()
-            ->build();
+        $cache = $this->buildCache(
+            maxCacheKb: self::LARGE_MAX_CACHE_KB,
+            evictionPolicy: ClientSideCache::EVICTION_LFU
+        );
 
         $arr = $cache->toArray();
 
         $this->assertArrayHasKey('cache_id', $arr);
-        $this->assertEquals(1024, $arr['max_cache_kb']);
-        $this->assertEquals(60000, $arr['entry_ttl_ms']);
+        $this->assertEquals(self::LARGE_MAX_CACHE_KB, $arr['max_cache_kb']);
+        $this->assertEquals(self::DEFAULT_ENTRY_TTL_MS, $arr['entry_ttl_ms']);
         $this->assertEquals(ClientSideCache::EVICTION_LFU, $arr['eviction_policy']);
         $this->assertTrue($arr['enable_metrics']);
     }

--- a/tests/ClientSideCacheTest.php
+++ b/tests/ClientSideCacheTest.php
@@ -1,0 +1,365 @@
+<?php
+
+defined('VALKEY_GLIDE_PHP_TESTRUN') or die("Use TestValkeyGlide.php to run tests!\n");
+
+require_once __DIR__ . "/ValkeyGlideBaseTest.php";
+require_once __DIR__ . "/../ClientSideCache.php";
+require_once __DIR__ . "/../ClientSideCacheBuilder.php";
+
+use ValkeyGlide\Cache\ClientSideCache;
+
+/**
+ * Client-Side Cache Test
+ * Tests client-side caching configuration, metrics, and behavior.
+ */
+class ClientSideCacheTest extends ValkeyGlideBaseTest
+{
+    public function __construct($host, $port, $auth, $tls)
+    {
+        parent::__construct($host, $port, $auth, $tls);
+    }
+
+    /**
+     * Helper to create a connected client with client-side cache enabled.
+     */
+    protected function newCachedInstance(array $cacheConfig): ValkeyGlide
+    {
+        $client = new ValkeyGlide();
+        $addresses = [[
+            'host' => $this->getHost(),
+            'port' => $this->getPort()
+        ]];
+
+        if ($this->getTLS()) {
+            $client->connect(
+                addresses: $addresses,
+                use_tls: true,
+                advanced_config: ['tls_config' => ['use_insecure_tls' => true]],
+                client_side_cache: $cacheConfig
+            );
+        } else {
+            $client->connect(
+                addresses: $addresses,
+                client_side_cache: $cacheConfig
+            );
+        }
+
+        if ($this->getAuth()) {
+            $this->assertTrue($client->auth($this->getAuth()));
+        }
+
+        return $client;
+    }
+
+    /**
+     * Test basic cache hit/miss behavior with metrics tracking.
+     */
+    public function testBasicCacheHitWithMetrics()
+    {
+        $cache = ClientSideCache::builder()
+            ->maxCacheKb(1)
+            ->entryTtlSeconds(60)
+            ->enableMetrics()
+            ->build();
+
+        $client = $this->newCachedInstance($cache->toArray());
+
+        $this->assertTrue($client->set('cache_test_key', 'cache_test_value'));
+
+        // First GET - cache miss
+        $this->assertEquals('cache_test_value', $client->get('cache_test_key'));
+        $this->assertEquals(1, $client->getCacheEntryCount());
+
+        // Second and third GET - cache hits
+        $this->assertEquals('cache_test_value', $client->get('cache_test_key'));
+        $this->assertEquals('cache_test_value', $client->get('cache_test_key'));
+
+        // Verify metrics: 1 miss + 2 hits = 3 total, hit rate ~66.67%
+        $hitRate = $client->getCacheHitRate();
+        $missRate = $client->getCacheMissRate();
+
+        $this->assertBetween($hitRate, 0.60, 0.70);
+        $this->assertBetween($missRate, 0.30, 0.40);
+        // Rates should sum to ~1.0
+        $this->assertBetween($hitRate + $missRate, 0.99, 1.01);
+
+        $client->close();
+    }
+
+    /**
+     * Test that cache works but metrics throw when disabled.
+     */
+    public function testCacheWithoutMetrics()
+    {
+        $cache = ClientSideCache::builder()
+            ->maxCacheKb(1)
+            ->entryTtlSeconds(60)
+            ->build(); // enableMetrics defaults to false
+
+        $client = $this->newCachedInstance($cache->toArray());
+
+        $this->assertTrue($client->set('key', 'value'));
+        $this->assertEquals('value', $client->get('key'));
+        $this->assertEquals('value', $client->get('key'));
+
+        // Metrics should throw
+        $this->assertThrowsMatch(null, function () use ($client) {
+            $client->getCacheHitRate();
+        }, '/metrics/i');
+
+        // Entry count should still work
+        $this->assertEquals(1, $client->getCacheEntryCount());
+
+        $client->close();
+    }
+
+    /**
+     * Test that NIL values are not cached.
+     */
+    public function testCacheNilValuesNotCached()
+    {
+        $cache = ClientSideCache::builder()
+            ->maxCacheKb(1)
+            ->entryTtlSeconds(60)
+            ->enableMetrics()
+            ->build();
+
+        $client = $this->newCachedInstance($cache->toArray());
+
+        $this->assertFalse($client->get('nonexistent_key'));
+        $this->assertEquals(0, $client->getCacheEntryCount());
+
+        $this->assertFalse($client->get('nonexistent_key'));
+
+        $missRate = $client->getCacheMissRate();
+        $this->assertBetween($missRate, 0.99, 1.01);
+
+        $client->close();
+    }
+
+    /**
+     * Test that cache entries expire after TTL.
+     */
+    public function testCacheTtlExpiration()
+    {
+        $cache = ClientSideCache::builder()
+            ->maxCacheKb(1)
+            ->entryTtlSeconds(2)
+            ->enableMetrics()
+            ->build();
+
+        $client = $this->newCachedInstance($cache->toArray());
+
+        $this->assertTrue($client->set('ttl_key', 'ttl_value'));
+        $this->assertEquals('ttl_value', $client->get('ttl_key'));
+        $this->assertEquals(1, $client->getCacheEntryCount());
+
+        // Second GET - from cache
+        $this->assertEquals('ttl_value', $client->get('ttl_key'));
+
+        // Wait for TTL to expire
+        sleep(3);
+
+        // GET after expiration - should fetch from server again
+        $this->assertEquals('ttl_value', $client->get('ttl_key'));
+
+        $this->assertEquals(1, $client->getCacheExpirations());
+
+        $client->close();
+    }
+
+    /**
+     * Test caching of multiple keys.
+     */
+    public function testCacheMultipleKeys()
+    {
+        $cache = ClientSideCache::builder()
+            ->maxCacheKb(1)
+            ->entryTtlSeconds(60)
+            ->enableMetrics()
+            ->build();
+
+        $client = $this->newCachedInstance($cache->toArray());
+
+        for ($i = 1; $i <= 3; $i++) {
+            $this->assertTrue($client->set("key{$i}", "value{$i}"));
+        }
+
+        // GET each key twice (miss + hit)
+        for ($i = 1; $i <= 3; $i++) {
+            $this->assertEquals("value{$i}", $client->get("key{$i}"));
+            $this->assertEquals("value{$i}", $client->get("key{$i}"));
+        }
+
+        $this->assertEquals(3, $client->getCacheEntryCount());
+
+        // 3 misses + 3 hits = 50% hit rate
+        $hitRate = $client->getCacheHitRate();
+        $this->assertBetween($hitRate, 0.45, 0.55);
+
+        $client->close();
+    }
+
+    /**
+     * Test that without cache, metrics are not available.
+     */
+    public function testNoCacheMetrics()
+    {
+        $client = $this->newInstance();
+
+        $this->assertTrue($client->set('key', 'value'));
+        $this->assertEquals('value', $client->get('key'));
+
+        $this->assertThrowsMatch(null, function () use ($client) {
+            $client->getCacheHitRate();
+        }, '/not enabled/i');
+
+        $this->assertThrowsMatch(null, function () use ($client) {
+            $client->getCacheEntryCount();
+        }, '/not enabled/i');
+
+        $client->close();
+    }
+
+    /**
+     * Test LRU eviction policy.
+     */
+    public function testCacheEvictionPolicyLru()
+    {
+        $cache = ClientSideCache::builder()
+            ->maxCacheKb(1)
+            ->evictionPolicy(ClientSideCache::EVICTION_LRU)
+            ->enableMetrics()
+            ->build();
+
+        $client = $this->newCachedInstance($cache->toArray());
+
+        $value = str_repeat('x', 250);
+
+        for ($i = 1; $i <= 3; $i++) {
+            $this->assertTrue($client->set("lru_key{$i}", $value));
+            $this->assertEquals($value, $client->get("lru_key{$i}"));
+        }
+
+        $this->assertEquals(3, $client->getCacheEntryCount());
+
+        // Access key1 to make it recently used
+        $this->assertEquals($value, $client->get('lru_key1'));
+
+        // Add 2 more keys - should evict key2 and key3
+        for ($i = 4; $i <= 5; $i++) {
+            $this->assertTrue($client->set("lru_key{$i}", $value));
+            $this->assertEquals($value, $client->get("lru_key{$i}"));
+        }
+
+        $this->assertEquals(2, $client->getCacheEvictions());
+
+        $client->close();
+    }
+
+    /**
+     * Test LFU eviction policy.
+     */
+    public function testCacheEvictionPolicyLfu()
+    {
+        $cache = ClientSideCache::builder()
+            ->maxCacheKb(1)
+            ->evictionPolicy(ClientSideCache::EVICTION_LFU)
+            ->enableMetrics()
+            ->build();
+
+        $client = $this->newCachedInstance($cache->toArray());
+
+        $value = str_repeat('x', 250);
+
+        // key1: high frequency
+        $this->assertTrue($client->set('key1', $value));
+        for ($j = 0; $j < 5; $j++) {
+            $this->assertEquals($value, $client->get('key1'));
+        }
+
+        // key2: medium frequency
+        $this->assertTrue($client->set('key2', $value));
+        for ($j = 0; $j < 2; $j++) {
+            $this->assertEquals($value, $client->get('key2'));
+        }
+
+        // key3: low frequency
+        $this->assertTrue($client->set('key3', $value));
+        $this->assertEquals($value, $client->get('key3'));
+
+        $this->assertEquals(3, $client->getCacheEntryCount());
+
+        // key4 should trigger eviction of key3 (lowest frequency)
+        $this->assertTrue($client->set('key4', $value));
+        $this->assertEquals($value, $client->get('key4'));
+
+        $this->assertEquals(3, $client->getCacheEntryCount());
+        $this->assertEquals(1, $client->getCacheEvictions());
+
+        $client->close();
+    }
+
+    /**
+     * Test the ClientSideCache builder validation.
+     */
+    public function testBuilderValidation()
+    {
+        // maxCacheKb must be positive
+        $this->assertThrowsMatch(null, function () {
+            ClientSideCache::builder()->maxCacheKb(0)->build();
+        });
+
+        // entryTtlSeconds must be positive
+        $this->assertThrowsMatch(null, function () {
+            ClientSideCache::builder()->maxCacheKb(1)->entryTtlSeconds(-1)->build();
+        });
+
+        // maxCacheKb is required
+        $this->assertThrowsMatch(null, function () {
+            ClientSideCache::builder()->build();
+        });
+
+        // Invalid eviction policy
+        $this->assertThrowsMatch(null, function () {
+            ClientSideCache::builder()->maxCacheKb(1)->evictionPolicy(99)->build();
+        });
+    }
+
+    /**
+     * Test that cache IDs are unique across builder instances.
+     */
+    public function testUniqueCacheIds()
+    {
+        $cache1 = ClientSideCache::builder()->maxCacheKb(1)->build();
+        $cache2 = ClientSideCache::builder()->maxCacheKb(1)->build();
+
+        $id1 = $cache1->getCacheId();
+        $id2 = $cache2->getCacheId();
+
+        if ($id1 === $id2) {
+            $this->assert('Cache IDs should be unique but got: %s and %s', $id1, $id2);
+        }
+    }
+
+    /**
+     * Test toArray() produces the expected structure.
+     */
+    public function testToArray()
+    {
+        $cache = ClientSideCache::builder()
+            ->maxCacheKb(1024)
+            ->entryTtlSeconds(60)
+            ->evictionPolicy(ClientSideCache::EVICTION_LFU)
+            ->enableMetrics()
+            ->build();
+
+        $arr = $cache->toArray();
+
+        $this->assertArrayHasKey('cache_id', $arr);
+        $this->assertEquals(1024, $arr['max_cache_kb']);
+        $this->assertEquals(60, $arr['entry_ttl_seconds']);
+        $this->assertEquals(ClientSideCache::EVICTION_LFU, $arr['eviction_policy']);
+        $this->assertTrue($arr['enable_metrics']);
+    }
+}

--- a/tests/TestValkeyGlide.php
+++ b/tests/TestValkeyGlide.php
@@ -97,6 +97,7 @@ require_once __DIR__ . "/ValkeyGlideJsonTest.php";
 require_once __DIR__ . "/ValkeyGlideClusterJsonTest.php";
 require_once __DIR__ . "/ValkeyGlideSearchTest.php";
 require_once __DIR__ . "/ValkeyGlideClusterSearchTest.php";
+require_once __DIR__ . "/ClientSideCacheTest.php";
 
 function getClassArray($classes)
 {
@@ -133,6 +134,7 @@ function getTestClass($class)
         'valkeyglideclusterjson' => 'ValkeyGlideClusterJsonTest',
         'valkeyglidesearch' => 'ValkeyGlideSearchTest',
         'valkeyglideclustersearch' => 'ValkeyGlideClusterSearchTest',
+        'clientsidecache' => 'ClientSideCacheTest'
     ];
 
     /* Return early if the class is one of our built-in ones */

--- a/utils/patch_proto_and_rust.py
+++ b/utils/patch_proto_and_rust.py
@@ -65,7 +65,7 @@ def patch_rust_types_rs(rust_types_file):
     - refresh_interval_seconds: Option<u32> -> u32
     - compression_level: Option<i32> -> i32
     - read_only: Option<bool> -> bool
-    - client_side_cache.entry_ttl_seconds: Option<u64> -> u64
+    - client_side_cache.entry_ttl_ms: Option<u64> -> u64
     - client_side_cache.eviction_policy: Option<EnumOrUnknown> -> EnumOrUnknown
     """
     
@@ -165,15 +165,15 @@ def patch_rust_types_rs(rust_types_file):
             needs_patching = True
             log_message("Applied read_only patch")
         
-        # Fix client_side_cache.entry_ttl_seconds: changed from Option<u64> to u64
-        entry_ttl_pattern = r'entry_ttl_seconds:\s*proto_cache\.entry_ttl_seconds,'
-        entry_ttl_replacement = 'entry_ttl_seconds: if proto_cache.entry_ttl_seconds != 0 { Some(proto_cache.entry_ttl_seconds) } else { None },'
+        # Fix client_side_cache.entry_ttl_ms: changed from Option<u64> to u64
+        entry_ttl_pattern = r'entry_ttl_ms:\s*proto_cache\.entry_ttl_ms,'
+        entry_ttl_replacement = 'entry_ttl_ms: if proto_cache.entry_ttl_ms != 0 { Some(proto_cache.entry_ttl_ms) } else { None },'
         if re.search(entry_ttl_pattern, new_content):
             if not needs_patching:
                 create_backup(rust_types_file)
             new_content = re.sub(entry_ttl_pattern, entry_ttl_replacement, new_content)
             needs_patching = True
-            log_message("Applied entry_ttl_seconds patch")
+            log_message("Applied entry_ttl_ms patch")
         
         # Fix client_side_cache.eviction_policy: changed from Option<EnumOrUnknown> to EnumOrUnknown
         eviction_pattern = (
@@ -224,7 +224,7 @@ def verify_rust_patch(rust_types_file):
         
         if tcp_nodelay_fixed and pubsub_fixed and jitter_fixed and refresh_fixed and compression_fixed and read_only_fixed and max_decompressed_fixed:
         read_only_fixed = 'let read_only = value.read_only;' in content
-        entry_ttl_fixed = 'if proto_cache.entry_ttl_seconds != 0 { Some(proto_cache.entry_ttl_seconds) } else { None }' in content
+        entry_ttl_fixed = 'if proto_cache.entry_ttl_ms != 0 { Some(proto_cache.entry_ttl_ms) } else { None }' in content
         eviction_fixed = '.enum_value()' in content and '.and_then(|enum_or_unknown|' not in content
         
         all_fixed = (tcp_nodelay_fixed and pubsub_fixed and jitter_fixed and
@@ -253,7 +253,7 @@ def verify_rust_patch(rust_types_file):
             if not read_only_fixed:
                 missing.append("read_only fix")
             if not entry_ttl_fixed:
-                missing.append("entry_ttl_seconds fix")
+                missing.append("entry_ttl_ms fix")
             if not eviction_fixed:
                 missing.append("eviction_policy fix")
             log_message(f"Rust patch verification: FAILED - Missing: {', '.join(missing)}", "ERROR")

--- a/utils/patch_proto_and_rust.py
+++ b/utils/patch_proto_and_rust.py
@@ -65,7 +65,8 @@ def patch_rust_types_rs(rust_types_file):
     - refresh_interval_seconds: Option<u32> -> u32
     - compression_level: Option<i32> -> i32
     - read_only: Option<bool> -> bool
-    - eviction_policy: Option<EnumOrUnknown> -> EnumOrUnknown
+    - client_side_cache.entry_ttl_seconds: Option<u64> -> u64
+    - client_side_cache.eviction_policy: Option<EnumOrUnknown> -> EnumOrUnknown
     """
     
     if not os.path.exists(rust_types_file):
@@ -164,14 +165,32 @@ def patch_rust_types_rs(rust_types_file):
             needs_patching = True
             log_message("Applied read_only patch")
         
-        # Fix eviction_policy: changed from Option<EnumOrUnknown> to EnumOrUnknown
-        # The .and_then() method doesn't exist on EnumOrUnknown, need to use .enum_value() directly
-        eviction_pattern = r'eviction_policy: proto_cache\s*\n\s*\.eviction_policy\s*\n\s*\.and_then\(\|enum_or_unknown\| enum_or_unknown\.enum_value\(\)\.ok\(\)\)'
-        eviction_replacement = 'eviction_policy: proto_cache\n                    .eviction_policy\n                    .enum_value().ok()'
-        if re.search(eviction_pattern, new_content):
+        # Fix client_side_cache.entry_ttl_seconds: changed from Option<u64> to u64
+        entry_ttl_pattern = r'entry_ttl_seconds:\s*proto_cache\.entry_ttl_seconds,'
+        entry_ttl_replacement = 'entry_ttl_seconds: if proto_cache.entry_ttl_seconds != 0 { Some(proto_cache.entry_ttl_seconds) } else { None },'
+        if re.search(entry_ttl_pattern, new_content):
             if not needs_patching:
                 create_backup(rust_types_file)
-            new_content = re.sub(eviction_pattern, eviction_replacement, new_content)
+            new_content = re.sub(entry_ttl_pattern, entry_ttl_replacement, new_content)
+            needs_patching = True
+            log_message("Applied entry_ttl_seconds patch")
+        
+        # Fix client_side_cache.eviction_policy: changed from Option<EnumOrUnknown> to EnumOrUnknown
+        eviction_pattern = (
+            r'eviction_policy:\s*proto_cache\s*'
+            r'\.eviction_policy\s*'
+            r'\.and_then\(\|enum_or_unknown\|\s*enum_or_unknown\.enum_value\(\)\.ok\(\)\)'
+        )
+        eviction_replacement = (
+            'eviction_policy: proto_cache\n'
+            '                    .eviction_policy\n'
+            '                    .enum_value()\n'
+            '                    .ok()'
+        )
+        if re.search(eviction_pattern, new_content, re.DOTALL):
+            if not needs_patching:
+                create_backup(rust_types_file)
+            new_content = re.sub(eviction_pattern, eviction_replacement, new_content, flags=re.DOTALL)
             needs_patching = True
             log_message("Applied eviction_policy patch")
         
@@ -204,6 +223,15 @@ def verify_rust_patch(rust_types_file):
         max_decompressed_fixed = 'if proto_config.max_decompressed_size != 0' in content
         
         if tcp_nodelay_fixed and pubsub_fixed and jitter_fixed and refresh_fixed and compression_fixed and read_only_fixed and max_decompressed_fixed:
+        read_only_fixed = 'let read_only = value.read_only;' in content
+        entry_ttl_fixed = 'if proto_cache.entry_ttl_seconds != 0 { Some(proto_cache.entry_ttl_seconds) } else { None }' in content
+        eviction_fixed = '.enum_value()' in content and '.and_then(|enum_or_unknown|' not in content
+        
+        all_fixed = (tcp_nodelay_fixed and pubsub_fixed and jitter_fixed and
+                     refresh_fixed and compression_fixed and read_only_fixed and
+                     entry_ttl_fixed and eviction_fixed)
+        
+        if all_fixed:
             log_message("Rust patch verification: SUCCESS")
             return True
         else:
@@ -222,6 +250,12 @@ def verify_rust_patch(rust_types_file):
                 missing.append("compression_level fix")
             if not max_decompressed_fixed:
                 missing.append("max_decompressed_size fix")
+            if not read_only_fixed:
+                missing.append("read_only fix")
+            if not entry_ttl_fixed:
+                missing.append("entry_ttl_seconds fix")
+            if not eviction_fixed:
+                missing.append("eviction_policy fix")
             log_message(f"Rust patch verification: FAILED - Missing: {', '.join(missing)}", "ERROR")
             return False
     

--- a/utils/patch_proto_and_rust.py
+++ b/utils/patch_proto_and_rust.py
@@ -65,7 +65,6 @@ def patch_rust_types_rs(rust_types_file):
     - refresh_interval_seconds: Option<u32> -> u32
     - compression_level: Option<i32> -> i32
     - read_only: Option<bool> -> bool
-    - client_side_cache.entry_ttl_ms: Option<u64> -> u64
     - client_side_cache.eviction_policy: Option<EnumOrUnknown> -> EnumOrUnknown
     """
     
@@ -165,16 +164,6 @@ def patch_rust_types_rs(rust_types_file):
             needs_patching = True
             log_message("Applied read_only patch")
         
-        # Fix client_side_cache.entry_ttl_ms: changed from Option<u64> to u64
-        entry_ttl_pattern = r'entry_ttl_ms:\s*proto_cache\.entry_ttl_ms,'
-        entry_ttl_replacement = 'entry_ttl_ms: if proto_cache.entry_ttl_ms != 0 { Some(proto_cache.entry_ttl_ms) } else { None },'
-        if re.search(entry_ttl_pattern, new_content):
-            if not needs_patching:
-                create_backup(rust_types_file)
-            new_content = re.sub(entry_ttl_pattern, entry_ttl_replacement, new_content)
-            needs_patching = True
-            log_message("Applied entry_ttl_ms patch")
-        
         # Fix client_side_cache.eviction_policy: changed from Option<EnumOrUnknown> to EnumOrUnknown
         eviction_pattern = (
             r'eviction_policy:\s*proto_cache\s*'
@@ -224,12 +213,11 @@ def verify_rust_patch(rust_types_file):
         
         if tcp_nodelay_fixed and pubsub_fixed and jitter_fixed and refresh_fixed and compression_fixed and read_only_fixed and max_decompressed_fixed:
         read_only_fixed = 'let read_only = value.read_only;' in content
-        entry_ttl_fixed = 'if proto_cache.entry_ttl_ms != 0 { Some(proto_cache.entry_ttl_ms) } else { None }' in content
         eviction_fixed = '.enum_value()' in content and '.and_then(|enum_or_unknown|' not in content
         
         all_fixed = (tcp_nodelay_fixed and pubsub_fixed and jitter_fixed and
                      refresh_fixed and compression_fixed and read_only_fixed and
-                     entry_ttl_fixed and eviction_fixed)
+                     eviction_fixed)
         
         if all_fixed:
             log_message("Rust patch verification: SUCCESS")
@@ -252,8 +240,6 @@ def verify_rust_patch(rust_types_file):
                 missing.append("max_decompressed_size fix")
             if not read_only_fixed:
                 missing.append("read_only fix")
-            if not entry_ttl_fixed:
-                missing.append("entry_ttl_ms fix")
             if not eviction_fixed:
                 missing.append("eviction_policy fix")
             log_message(f"Rust patch verification: FAILED - Missing: {', '.join(missing)}", "ERROR")

--- a/utils/patch_proto_and_rust.py
+++ b/utils/patch_proto_and_rust.py
@@ -24,39 +24,39 @@ def remove_optional_from_proto(directory):
     files_modified = 0
 
     log_message(f"Scanning protobuf files in: {directory}")
-    
+
     for root, _, files in os.walk(directory):
         for file in files:
             if proto_file_pattern.match(file):
                 filepath = os.path.join(root, file)
-                
+
                 try:
                     with open(filepath, 'r') as f:
                         content = f.read()
-                    
+
                     # Check if file needs modification
                     if 'optional ' in content:
                         create_backup(filepath)
                         new_content = re.sub(r'\boptional\s+', '', content)
-                        
+
                         with open(filepath, 'w') as f:
                             f.write(new_content)
-                        
+
                         log_message(f"Updated protobuf: {filepath}")
                         files_modified += 1
                     else:
                         log_message(f"No changes needed: {filepath}")
-                        
+
                 except Exception as e:
                     log_message(f"Error processing {filepath}: {e}", "ERROR")
                     return False
-    
+
     log_message(f"Modified {files_modified} protobuf files")
     return True
 
 def patch_rust_types_rs(rust_types_file):
     """Patch the Rust types.rs file to fix type mismatches between protobuf and Rust code.
-    
+
     Fixes several fields that changed from Option<T> to T in protobuf:
     - tcp_nodelay: Option<bool> -> bool
     - read_only: Option<bool> -> bool
@@ -64,23 +64,23 @@ def patch_rust_types_rs(rust_types_file):
     - jitter_percent: Option<u32> -> u32
     - refresh_interval_seconds: Option<u32> -> u32
     - compression_level: Option<i32> -> i32
-    - read_only: Option<bool> -> bool
+    - max_decompressed_size: Option<u64> -> u64
     - client_side_cache.eviction_policy: Option<EnumOrUnknown> -> EnumOrUnknown
     """
-    
+
     if not os.path.exists(rust_types_file):
         log_message(f"Rust types file not found: {rust_types_file}", "ERROR")
         return False
-    
+
     log_message(f"Patching Rust file: {rust_types_file}")
-    
+
     try:
         with open(rust_types_file, 'r') as f:
             content = f.read()
-        
+
         needs_patching = False
         new_content = content
-        
+
         # Fix tcp_nodelay: changed from Option<bool> to bool
         tcp_nodelay_pattern = r'let tcp_nodelay = value\.tcp_nodelay\.unwrap_or\(true\);'
         tcp_nodelay_replacement = 'let tcp_nodelay = value.tcp_nodelay;'
@@ -89,7 +89,7 @@ def patch_rust_types_rs(rust_types_file):
             new_content = re.sub(tcp_nodelay_pattern, tcp_nodelay_replacement, new_content)
             needs_patching = True
             log_message("Applied tcp_nodelay patch")
-        
+
         # Fix read_only: changed from Option<bool> to bool
         read_only_pattern = r'let read_only = value\.read_only\.unwrap_or\(false\);'
         read_only_replacement = 'let read_only = value.read_only;'
@@ -99,7 +99,7 @@ def patch_rust_types_rs(rust_types_file):
             new_content = re.sub(read_only_pattern, read_only_replacement, new_content)
             needs_patching = True
             log_message("Applied read_only patch")
-        
+
         # Fix pubsub_reconciliation_interval_ms: changed from Option<u32> to u32
         pubsub_pattern = r'value\.pubsub_reconciliation_interval_ms\.filter\(\|&v\| v != 0\);'
         pubsub_replacement = 'if value.pubsub_reconciliation_interval_ms != 0 { Some(value.pubsub_reconciliation_interval_ms) } else { None };'
@@ -109,7 +109,7 @@ def patch_rust_types_rs(rust_types_file):
             new_content = re.sub(pubsub_pattern, pubsub_replacement, new_content)
             needs_patching = True
             log_message("Applied pubsub_reconciliation_interval_ms patch")
-        
+
         # Fix jitter_percent: changed from Option<u32> to u32
         jitter_pattern = r'jitter_percent:\s*strategy\.jitter_percent,'
         jitter_replacement = 'jitter_percent: Some(strategy.jitter_percent),'
@@ -119,7 +119,7 @@ def patch_rust_types_rs(rust_types_file):
             new_content = re.sub(jitter_pattern, jitter_replacement, new_content)
             needs_patching = True
             log_message("Applied jitter_percent patch")
-        
+
         # Fix refresh_interval_seconds: changed from Option<u32> to u32
         refresh_pattern = r'refresh_interval_seconds,\s*\n\s*}'
         refresh_replacement = 'refresh_interval_seconds: Some(refresh_interval_seconds),\n                }'
@@ -129,7 +129,7 @@ def patch_rust_types_rs(rust_types_file):
             new_content = re.sub(refresh_pattern, refresh_replacement, new_content)
             needs_patching = True
             log_message("Applied refresh_interval_seconds patch")
-        
+
         # Fix compression_level: changed from Option<i32> to i32
         compression_pattern = r'compression_level:\s*proto_config\.compression_level,'
         compression_replacement = 'compression_level: Some(proto_config.compression_level),'
@@ -139,7 +139,7 @@ def patch_rust_types_rs(rust_types_file):
             new_content = re.sub(compression_pattern, compression_replacement, new_content)
             needs_patching = True
             log_message("Applied compression_level patch")
-        
+
         # Fix max_decompressed_size: changed from Option<u64> to u64
         max_decompressed_pattern = r'max_decompressed_size:\s*proto_config\s*\n\s*\.max_decompressed_size\s*\n\s*\.map\(\|size\| size as usize\)'
         max_decompressed_replacement = '''max_decompressed_size: if proto_config.max_decompressed_size != 0 {
@@ -153,17 +153,7 @@ def patch_rust_types_rs(rust_types_file):
             new_content = re.sub(max_decompressed_pattern, max_decompressed_replacement, new_content)
             needs_patching = True
             log_message("Applied max_decompressed_size patch")
-        
-        # Fix read_only: changed from Option<bool> to bool
-        read_only_pattern = r'let read_only = value\.read_only\.unwrap_or\(false\);'
-        read_only_replacement = 'let read_only = value.read_only;'
-        if re.search(read_only_pattern, new_content):
-            if not needs_patching:
-                create_backup(rust_types_file)
-            new_content = re.sub(read_only_pattern, read_only_replacement, new_content)
-            needs_patching = True
-            log_message("Applied read_only patch")
-        
+
         # Fix client_side_cache.eviction_policy: changed from Option<EnumOrUnknown> to EnumOrUnknown
         eviction_pattern = (
             r'eviction_policy:\s*proto_cache\s*'
@@ -182,7 +172,7 @@ def patch_rust_types_rs(rust_types_file):
             new_content = re.sub(eviction_pattern, eviction_replacement, new_content, flags=re.DOTALL)
             needs_patching = True
             log_message("Applied eviction_policy patch")
-        
+
         if needs_patching:
             with open(rust_types_file, 'w') as f:
                 f.write(new_content)
@@ -191,7 +181,7 @@ def patch_rust_types_rs(rust_types_file):
         else:
             log_message(f"File already patched: {rust_types_file}")
             return True
-    
+
     except Exception as e:
         log_message(f"Error patching {rust_types_file}: {e}", "ERROR")
         return False
@@ -201,7 +191,7 @@ def verify_rust_patch(rust_types_file):
     try:
         with open(rust_types_file, 'r') as f:
             content = f.read()
-        
+
         # Check for the fixed patterns
         tcp_nodelay_fixed = 'let tcp_nodelay = value.tcp_nodelay;' in content
         read_only_fixed = 'let read_only = value.read_only;' in content
@@ -210,15 +200,12 @@ def verify_rust_patch(rust_types_file):
         refresh_fixed = 'refresh_interval_seconds: Some(refresh_interval_seconds)' in content
         compression_fixed = 'Some(proto_config.compression_level)' in content
         max_decompressed_fixed = 'if proto_config.max_decompressed_size != 0' in content
-        
-        if tcp_nodelay_fixed and pubsub_fixed and jitter_fixed and refresh_fixed and compression_fixed and read_only_fixed and max_decompressed_fixed:
-        read_only_fixed = 'let read_only = value.read_only;' in content
         eviction_fixed = '.enum_value()' in content and '.and_then(|enum_or_unknown|' not in content
-        
+
         all_fixed = (tcp_nodelay_fixed and pubsub_fixed and jitter_fixed and
                      refresh_fixed and compression_fixed and read_only_fixed and
-                     eviction_fixed)
-        
+                     max_decompressed_fixed and eviction_fixed)
+
         if all_fixed:
             log_message("Rust patch verification: SUCCESS")
             return True
@@ -238,52 +225,75 @@ def verify_rust_patch(rust_types_file):
                 missing.append("compression_level fix")
             if not max_decompressed_fixed:
                 missing.append("max_decompressed_size fix")
-            if not read_only_fixed:
-                missing.append("read_only fix")
             if not eviction_fixed:
                 missing.append("eviction_policy fix")
             log_message(f"Rust patch verification: FAILED - Missing: {', '.join(missing)}", "ERROR")
             return False
-    
+
     except Exception as e:
         log_message(f"Error verifying patch: {e}", "ERROR")
         return False
 
 def patch_ffi_lib_rs(ffi_lib_file):
-    """Patch the FFI lib.rs file to fix type mismatches between protobuf and Rust code.
-    
-    Fixes several fields that changed from Option<T> to T in protobuf:
-    - tcp_nodelay: Some(enabled) -> enabled
-    - read_only: Some(enabled) -> enabled
-    - pubsub_reconciliation_interval_ms: Some(interval_ms) -> interval_ms
-    - jitter_percent: Some(...) -> ...
-    - compression_level: Some(level_val) -> level_val
-    - refresh_interval_seconds: Some(interval_val) -> interval_val
+    """Patch the FFI lib.rs file to fix type mismatches after removing 'optional' from protos.
+
+    The upstream lib.rs wraps assignments in Some() for fields that were optional in proto.
+    After stripping 'optional', those fields become plain T, so Some() must be removed.
+
+    Fixes:
+    - strategy.jitter_percent = Some(...) -> direct assignment
+    - request.tcp_nodelay = Some(enabled) -> request.tcp_nodelay = enabled
+    - request.read_only = Some(enabled) -> request.read_only = enabled
+    - request.pubsub_reconciliation_interval_ms = Some(...) -> direct assignment
+    - config.compression_level = Some(...) -> direct assignment
+    - iam_creds.refresh_interval_seconds = Some(...) -> direct assignment
     """
-    
+
     if not os.path.exists(ffi_lib_file):
         log_message(f"FFI lib.rs file not found: {ffi_lib_file}", "ERROR")
         return False
-    
+
     log_message(f"Patching FFI lib.rs file: {ffi_lib_file}")
-    
+
     try:
         with open(ffi_lib_file, 'r') as f:
             content = f.read()
-        
+
         needs_patching = False
         new_content = content
-        
-        # Fix tcp_nodelay: request.tcp_nodelay = Some(enabled) -> request.tcp_nodelay = enabled
-        tcp_nodelay_pattern = r'request\.tcp_nodelay = Some\(enabled\);'
-        tcp_nodelay_replacement = 'request.tcp_nodelay = enabled;'
-        if re.search(tcp_nodelay_pattern, content):
+
+        # Fix jitter_percent: Some(value as u32,) -> value as u32
+        jitter_pattern = (
+            r'strategy\.jitter_percent = Some\(\s*\n'
+            r'\s*jitter\s*\n'
+            r'\s*\.as_u64\(\)\s*\n'
+            r'\s*\.ok_or_else\(\|\| "jitter_percent must be a positive integer"\.to_string\(\)\)\?\s*\n'
+            r'\s*as u32,\s*\n'
+            r'\s*\);'
+        )
+        jitter_replacement = (
+            'strategy.jitter_percent = jitter\n'
+            '                    .as_u64()\n'
+            '                    .ok_or_else(|| "jitter_percent must be a positive integer".to_string())?\n'
+            '                    as u32;'
+        )
+        if re.search(jitter_pattern, content):
             create_backup(ffi_lib_file)
-            new_content = re.sub(tcp_nodelay_pattern, tcp_nodelay_replacement, new_content)
+            new_content = re.sub(jitter_pattern, jitter_replacement, new_content)
+            needs_patching = True
+            log_message("Applied FFI jitter_percent patch")
+
+        # Fix tcp_nodelay: Some(enabled) -> enabled
+        tcp_pattern = r'request\.tcp_nodelay = Some\(enabled\);'
+        tcp_replacement = 'request.tcp_nodelay = enabled;'
+        if re.search(tcp_pattern, new_content):
+            if not needs_patching:
+                create_backup(ffi_lib_file)
+            new_content = re.sub(tcp_pattern, tcp_replacement, new_content)
             needs_patching = True
             log_message("Applied FFI tcp_nodelay patch")
-        
-        # Fix read_only: request.read_only = Some(enabled) -> request.read_only = enabled
+
+        # Fix read_only: Some(enabled) -> enabled
         read_only_pattern = r'request\.read_only = Some\(enabled\);'
         read_only_replacement = 'request.read_only = enabled;'
         if re.search(read_only_pattern, new_content):
@@ -292,7 +302,7 @@ def patch_ffi_lib_rs(ffi_lib_file):
             new_content = re.sub(read_only_pattern, read_only_replacement, new_content)
             needs_patching = True
             log_message("Applied FFI read_only patch")
-        
+
         # Fix pubsub_reconciliation_interval_ms: Some(interval_ms) -> interval_ms
         pubsub_pattern = r'request\.pubsub_reconciliation_interval_ms = Some\(interval_ms\);'
         pubsub_replacement = 'request.pubsub_reconciliation_interval_ms = interval_ms;'
@@ -302,21 +312,8 @@ def patch_ffi_lib_rs(ffi_lib_file):
             new_content = re.sub(pubsub_pattern, pubsub_replacement, new_content)
             needs_patching = True
             log_message("Applied FFI pubsub_reconciliation_interval_ms patch")
-        
-        # Fix jitter_percent: strategy.jitter_percent = Some(...) -> strategy.jitter_percent = ...
-        jitter_pattern = r'strategy\.jitter_percent = Some\(\s*\n\s*jitter\s*\n\s*\.as_u64\(\)\s*\n\s*\.ok_or_else\(\|\| "jitter_percent must be a positive integer"\.to_string\(\)\)\?\s*\n\s*as u32,\s*\n\s*\);'
-        jitter_replacement = '''strategy.jitter_percent = jitter
-                    .as_u64()
-                    .ok_or_else(|| "jitter_percent must be a positive integer".to_string())?
-                    as u32;'''
-        if re.search(jitter_pattern, new_content):
-            if not needs_patching:
-                create_backup(ffi_lib_file)
-            new_content = re.sub(jitter_pattern, jitter_replacement, new_content)
-            needs_patching = True
-            log_message("Applied FFI jitter_percent patch")
-        
-        # Fix compression_level: config.compression_level = Some(level_val) -> config.compression_level = level_val
+
+        # Fix compression_level: Some(level_val) -> level_val
         compression_pattern = r'config\.compression_level = Some\(level_val\);'
         compression_replacement = 'config.compression_level = level_val;'
         if re.search(compression_pattern, new_content):
@@ -325,8 +322,8 @@ def patch_ffi_lib_rs(ffi_lib_file):
             new_content = re.sub(compression_pattern, compression_replacement, new_content)
             needs_patching = True
             log_message("Applied FFI compression_level patch")
-        
-        # Fix refresh_interval_seconds: iam_creds.refresh_interval_seconds = Some(interval_val) -> iam_creds.refresh_interval_seconds = interval_val
+
+        # Fix refresh_interval_seconds: Some(interval_val) -> interval_val
         refresh_pattern = r'iam_creds\.refresh_interval_seconds = Some\(interval_val\);'
         refresh_replacement = 'iam_creds.refresh_interval_seconds = interval_val;'
         if re.search(refresh_pattern, new_content):
@@ -335,39 +332,67 @@ def patch_ffi_lib_rs(ffi_lib_file):
             new_content = re.sub(refresh_pattern, refresh_replacement, new_content)
             needs_patching = True
             log_message("Applied FFI refresh_interval_seconds patch")
-        
+
         if needs_patching:
             with open(ffi_lib_file, 'w') as f:
                 f.write(new_content)
-            log_message(f"Successfully patched FFI lib.rs file: {ffi_lib_file}")
+            log_message(f"Successfully patched FFI lib.rs: {ffi_lib_file}")
             return True
         else:
-            log_message(f"FFI lib.rs file already patched or no changes needed: {ffi_lib_file}")
+            log_message(f"FFI lib.rs already patched: {ffi_lib_file}")
             return True
-    
+
     except Exception as e:
         log_message(f"Error patching {ffi_lib_file}: {e}", "ERROR")
         return False
 
+def verify_ffi_patch(ffi_lib_file):
+    """Verify that the FFI lib.rs patch was applied correctly"""
+    try:
+        with open(ffi_lib_file, 'r') as f:
+            content = f.read()
+
+        checks = {
+            "jitter_percent": 'strategy.jitter_percent = Some(' not in content,
+            "tcp_nodelay": 'request.tcp_nodelay = Some(enabled)' not in content,
+            "read_only": 'request.read_only = Some(enabled)' not in content,
+            "pubsub_reconciliation_interval_ms": 'request.pubsub_reconciliation_interval_ms = Some(interval_ms)' not in content,
+            "compression_level": 'config.compression_level = Some(level_val)' not in content,
+            "refresh_interval_seconds": 'iam_creds.refresh_interval_seconds = Some(interval_val)' not in content,
+        }
+
+        missing = [name for name, fixed in checks.items() if not fixed]
+
+        if not missing:
+            log_message("FFI lib.rs patch verification: SUCCESS")
+            return True
+        else:
+            log_message(f"FFI lib.rs patch verification: FAILED - Still has Some() for: {', '.join(missing)}", "ERROR")
+            return False
+
+    except Exception as e:
+        log_message(f"Error verifying FFI patch: {e}", "ERROR")
+        return False
+
 def main():
     """Main function to run all patching operations.
-    
+
     This script patches protobuf files and Rust code to fix type mismatches
     that occur when protobuf 'optional' fields are removed, causing them to
     change from Option<T> to T in the generated Rust code.
     """
     log_message("Starting build-time patching process for protobuf and Rust files")
-    
+
     # Base directory (relative to script location)
     base_dir = Path(__file__).parent.parent
-    
+
     # Define paths
     protobuf_directory = base_dir / "valkey-glide" / "glide-core" / "src" / "protobuf"
     rust_types_file = base_dir / "valkey-glide" / "glide-core" / "src" / "client" / "types.rs"
     ffi_lib_file = base_dir / "valkey-glide" / "ffi" / "src" / "lib.rs"
-    
+
     success = True
-    
+
     # Step 1: Remove optional from protobuf files
     log_message("=== Phase 1: Patching Protobuf Files ===")
     if protobuf_directory.exists():
@@ -376,9 +401,9 @@ def main():
     else:
         log_message(f"Protobuf directory not found: {protobuf_directory}", "ERROR")
         success = False
-    
+
     # Step 2: Patch Rust types.rs
-    log_message("=== Phase 2: Patching Rust types.rs ===")
+    log_message("=== Phase 2: Patching Rust Code (types.rs) ===")
     if rust_types_file.exists():
         if not patch_rust_types_rs(str(rust_types_file)):
             success = False
@@ -389,16 +414,18 @@ def main():
     else:
         log_message(f"Rust types file not found: {rust_types_file}", "ERROR")
         success = False
-    
+
     # Step 3: Patch FFI lib.rs
-    log_message("=== Phase 3: Patching FFI lib.rs ===")
+    log_message("=== Phase 3: Patching FFI Code (lib.rs) ===")
     if ffi_lib_file.exists():
         if not patch_ffi_lib_rs(str(ffi_lib_file)):
             success = False
+        else:
+            if not verify_ffi_patch(str(ffi_lib_file)):
+                success = False
     else:
-        log_message(f"FFI lib.rs file not found: {ffi_lib_file}", "ERROR")
-        success = False
-    
+        log_message(f"FFI lib.rs file not found: {ffi_lib_file}", "WARN")
+
     # Summary
     if success:
         log_message("=== Build-time patching for protobuf and Rust files completed successfully ===")

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -2576,6 +2576,7 @@
 # Stack: tokio::runtime::builder::Builder::build -> std::thread::Thread::new
 {
    tokio_runtime_thread_init
+   rust_thread_current_init_arc
    Memcheck:Leak
    match-leak-kinds: possible
    fun:malloc

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -2576,7 +2576,6 @@
 # Stack: tokio::runtime::builder::Builder::build -> std::thread::Thread::new
 {
    tokio_runtime_thread_init
-   rust_thread_current_init_arc
    Memcheck:Leak
    match-leak-kinds: possible
    fun:malloc

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -541,13 +541,28 @@ int valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_pa
 
         /* Parse entry_ttl_ms (required, 0 = no expiration) */
         zval* ttl_zv = zend_hash_str_find(cache_ht, "entry_ttl_ms", sizeof("entry_ttl_ms") - 1);
-        config->client_side_cache->entry_ttl_ms = ttl_zv ? zval_get_long(ttl_zv) : 0;
+        if (ttl_zv) {
+            config->client_side_cache->entry_ttl_ms = zval_get_long(ttl_zv);
+        } else {
+            efree(config->client_side_cache);
+            config->client_side_cache = NULL;
+            valkey_glide_cleanup_client_config(config);
+            zend_throw_exception(
+                get_valkey_glide_exception_ce(), "client_side_cache requires entry_ttl_ms", 0);
+            return FAILURE;
+        }
 
-        /* Parse eviction_policy (optional, -1 = not set / use default LRU) */
+        /* Parse eviction_policy (optional, default LRU) */
         zval* eviction_zv =
             zend_hash_str_find(cache_ht, "eviction_policy", sizeof("eviction_policy") - 1);
-        config->client_side_cache->eviction_policy =
-            eviction_zv ? (int) zval_get_long(eviction_zv) : -1;
+        if (eviction_zv) {
+            config->client_side_cache->eviction_policy =
+                (valkey_glide_eviction_policy_t) zval_get_long(eviction_zv);
+            config->client_side_cache->has_eviction_policy = true;
+        } else {
+            config->client_side_cache->eviction_policy     = VALKEY_GLIDE_EVICTION_POLICY_LRU;
+            config->client_side_cache->has_eviction_policy = false;
+        }
 
         /* Parse enable_metrics (optional, default false) */
         zval* metrics_zv =
@@ -1144,6 +1159,10 @@ GET_CACHE_EVICTIONS_METHOD_IMPL(ValkeyGlide)
 
 /* {{{ proto int ValkeyGlide::getCacheExpirations() */
 GET_CACHE_EXPIRATIONS_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto int ValkeyGlide::getCacheTotalLookups() */
+GET_CACHE_TOTAL_LOOKUPS_METHOD_IMPL(ValkeyGlide)
 /* }}} */
 
 /* Basic method stubs - these need to be implemented with ValkeyGlide */

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -556,11 +556,10 @@ int valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_pa
         zval* eviction_zv =
             zend_hash_str_find(cache_ht, "eviction_policy", sizeof("eviction_policy") - 1);
         if (eviction_zv) {
-            config->client_side_cache->eviction_policy =
-                (valkey_glide_eviction_policy_t) zval_get_long(eviction_zv);
+            config->client_side_cache->eviction_policy     = (int) zval_get_long(eviction_zv);
             config->client_side_cache->has_eviction_policy = true;
         } else {
-            config->client_side_cache->eviction_policy     = VALKEY_GLIDE_EVICTION_POLICY_LRU;
+            config->client_side_cache->eviction_policy = CONNECTION_REQUEST__EVICTION_POLICY__LRU;
             config->client_side_cache->has_eviction_policy = false;
         }
 

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -539,10 +539,10 @@ int valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_pa
             return FAILURE;
         }
 
-        /* Parse entry_ttl_ms (optional, -1 = not set) */
+        /* Parse entry_ttl_ms (required, 0 = no expiration) */
         zval* ttl_zv =
             zend_hash_str_find(cache_ht, "entry_ttl_ms", sizeof("entry_ttl_ms") - 1);
-        config->client_side_cache->entry_ttl_ms = ttl_zv ? zval_get_long(ttl_zv) : -1;
+        config->client_side_cache->entry_ttl_ms = ttl_zv ? zval_get_long(ttl_zv) : 0;
 
         /* Parse eviction_policy (optional, -1 = not set / use default LRU) */
         zval* eviction_zv =

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -539,10 +539,10 @@ int valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_pa
             return FAILURE;
         }
 
-        /* Parse entry_ttl_seconds (optional, -1 = not set) */
+        /* Parse entry_ttl_ms (optional, -1 = not set) */
         zval* ttl_zv =
-            zend_hash_str_find(cache_ht, "entry_ttl_seconds", sizeof("entry_ttl_seconds") - 1);
-        config->client_side_cache->entry_ttl_seconds = ttl_zv ? zval_get_long(ttl_zv) : -1;
+            zend_hash_str_find(cache_ht, "entry_ttl_ms", sizeof("entry_ttl_ms") - 1);
+        config->client_side_cache->entry_ttl_ms = ttl_zv ? zval_get_long(ttl_zv) : -1;
 
         /* Parse eviction_policy (optional, -1 = not set / use default LRU) */
         zval* eviction_zv =

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -509,12 +509,10 @@ int valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_pa
     if (params->client_side_cache && Z_TYPE_P(params->client_side_cache) == IS_ARRAY) {
         HashTable* cache_ht = Z_ARRVAL_P(params->client_side_cache);
 
-        config->client_side_cache =
-            ecalloc(1, sizeof(valkey_glide_client_side_cache_config_t));
+        config->client_side_cache = ecalloc(1, sizeof(valkey_glide_client_side_cache_config_t));
 
         /* Parse cache_id (required) */
-        zval* cache_id_zv =
-            zend_hash_str_find(cache_ht, "cache_id", sizeof("cache_id") - 1);
+        zval* cache_id_zv = zend_hash_str_find(cache_ht, "cache_id", sizeof("cache_id") - 1);
         if (cache_id_zv && Z_TYPE_P(cache_id_zv) == IS_STRING) {
             config->client_side_cache->cache_id     = Z_STRVAL_P(cache_id_zv);
             config->client_side_cache->cache_id_len = Z_STRLEN_P(cache_id_zv);
@@ -549,7 +547,8 @@ int valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_pa
         /* Parse eviction_policy (optional, -1 = not set / use default LRU) */
         zval* eviction_zv =
             zend_hash_str_find(cache_ht, "eviction_policy", sizeof("eviction_policy") - 1);
-        config->client_side_cache->eviction_policy = eviction_zv ? (int) zval_get_long(eviction_zv) : -1;
+        config->client_side_cache->eviction_policy =
+            eviction_zv ? (int) zval_get_long(eviction_zv) : -1;
 
         /* Parse enable_metrics (optional, default false) */
         zval* metrics_zv =
@@ -842,8 +841,8 @@ static int valkey_glide_create_connection(valkey_glide_object* valkey_glide,
         common_params.lazy_connect_is_null = false;
     }
 
-    common_params.context     = context;
-    common_params.compression = compression;
+    common_params.context           = context;
+    common_params.compression       = compression;
     common_params.client_side_cache = client_side_cache;
 
     /* Default to localhost:6379 if no addresses provided */

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -540,8 +540,7 @@ int valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_pa
         }
 
         /* Parse entry_ttl_ms (required, 0 = no expiration) */
-        zval* ttl_zv =
-            zend_hash_str_find(cache_ht, "entry_ttl_ms", sizeof("entry_ttl_ms") - 1);
+        zval* ttl_zv = zend_hash_str_find(cache_ht, "entry_ttl_ms", sizeof("entry_ttl_ms") - 1);
         config->client_side_cache->entry_ttl_ms = ttl_zv ? zval_get_long(ttl_zv) : 0;
 
         /* Parse eviction_policy (optional, -1 = not set / use default LRU) */

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -31,6 +31,10 @@ extern struct CommandResult* command(const void*          client_adapter_ptr,
 
 extern void free_command_result(struct CommandResult* command_result_ptr);
 
+extern struct CommandResult* get_cache_metrics(const void* client_adapter_ptr,
+                                               uintptr_t   request_id,
+                                               int32_t     metrics_type);
+
 #include "valkey_glide_otel.h"  // Include OTEL support
 
 /* Enum support includes - must be BEFORE arginfo includes */
@@ -177,6 +181,7 @@ void valkey_glide_init_common_constructor_params(
     params->database_id_is_null     = 1;
     params->context                 = NULL;
     params->compression             = NULL;
+    params->client_side_cache       = NULL;
 }
 
 int valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_params_t* params,
@@ -500,6 +505,60 @@ int valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_pa
         config->compression_config = NULL;
     }
 
+    /* Process client-side cache configuration if provided */
+    if (params->client_side_cache && Z_TYPE_P(params->client_side_cache) == IS_ARRAY) {
+        HashTable* cache_ht = Z_ARRVAL_P(params->client_side_cache);
+
+        config->client_side_cache =
+            ecalloc(1, sizeof(valkey_glide_client_side_cache_config_t));
+
+        /* Parse cache_id (required) */
+        zval* cache_id_zv =
+            zend_hash_str_find(cache_ht, "cache_id", sizeof("cache_id") - 1);
+        if (cache_id_zv && Z_TYPE_P(cache_id_zv) == IS_STRING) {
+            config->client_side_cache->cache_id     = Z_STRVAL_P(cache_id_zv);
+            config->client_side_cache->cache_id_len = Z_STRLEN_P(cache_id_zv);
+        } else {
+            efree(config->client_side_cache);
+            config->client_side_cache = NULL;
+            valkey_glide_cleanup_client_config(config);
+            zend_throw_exception(
+                get_valkey_glide_exception_ce(), "client_side_cache requires a cache_id", 0);
+            return FAILURE;
+        }
+
+        /* Parse max_cache_kb (required) */
+        zval* max_cache_kb_zv =
+            zend_hash_str_find(cache_ht, "max_cache_kb", sizeof("max_cache_kb") - 1);
+        if (max_cache_kb_zv) {
+            config->client_side_cache->max_cache_kb = zval_get_long(max_cache_kb_zv);
+        } else {
+            efree(config->client_side_cache);
+            config->client_side_cache = NULL;
+            valkey_glide_cleanup_client_config(config);
+            zend_throw_exception(
+                get_valkey_glide_exception_ce(), "client_side_cache requires max_cache_kb", 0);
+            return FAILURE;
+        }
+
+        /* Parse entry_ttl_seconds (optional, -1 = not set) */
+        zval* ttl_zv =
+            zend_hash_str_find(cache_ht, "entry_ttl_seconds", sizeof("entry_ttl_seconds") - 1);
+        config->client_side_cache->entry_ttl_seconds = ttl_zv ? zval_get_long(ttl_zv) : -1;
+
+        /* Parse eviction_policy (optional, -1 = not set / use default LRU) */
+        zval* eviction_zv =
+            zend_hash_str_find(cache_ht, "eviction_policy", sizeof("eviction_policy") - 1);
+        config->client_side_cache->eviction_policy = eviction_zv ? (int) zval_get_long(eviction_zv) : -1;
+
+        /* Parse enable_metrics (optional, default false) */
+        zval* metrics_zv =
+            zend_hash_str_find(cache_ht, "enable_metrics", sizeof("enable_metrics") - 1);
+        config->client_side_cache->enable_metrics = metrics_zv ? zval_is_true(metrics_zv) : false;
+    } else {
+        config->client_side_cache = NULL;
+    }
+
     _initialize_open_telemetry(params, is_cluster);
     return SUCCESS;
 }
@@ -628,6 +687,11 @@ void valkey_glide_cleanup_client_config(valkey_glide_base_client_configuration_t
         efree(config->compression_config);
         config->compression_config = NULL;
     }
+
+    if (config->client_side_cache) {
+        efree(config->client_side_cache);
+        config->client_side_cache = NULL;
+    }
 }
 
 /**
@@ -734,7 +798,8 @@ static int valkey_glide_create_connection(valkey_glide_object* valkey_glide,
                                           zval*                advanced_config,
                                           zval*                lazy_connect_zval,
                                           zval*                context,
-                                          zval*                compression) {
+                                          zval*                compression,
+                                          zval*                client_side_cache) {
     valkey_glide_php_common_constructor_params_t common_params;
     valkey_glide_init_common_constructor_params(&common_params);
 
@@ -779,6 +844,7 @@ static int valkey_glide_create_connection(valkey_glide_object* valkey_glide,
 
     common_params.context     = context;
     common_params.compression = compression;
+    common_params.client_side_cache = client_side_cache;
 
     /* Default to localhost:6379 if no addresses provided */
     zval      addresses_array;
@@ -865,7 +931,7 @@ static int valkey_glide_create_connection(valkey_glide_object* valkey_glide,
    ?array $addresses, ?bool $use_tls, ?array $credentials, ?int $read_from,
    ?int $request_timeout, ?array $reconnect_strategy, ?int $database_id,
    ?string $client_name, ?string $client_az, ?array $advanced_config,
-   ?bool $lazy_connect, ?resource $context)
+   ?bool $lazy_connect, ?resource $context, ?array $client_side_cache)
    Establishes connection to Valkey server. Supports both PHPRedis-compatible
    (host/port) and ValkeyGlide-style (addresses array) parameters.
    Returns true on success, false on failure. */
@@ -893,8 +959,9 @@ PHP_METHOD(ValkeyGlide, connect) {
     zval*  lazy_connect_zval    = NULL;
     zval*  context              = NULL;
     zval*  compression          = NULL;
+    zval*  client_side_cache    = NULL;
 
-    ZEND_PARSE_PARAMETERS_START(0, 19)
+    ZEND_PARSE_PARAMETERS_START(0, 20)
     Z_PARAM_OPTIONAL
     Z_PARAM_STRING_OR_NULL(host, host_len)
     Z_PARAM_ZVAL_OR_NULL(port_zval)
@@ -915,6 +982,7 @@ PHP_METHOD(ValkeyGlide, connect) {
     Z_PARAM_ZVAL_OR_NULL(lazy_connect_zval)
     Z_PARAM_ZVAL_OR_NULL(context)
     Z_PARAM_ARRAY_OR_NULL(compression)
+    Z_PARAM_ARRAY_OR_NULL(client_side_cache)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_THROWS());
 
     /* Apply defaults for nullable parameters */
@@ -986,7 +1054,8 @@ PHP_METHOD(ValkeyGlide, connect) {
                                                 advanced_config,
                                                 lazy_connect_zval,
                                                 context,
-                                                compression);
+                                                compression,
+                                                client_side_cache);
 
     /* Clean up temporary addresses array if we created it */
     if (host != NULL) {
@@ -1057,6 +1126,26 @@ CLEAR_CONNECTION_PASSWORD_METHOD_IMPL(ValkeyGlide)
 /* {{{ proto string ValkeyGlide::refreshIamToken()
  */
 REFRESH_IAM_TOKEN_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto float ValkeyGlide::getCacheHitRate() */
+GET_CACHE_HIT_RATE_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto float ValkeyGlide::getCacheMissRate() */
+GET_CACHE_MISS_RATE_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto int ValkeyGlide::getCacheEntryCount() */
+GET_CACHE_ENTRY_COUNT_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto int ValkeyGlide::getCacheEvictions() */
+GET_CACHE_EVICTIONS_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto int ValkeyGlide::getCacheExpirations() */
+GET_CACHE_EXPIRATIONS_METHOD_IMPL(ValkeyGlide)
 /* }}} */
 
 /* Basic method stubs - these need to be implemented with ValkeyGlide */

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -376,7 +376,7 @@ class ValkeyGlide
      * @param resource|array|null $context Stream context resource or array for TLS configuration
      * @param array|null $compression Compression configuration: ['enabled' => true, 'backend' => COMPRESSION_BACKEND_ZSTD, 'compression_level' => 3, 'min_compression_size' => 64]
      * @param array|null $client_side_cache Client-side cache configuration array from ClientSideCache::toArray():
-     *                                      ['cache_id' => string, 'max_cache_kb' => int, 'entry_ttl_seconds' => ?int,
+     *                                      ['cache_id' => string, 'max_cache_kb' => int, 'entry_ttl_ms' => ?int,
      *                                       'eviction_policy' => ?int, 'enable_metrics' => bool]
      * @return bool True on successful connection, false on failure
      *

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -375,6 +375,9 @@ class ValkeyGlide
      * @param bool|null $lazy_connect Defer connection until first command (default: false)
      * @param resource|array|null $context Stream context resource or array for TLS configuration
      * @param array|null $compression Compression configuration: ['enabled' => true, 'backend' => COMPRESSION_BACKEND_ZSTD, 'compression_level' => 3, 'min_compression_size' => 64]
+     * @param array|null $client_side_cache Client-side cache configuration array from ClientSideCache::toArray():
+     *                                      ['cache_id' => string, 'max_cache_kb' => int, 'entry_ttl_seconds' => ?int,
+     *                                       'eviction_policy' => ?int, 'enable_metrics' => bool]
      * @return bool True on successful connection, false on failure
      *
      * @throws ValkeyGlideException If conflicting parameters are specified or connection fails
@@ -407,6 +410,7 @@ class ValkeyGlide
         ?bool $lazy_connect = null,
         resource|array|null $context = null,
         ?array $compression = null,
+        ?array $client_side_cache = null,
     ): bool;
 
     public function __destruct();
@@ -639,6 +643,46 @@ class ValkeyGlide
      * echo "Space saved: " . ($stats['total_original_bytes'] - $stats['total_bytes_compressed']) . " bytes\n";
      */
     public function getStatistics(): array;
+
+    /**
+     * Get the cache hit rate (hits / total requests).
+     *
+     * @return float The cache hit rate as a float between 0.0 and 1.0.
+     * @throws ValkeyGlideException If client-side caching is not enabled or metrics tracking is disabled.
+     */
+    public function getCacheHitRate(): float;
+
+    /**
+     * Get the cache miss rate (misses / total requests).
+     *
+     * @return float The cache miss rate as a float between 0.0 and 1.0.
+     * @throws ValkeyGlideException If client-side caching is not enabled or metrics tracking is disabled.
+     */
+    public function getCacheMissRate(): float;
+
+    /**
+     * Get the current number of entries in the client-side cache.
+     *
+     * @return int The number of entries in the cache.
+     * @throws ValkeyGlideException If client-side caching is not enabled.
+     */
+    public function getCacheEntryCount(): int;
+
+    /**
+     * Get the total number of entries evicted from the client-side cache due to memory constraints.
+     *
+     * @return int The number of evictions.
+     * @throws ValkeyGlideException If client-side caching is not enabled or metrics tracking is disabled.
+     */
+    public function getCacheEvictions(): int;
+
+    /**
+     * Get the total number of entries removed from the client-side cache due to TTL expiration.
+     *
+     * @return int The number of expirations.
+     * @throws ValkeyGlideException If client-side caching is not enabled or metrics tracking is disabled.
+     */
+    public function getCacheExpirations(): int;
 
     /**
      * Set the OpenTelemetry sample percentage at runtime.

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -376,7 +376,7 @@ class ValkeyGlide
      * @param resource|array|null $context Stream context resource or array for TLS configuration
      * @param array|null $compression Compression configuration: ['enabled' => true, 'backend' => COMPRESSION_BACKEND_ZSTD, 'compression_level' => 3, 'min_compression_size' => 64]
      * @param array|null $client_side_cache Client-side cache configuration array from ClientSideCache::toArray():
-     *                                      ['cache_id' => string, 'max_cache_kb' => int, 'entry_ttl_ms' => ?int,
+     *                                      ['cache_id' => string, 'max_cache_kb' => int, 'entry_ttl_ms' => int,
      *                                       'eviction_policy' => ?int, 'enable_metrics' => bool]
      * @return bool True on successful connection, false on failure
      *

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -685,6 +685,14 @@ class ValkeyGlide
     public function getCacheExpirations(): int;
 
     /**
+     * Get the total number of cache lookups (hits + misses).
+     *
+     * @return int The total number of lookups.
+     * @throws ValkeyGlideException If client-side caching is not enabled or metrics tracking is disabled.
+     */
+    public function getCacheTotalLookups(): int;
+
+    /**
      * Set the OpenTelemetry sample percentage at runtime.
      *
      * @param int $percentage The sample percentage (0-100)

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -1126,6 +1126,10 @@ GET_CACHE_EVICTIONS_METHOD_IMPL(ValkeyGlideCluster)
 GET_CACHE_EXPIRATIONS_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
+/* {{{ proto int ValkeyGlideCluster::getCacheTotalLookups() */
+GET_CACHE_TOTAL_LOOKUPS_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
 COPY_METHOD_IMPL(ValkeyGlideCluster)
 
 /* Script commands */

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -179,12 +179,13 @@ PHP_METHOD(ValkeyGlideCluster, __construct) {
     zend_long database_id             = 0;
     zend_bool database_id_is_null     = 1;
     zval*     compression             = NULL;
+    zval*     client_side_cache       = NULL;
 
     valkey_glide_php_common_constructor_params_t common_params;
     valkey_glide_init_common_constructor_params(&common_params);
     valkey_glide_object* valkey_glide;
 
-    ZEND_PARSE_PARAMETERS_START(0, 20)
+    ZEND_PARSE_PARAMETERS_START(0, 21)
     Z_PARAM_OPTIONAL
     Z_PARAM_STRING_OR_NULL(name, name_len)
     Z_PARAM_ARRAY_OR_NULL(seeds)
@@ -206,6 +207,7 @@ PHP_METHOD(ValkeyGlideCluster, __construct) {
     Z_PARAM_BOOL_OR_NULL(lazy_connect, lazy_connect_is_null)
     Z_PARAM_LONG_OR_NULL(database_id, database_id_is_null)
     Z_PARAM_ARRAY_OR_NULL(compression)
+    Z_PARAM_ARRAY_OR_NULL(client_side_cache)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_THROWS());
 
     valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, getThis());
@@ -264,6 +266,7 @@ PHP_METHOD(ValkeyGlideCluster, __construct) {
     common_params.database_id             = database_id;
     common_params.database_id_is_null     = database_id_is_null;
     common_params.compression             = compression;
+    common_params.client_side_cache       = client_side_cache;
 
     /* Call helper function to create cluster connection */
     valkey_glide_cluster_create_connection(
@@ -1103,6 +1106,25 @@ CLEAR_CONNECTION_PASSWORD_METHOD_IMPL(ValkeyGlideCluster)
 REFRESH_IAM_TOKEN_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
+/* {{{ proto float ValkeyGlideCluster::getCacheHitRate() */
+GET_CACHE_HIT_RATE_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto float ValkeyGlideCluster::getCacheMissRate() */
+GET_CACHE_MISS_RATE_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto int ValkeyGlideCluster::getCacheEntryCount() */
+GET_CACHE_ENTRY_COUNT_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto int ValkeyGlideCluster::getCacheEvictions() */
+GET_CACHE_EVICTIONS_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto int ValkeyGlideCluster::getCacheExpirations() */
+GET_CACHE_EXPIRATIONS_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
 
 COPY_METHOD_IMPL(ValkeyGlideCluster)
 

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -249,6 +249,9 @@ class ValkeyGlideCluster
      *                                          For cluster mode, requires Valkey 9.0+ with cluster-databases > 1.
      *                                          If not specified, defaults to database 0.
      * @param array|null $compression           Compression configuration: ['enabled' => true, 'backend' => COMPRESSION_BACKEND_ZSTD, 'compression_level' => 3, 'min_compression_size' => 64]
+     * @param array|null $client_side_cache     Client-side cache configuration array from ClientSideCache::toArray():
+     *                                          ['cache_id' => string, 'max_cache_kb' => int, 'entry_ttl_seconds' => ?int,
+     *                                          'eviction_policy' => ?int, 'enable_metrics' => bool]
      *
      * Note: Cannot mix PHPRedis-style and ValkeyGlide-style parameters.
      */
@@ -273,6 +276,7 @@ class ValkeyGlideCluster
         ?bool $lazy_connect = null,
         ?int $database_id = null,
         ?array $compression = null,
+        ?array $client_side_cache = null,
     ) {
     }
 
@@ -391,6 +395,31 @@ class ValkeyGlideCluster
      * @see ValkeyGlide::getStatistics
      */
     public function getStatistics(): array;
+
+    /**
+     * @see ValkeyGlide::getCacheHitRate
+     */
+    public function getCacheHitRate(): float;
+
+    /**
+     * @see ValkeyGlide::getCacheMissRate
+     */
+    public function getCacheMissRate(): float;
+
+    /**
+     * @see ValkeyGlide::getCacheEntryCount
+     */
+    public function getCacheEntryCount(): int;
+
+    /**
+     * @see ValkeyGlide::getCacheEvictions
+     */
+    public function getCacheEvictions(): int;
+
+    /**
+     * @see ValkeyGlide::getCacheExpirations
+     */
+    public function getCacheExpirations(): int;
 
     /**
      * @see ValkeyGlide::updateConnectionPassword

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -250,7 +250,7 @@ class ValkeyGlideCluster
      *                                          If not specified, defaults to database 0.
      * @param array|null $compression           Compression configuration: ['enabled' => true, 'backend' => COMPRESSION_BACKEND_ZSTD, 'compression_level' => 3, 'min_compression_size' => 64]
      * @param array|null $client_side_cache     Client-side cache configuration array from ClientSideCache::toArray():
-     *                                          ['cache_id' => string, 'max_cache_kb' => int, 'entry_ttl_seconds' => ?int,
+     *                                          ['cache_id' => string, 'max_cache_kb' => int, 'entry_ttl_ms' => ?int,
      *                                          'eviction_policy' => ?int, 'enable_metrics' => bool]
      *
      * Note: Cannot mix PHPRedis-style and ValkeyGlide-style parameters.

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -422,6 +422,11 @@ class ValkeyGlideCluster
     public function getCacheExpirations(): int;
 
     /**
+     * @see ValkeyGlide::getCacheTotalLookups
+     */
+    public function getCacheTotalLookups(): int;
+
+    /**
      * @see ValkeyGlide::updateConnectionPassword
      */
     public function updateConnectionPassword(string $password, bool $immediateAuth = false): string;

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -250,7 +250,7 @@ class ValkeyGlideCluster
      *                                          If not specified, defaults to database 0.
      * @param array|null $compression           Compression configuration: ['enabled' => true, 'backend' => COMPRESSION_BACKEND_ZSTD, 'compression_level' => 3, 'min_compression_size' => 64]
      * @param array|null $client_side_cache     Client-side cache configuration array from ClientSideCache::toArray():
-     *                                          ['cache_id' => string, 'max_cache_kb' => int, 'entry_ttl_ms' => ?int,
+     *                                          ['cache_id' => string, 'max_cache_kb' => int, 'entry_ttl_ms' => int,
      *                                          'eviction_policy' => ?int, 'enable_metrics' => bool]
      *
      * Note: Cannot mix PHPRedis-style and ValkeyGlide-style parameters.

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -233,8 +233,8 @@ uint8_t* create_connection_request(size_t*                                   len
         client_side_cache_msg.max_cache_kb   = config->client_side_cache->max_cache_kb;
         client_side_cache_msg.enable_metrics = config->client_side_cache->enable_metrics;
 
-        if (config->client_side_cache->entry_ttl_seconds >= 0) {
-            client_side_cache_msg.entry_ttl_seconds = config->client_side_cache->entry_ttl_seconds;
+        if (config->client_side_cache->entry_ttl_ms >= 0) {
+            client_side_cache_msg.entry_ttl_ms = config->client_side_cache->entry_ttl_ms;
         }
 
         if (config->client_side_cache->eviction_policy >= 0) {

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -229,13 +229,12 @@ uint8_t* create_connection_request(size_t*                                   len
     ConnectionRequest__ClientSideCache client_side_cache_msg =
         CONNECTION_REQUEST__CLIENT_SIDE_CACHE__INIT;
     if (config->client_side_cache) {
-        client_side_cache_msg.cache_id     = config->client_side_cache->cache_id;
-        client_side_cache_msg.max_cache_kb = config->client_side_cache->max_cache_kb;
+        client_side_cache_msg.cache_id       = config->client_side_cache->cache_id;
+        client_side_cache_msg.max_cache_kb   = config->client_side_cache->max_cache_kb;
         client_side_cache_msg.enable_metrics = config->client_side_cache->enable_metrics;
 
         if (config->client_side_cache->entry_ttl_seconds >= 0) {
-            client_side_cache_msg.entry_ttl_seconds =
-                config->client_side_cache->entry_ttl_seconds;
+            client_side_cache_msg.entry_ttl_seconds = config->client_side_cache->entry_ttl_seconds;
         }
 
         if (config->client_side_cache->eviction_policy >= 0) {
@@ -2394,16 +2393,14 @@ void execute_get_cache_metrics(zval*             object,
     }
 
     /* Call FFI function */
-    CommandResult* result =
-        get_cache_metrics(valkey_glide->glide_client,
-                          0, /* request_id - using 0 for synchronous call */
-                          metrics_type);
+    CommandResult* result = get_cache_metrics(valkey_glide->glide_client,
+                                              0, /* request_id - using 0 for synchronous call */
+                                              metrics_type);
 
     /* Check result */
     if (!result) {
         VALKEY_LOG_ERROR("get_cache_metrics", "FFI call returned NULL result");
-        zend_throw_exception(
-            get_valkey_glide_exception_ce(), "Failed to get cache metrics", 0);
+        zend_throw_exception(get_valkey_glide_exception_ce(), "Failed to get cache metrics", 0);
         return;
     }
 
@@ -2439,9 +2436,8 @@ void execute_get_cache_metrics(zval*             object,
             result->response->string_value ? result->response->string_value : "Unknown error",
             0);
     } else {
-        zend_throw_exception(get_valkey_glide_exception_ce(),
-                             "Unexpected response type for cache metrics",
-                             0);
+        zend_throw_exception(
+            get_valkey_glide_exception_ce(), "Unexpected response type for cache metrics", 0);
     }
 
     free_command_result(result);

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -235,7 +235,7 @@ uint8_t* create_connection_request(size_t*                                   len
 
         client_side_cache_msg.entry_ttl_ms = config->client_side_cache->entry_ttl_ms;
 
-        if (config->client_side_cache->eviction_policy >= 0) {
+        if (config->client_side_cache->has_eviction_policy) {
             client_side_cache_msg.eviction_policy =
                 (ConnectionRequest__EvictionPolicy) config->client_side_cache->eviction_policy;
         }

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -225,6 +225,27 @@ uint8_t* create_connection_request(size_t*                                   len
     pubsub_subs.channels_or_patterns_by_type   = NULL;
     conn_req.pubsub_subscriptions              = &pubsub_subs;
 
+    /* Set client-side cache configuration */
+    ConnectionRequest__ClientSideCache client_side_cache_msg =
+        CONNECTION_REQUEST__CLIENT_SIDE_CACHE__INIT;
+    if (config->client_side_cache) {
+        client_side_cache_msg.cache_id     = config->client_side_cache->cache_id;
+        client_side_cache_msg.max_cache_kb = config->client_side_cache->max_cache_kb;
+        client_side_cache_msg.enable_metrics = config->client_side_cache->enable_metrics;
+
+        if (config->client_side_cache->entry_ttl_seconds >= 0) {
+            client_side_cache_msg.entry_ttl_seconds =
+                config->client_side_cache->entry_ttl_seconds;
+        }
+
+        if (config->client_side_cache->eviction_policy >= 0) {
+            client_side_cache_msg.eviction_policy =
+                (ConnectionRequest__EvictionPolicy) config->client_side_cache->eviction_policy;
+        }
+
+        conn_req.client_side_cache = &client_side_cache_msg;
+    }
+
     /* Calculate the size of the serialized message */
     *len = connection_request__connection_request__get_packed_size(&conn_req);
 
@@ -2342,6 +2363,85 @@ void execute_refresh_iam_token(zval* object, zval* return_value, zend_class_entr
         VALKEY_LOG_ERROR_FMT(
             "refresh_iam_token", "Unexpected response type: %d", result->response->response_type);
         zend_throw_exception(get_valkey_glide_exception_ce(), "Unexpected response from server", 0);
+    }
+
+    free_command_result(result);
+}
+
+/**
+ * Execute get_cache_metrics command
+ *
+ * @param object The ValkeyGlide or ValkeyGlideCluster object
+ * @param metrics_type The type of cache metric to retrieve (see CACHE_METRICS_* constants)
+ * @param return_value The return value zval
+ * @param ce The class entry
+ */
+void execute_get_cache_metrics(zval*             object,
+                               int               metrics_type,
+                               zval*             return_value,
+                               zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+
+    /* Get ValkeyGlide object */
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        VALKEY_LOG_ERROR("get_cache_metrics",
+                         "Invalid client object or client connection handle is NULL");
+        zend_throw_exception(get_valkey_glide_exception_ce(),
+                             "Invalid client object or client connection handle is NULL",
+                             0);
+        return;
+    }
+
+    /* Call FFI function */
+    CommandResult* result =
+        get_cache_metrics(valkey_glide->glide_client,
+                          0, /* request_id - using 0 for synchronous call */
+                          metrics_type);
+
+    /* Check result */
+    if (!result) {
+        VALKEY_LOG_ERROR("get_cache_metrics", "FFI call returned NULL result");
+        zend_throw_exception(
+            get_valkey_glide_exception_ce(), "Failed to get cache metrics", 0);
+        return;
+    }
+
+    /* Check for command error */
+    if (result->command_error) {
+        VALKEY_LOG_ERROR_FMT("get_cache_metrics",
+                             "Command execution failed with error: %s",
+                             result->command_error->command_error_message
+                                 ? result->command_error->command_error_message
+                                 : "Unknown error");
+        zend_throw_exception(
+            get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+        free_command_result(result);
+        return;
+    }
+
+    if (!result->response) {
+        VALKEY_LOG_ERROR("get_cache_metrics", "No response received");
+        free_command_result(result);
+        zend_throw_exception(
+            get_valkey_glide_exception_ce(), "No response received for cache metrics", 0);
+        return;
+    }
+
+    /* Process response based on type */
+    if (result->response->response_type == Float) {
+        ZVAL_DOUBLE(return_value, result->response->float_value);
+    } else if (result->response->response_type == Int) {
+        ZVAL_LONG(return_value, result->response->int_value);
+    } else if (result->response->response_type == Error) {
+        zend_throw_exception(
+            get_valkey_glide_exception_ce(),
+            result->response->string_value ? result->response->string_value : "Unknown error",
+            0);
+    } else {
+        zend_throw_exception(get_valkey_glide_exception_ce(),
+                             "Unexpected response type for cache metrics",
+                             0);
     }
 
     free_command_result(result);

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -233,9 +233,7 @@ uint8_t* create_connection_request(size_t*                                   len
         client_side_cache_msg.max_cache_kb   = config->client_side_cache->max_cache_kb;
         client_side_cache_msg.enable_metrics = config->client_side_cache->enable_metrics;
 
-        if (config->client_side_cache->entry_ttl_ms >= 0) {
-            client_side_cache_msg.entry_ttl_ms = config->client_side_cache->entry_ttl_ms;
-        }
+        client_side_cache_msg.entry_ttl_ms = config->client_side_cache->entry_ttl_ms;
 
         if (config->client_side_cache->eviction_policy >= 0) {
             client_side_cache_msg.eviction_policy =

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -236,8 +236,7 @@ uint8_t* create_connection_request(size_t*                                   len
         client_side_cache_msg.entry_ttl_ms = config->client_side_cache->entry_ttl_ms;
 
         if (config->client_side_cache->has_eviction_policy) {
-            client_side_cache_msg.eviction_policy =
-                (ConnectionRequest__EvictionPolicy) config->client_side_cache->eviction_policy;
+            client_side_cache_msg.eviction_policy = config->client_side_cache->eviction_policy;
         }
 
         conn_req.client_side_cache = &client_side_cache_msg;

--- a/valkey_glide_core_common.h
+++ b/valkey_glide_core_common.h
@@ -424,6 +424,5 @@ void execute_get_cache_metrics(zval*             object,
         execute_get_cache_metrics(                                                     \
             ZEND_THIS, CACHE_METRICS_EXPIRATIONS, return_value, Z_OBJCE_P(ZEND_THIS)); \
     }
-    }
 
 #endif /* VALKEY_GLIDE_CORE_COMMON_H */

--- a/valkey_glide_core_common.h
+++ b/valkey_glide_core_common.h
@@ -376,6 +376,7 @@ void execute_refresh_iam_token(zval* object, zval* return_value, zend_class_entr
 #define CACHE_METRICS_ENTRY_COUNT 2
 #define CACHE_METRICS_EVICTIONS 3
 #define CACHE_METRICS_EXPIRATIONS 4
+#define CACHE_METRICS_TOTAL_LOOKUPS 5
 
 /**
  * Execute get_cache_metrics command
@@ -423,6 +424,14 @@ void execute_get_cache_metrics(zval*             object,
         ZEND_PARSE_PARAMETERS_NONE();                                                  \
         execute_get_cache_metrics(                                                     \
             ZEND_THIS, CACHE_METRICS_EXPIRATIONS, return_value, Z_OBJCE_P(ZEND_THIS)); \
+    }
+
+/* Macro for getCacheTotalLookups method implementation */
+#define GET_CACHE_TOTAL_LOOKUPS_METHOD_IMPL(class_name)                                  \
+    PHP_METHOD(class_name, getCacheTotalLookups) {                                       \
+        ZEND_PARSE_PARAMETERS_NONE();                                                    \
+        execute_get_cache_metrics(                                                       \
+            ZEND_THIS, CACHE_METRICS_TOTAL_LOOKUPS, return_value, Z_OBJCE_P(ZEND_THIS)); \
     }
 
 #endif /* VALKEY_GLIDE_CORE_COMMON_H */

--- a/valkey_glide_core_common.h
+++ b/valkey_glide_core_common.h
@@ -370,4 +370,60 @@ void execute_refresh_iam_token(zval* object, zval* return_value, zend_class_entr
         execute_refresh_iam_token(object, return_value, Z_OBJCE_P(object));                 \
     }
 
+/* Cache metrics type constants */
+#define CACHE_METRICS_HIT_RATE 0
+#define CACHE_METRICS_MISS_RATE 1
+#define CACHE_METRICS_ENTRY_COUNT 2
+#define CACHE_METRICS_EVICTIONS 3
+#define CACHE_METRICS_EXPIRATIONS 4
+
+/**
+ * Execute get_cache_metrics command
+ */
+void execute_get_cache_metrics(zval*             object,
+                               int               metrics_type,
+                               zval*             return_value,
+                               zend_class_entry* ce);
+
+/* Macro for getCacheHitRate method implementation */
+#define GET_CACHE_HIT_RATE_METHOD_IMPL(class_name)                                    \
+    PHP_METHOD(class_name, getCacheHitRate) {                                          \
+        ZEND_PARSE_PARAMETERS_NONE();                                                  \
+        execute_get_cache_metrics(                                                     \
+            ZEND_THIS, CACHE_METRICS_HIT_RATE, return_value, Z_OBJCE_P(ZEND_THIS));   \
+    }
+
+/* Macro for getCacheMissRate method implementation */
+#define GET_CACHE_MISS_RATE_METHOD_IMPL(class_name)                                   \
+    PHP_METHOD(class_name, getCacheMissRate) {                                         \
+        ZEND_PARSE_PARAMETERS_NONE();                                                  \
+        execute_get_cache_metrics(                                                     \
+            ZEND_THIS, CACHE_METRICS_MISS_RATE, return_value, Z_OBJCE_P(ZEND_THIS));  \
+    }
+
+/* Macro for getCacheEntryCount method implementation */
+#define GET_CACHE_ENTRY_COUNT_METHOD_IMPL(class_name)                                  \
+    PHP_METHOD(class_name, getCacheEntryCount) {                                       \
+        ZEND_PARSE_PARAMETERS_NONE();                                                  \
+        execute_get_cache_metrics(                                                     \
+            ZEND_THIS, CACHE_METRICS_ENTRY_COUNT, return_value, Z_OBJCE_P(ZEND_THIS));\
+    }
+
+/* Macro for getCacheEvictions method implementation */
+#define GET_CACHE_EVICTIONS_METHOD_IMPL(class_name)                                    \
+    PHP_METHOD(class_name, getCacheEvictions) {                                        \
+        ZEND_PARSE_PARAMETERS_NONE();                                                  \
+        execute_get_cache_metrics(                                                     \
+            ZEND_THIS, CACHE_METRICS_EVICTIONS, return_value, Z_OBJCE_P(ZEND_THIS));  \
+    }
+
+/* Macro for getCacheExpirations method implementation */
+#define GET_CACHE_EXPIRATIONS_METHOD_IMPL(class_name)                                  \
+    PHP_METHOD(class_name, getCacheExpirations) {                                      \
+        ZEND_PARSE_PARAMETERS_NONE();                                                  \
+        execute_get_cache_metrics(                                                     \
+            ZEND_THIS, CACHE_METRICS_EXPIRATIONS, return_value, Z_OBJCE_P(ZEND_THIS));\
+    }
+    }
+
 #endif /* VALKEY_GLIDE_CORE_COMMON_H */

--- a/valkey_glide_core_common.h
+++ b/valkey_glide_core_common.h
@@ -386,19 +386,19 @@ void execute_get_cache_metrics(zval*             object,
                                zend_class_entry* ce);
 
 /* Macro for getCacheHitRate method implementation */
-#define GET_CACHE_HIT_RATE_METHOD_IMPL(class_name)                                    \
-    PHP_METHOD(class_name, getCacheHitRate) {                                          \
-        ZEND_PARSE_PARAMETERS_NONE();                                                  \
-        execute_get_cache_metrics(                                                     \
-            ZEND_THIS, CACHE_METRICS_HIT_RATE, return_value, Z_OBJCE_P(ZEND_THIS));   \
+#define GET_CACHE_HIT_RATE_METHOD_IMPL(class_name)                                  \
+    PHP_METHOD(class_name, getCacheHitRate) {                                       \
+        ZEND_PARSE_PARAMETERS_NONE();                                               \
+        execute_get_cache_metrics(                                                  \
+            ZEND_THIS, CACHE_METRICS_HIT_RATE, return_value, Z_OBJCE_P(ZEND_THIS)); \
     }
 
 /* Macro for getCacheMissRate method implementation */
-#define GET_CACHE_MISS_RATE_METHOD_IMPL(class_name)                                   \
-    PHP_METHOD(class_name, getCacheMissRate) {                                         \
-        ZEND_PARSE_PARAMETERS_NONE();                                                  \
-        execute_get_cache_metrics(                                                     \
-            ZEND_THIS, CACHE_METRICS_MISS_RATE, return_value, Z_OBJCE_P(ZEND_THIS));  \
+#define GET_CACHE_MISS_RATE_METHOD_IMPL(class_name)                                  \
+    PHP_METHOD(class_name, getCacheMissRate) {                                       \
+        ZEND_PARSE_PARAMETERS_NONE();                                                \
+        execute_get_cache_metrics(                                                   \
+            ZEND_THIS, CACHE_METRICS_MISS_RATE, return_value, Z_OBJCE_P(ZEND_THIS)); \
     }
 
 /* Macro for getCacheEntryCount method implementation */
@@ -406,15 +406,15 @@ void execute_get_cache_metrics(zval*             object,
     PHP_METHOD(class_name, getCacheEntryCount) {                                       \
         ZEND_PARSE_PARAMETERS_NONE();                                                  \
         execute_get_cache_metrics(                                                     \
-            ZEND_THIS, CACHE_METRICS_ENTRY_COUNT, return_value, Z_OBJCE_P(ZEND_THIS));\
+            ZEND_THIS, CACHE_METRICS_ENTRY_COUNT, return_value, Z_OBJCE_P(ZEND_THIS)); \
     }
 
 /* Macro for getCacheEvictions method implementation */
-#define GET_CACHE_EVICTIONS_METHOD_IMPL(class_name)                                    \
-    PHP_METHOD(class_name, getCacheEvictions) {                                        \
-        ZEND_PARSE_PARAMETERS_NONE();                                                  \
-        execute_get_cache_metrics(                                                     \
-            ZEND_THIS, CACHE_METRICS_EVICTIONS, return_value, Z_OBJCE_P(ZEND_THIS));  \
+#define GET_CACHE_EVICTIONS_METHOD_IMPL(class_name)                                  \
+    PHP_METHOD(class_name, getCacheEvictions) {                                      \
+        ZEND_PARSE_PARAMETERS_NONE();                                                \
+        execute_get_cache_metrics(                                                   \
+            ZEND_THIS, CACHE_METRICS_EVICTIONS, return_value, Z_OBJCE_P(ZEND_THIS)); \
     }
 
 /* Macro for getCacheExpirations method implementation */
@@ -422,7 +422,7 @@ void execute_get_cache_metrics(zval*             object,
     PHP_METHOD(class_name, getCacheExpirations) {                                      \
         ZEND_PARSE_PARAMETERS_NONE();                                                  \
         execute_get_cache_metrics(                                                     \
-            ZEND_THIS, CACHE_METRICS_EXPIRATIONS, return_value, Z_OBJCE_P(ZEND_THIS));\
+            ZEND_THIS, CACHE_METRICS_EXPIRATIONS, return_value, Z_OBJCE_P(ZEND_THIS)); \
     }
     }
 


### PR DESCRIPTION
### Summary

Add client-side caching support with TTL-based expiration to the PHP client.
### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Features / Behaviour Changes

- New `ClientSideCache` class and `ClientSideCacheBuilder` for configuring local caching of read command responses (GET, HGETALL, SMEMBERS)
- LRU and LFU eviction policies with configurable max cache size and entry TTL
- Cache sharing between clients created with the same `ClientSideCache` instance
- Cache metrics API: `getCacheHitRate()`, `getCacheMissRate()`, `getCacheEntryCount()`, `getCacheEvictions()`, `getCacheExpirations()`
- Available on both standalone and cluster clients

### Implementation

- `ClientSideCache.php` / `ClientSideCacheBuilder.php` — PHP configuration classes with builder pattern and input validation
- `common.h` — New `valkey_glide_client_side_cache_config_t` struct and `valkey_glide_eviction_policy_t` enum
- `valkey_glide_core_common.h` — Cache metrics macros and `execute_get_cache_metrics()` declaration
- `valkey_glide_core_commands.c` — Marshals cache config into the protobuf connection request
- `valkey_glide.c` / `valkey_glide_cluster.c` — Parses cache config from constructor args, wires up metrics methods
- `valkey_glide.stub.php` / `valkey_glide_cluster.stub.php` — PHP API stubs for cache methods
- `utils/patch_proto_and_rust.py` — Updated to handle cache-related code generation
- `valkey-glide` submodule bumped to include caching support in glide-core

### Limitations

- Cached entries expire via lazy TTL — no background eviction, entries are removed on access after TTL expires
- Server-side key changes are not propagated to the cache; values may be stale before TTL expires
- Only GET, HGETALL, and SMEMBERS responses are cached

### Testing

- `ClientSideCacheTest.php` added with comprehensive coverage: builder validation, eviction policies, TTL, metrics, cache sharing, `toArray()` serialization, and edge cases

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.
