### PR TITLE
PHP: Add JSON commands

### DIFF
--- a/.github/workflows/build-php-wrapper/action.yml
+++ b/.github/workflows/build-php-wrapper/action.yml
@@ -181,7 +181,6 @@ runs:
     - name: Build PHP extension
       shell: bash
       run: |
-        make build-modules-pre
         make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "4")
 
     - name: Verify extension build

--- a/.github/workflows/build-php-wrapper/action.yml
+++ b/.github/workflows/build-php-wrapper/action.yml
@@ -181,6 +181,7 @@ runs:
     - name: Build PHP extension
       shell: bash
       run: |
+        make build-modules-pre
         make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "4")
 
     - name: Verify extension build

--- a/tests/ValkeyGlideClusterJsonTest.php
+++ b/tests/ValkeyGlideClusterJsonTest.php
@@ -313,10 +313,13 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": "hello", "c": [1, 2]}');
 
             $result = $this->valkey_glide->jsonType($key, '$.a');
-            $this->assertNotNull($result);
+            $this->assertEquals(['integer'], $result);
+
+            $result = $this->valkey_glide->jsonType($key, '$.b');
+            $this->assertEquals(['string'], $result);
 
             $result = $this->valkey_glide->jsonType($key, '$.c');
-            $this->assertNotNull($result);
+            $this->assertEquals(['array'], $result);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -358,11 +361,9 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"bool": true, "nested": {"bool": false}}');
 
             $result = $this->valkey_glide->jsonToggle($key, '$..bool');
-            $this->assertNotNull($result);
-
-            $getResult = $this->valkey_glide->jsonGet($key);
-            $this->assertTrue(strpos($getResult, 'false') !== false);
-            $this->assertTrue(strpos($getResult, 'true') !== false);
+            $this->assertIsArray($result);
+            $this->assertEquals(false, $result[0]);
+            $this->assertEquals(true, $result[1]);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -372,13 +373,13 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
     {
         $key = '{json}:' . uniqid();
         try {
-            $this->valkey_glide->jsonSet($key, '$', '{"a": "foo", "b": "bar"}');
+            $this->valkey_glide->jsonSet($key, '$', '{"a": "foo"}');
 
-            $result = $this->valkey_glide->jsonStrAppend($key, '$.a', '"baz"');
-            $this->assertNotNull($result);
+            $result = $this->valkey_glide->jsonStrAppend($key, '$.a', '"bar"');
+            $this->assertEquals([6], $result);
 
             $getResult = $this->valkey_glide->jsonGet($key, '$.a');
-            $this->assertTrue(strpos($getResult, 'foobaz') !== false);
+            $this->assertTrue(strpos($getResult, 'foobar') !== false);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -391,7 +392,7 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": "hello"}');
 
             $result = $this->valkey_glide->jsonStrLen($key, '$.a');
-            $this->assertNotNull($result);
+            $this->assertEquals([5], $result);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -407,7 +408,7 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
             $this->assertEquals(2, $result);
 
             $result = $this->valkey_glide->jsonObjLen($key, '$.b');
-            $this->assertNotNull($result);
+            $this->assertEquals([2], $result);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -420,7 +421,7 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": 2}');
 
             $result = $this->valkey_glide->jsonObjKeys($key);
-            $this->assertNotNull($result);
+            $this->assertEquals(['a', 'b'], $result);
 
             $result = $this->valkey_glide->jsonObjKeys('non_existing_key_' . uniqid());
             $this->assertNull($result);
@@ -436,11 +437,10 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2]}');
 
             $result = $this->valkey_glide->jsonArrAppend($key, '$.a', '3', '4');
-            $this->assertNotNull($result);
+            $this->assertEquals([4], $result);
 
-            $getResult = $this->valkey_glide->jsonGet($key);
-            $this->assertTrue(strpos($getResult, '3') !== false);
-            $this->assertTrue(strpos($getResult, '4') !== false);
+            $getResult = $this->valkey_glide->jsonGet($key, '$.a');
+            $this->assertEquals('[[1,2,3,4]]', $getResult);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -453,10 +453,10 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3]}');
 
             $result = $this->valkey_glide->jsonArrInsert($key, '$.a', 1, '"x"');
-            $this->assertNotNull($result);
+            $this->assertEquals([4], $result);
 
-            $getResult = $this->valkey_glide->jsonGet($key);
-            $this->assertTrue(strpos($getResult, 'x') !== false);
+            $getResult = $this->valkey_glide->jsonGet($key, '$.a');
+            $this->assertEquals('[[1,"x",2,3]]', $getResult);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -469,10 +469,10 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3, 2]}');
 
             $result = $this->valkey_glide->jsonArrIndex($key, '$.a', '2');
-            $this->assertNotNull($result);
+            $this->assertEquals([1], $result);
 
             $result = $this->valkey_glide->jsonArrIndex($key, '$.a', '99');
-            $this->assertNotNull($result);
+            $this->assertEquals([-1], $result);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -485,7 +485,7 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3]}');
 
             $result = $this->valkey_glide->jsonArrLen($key, '$.a');
-            $this->assertNotNull($result);
+            $this->assertEquals([3], $result);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -498,11 +498,11 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": [10, 20, 30]}');
 
             $result = $this->valkey_glide->jsonArrPop($key, '$.a');
-            $this->assertNotNull($result);
+            $this->assertEquals(['30'], $result);
 
             $this->valkey_glide->jsonSet($key, '$', '{"a": [10, 20, 30]}');
             $result = $this->valkey_glide->jsonArrPop($key, '$.a', 0);
-            $this->assertNotNull($result);
+            $this->assertEquals(['10'], $result);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -515,12 +515,10 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3, 4, 5]}');
 
             $result = $this->valkey_glide->jsonArrTrim($key, '$.a', 1, 3);
-            $this->assertNotNull($result);
+            $this->assertEquals([3], $result);
 
-            $getResult = $this->valkey_glide->jsonGet($key);
-            $this->assertTrue(strpos($getResult, '2') !== false);
-            $this->assertTrue(strpos($getResult, '3') !== false);
-            $this->assertTrue(strpos($getResult, '4') !== false);
+            $getResult = $this->valkey_glide->jsonGet($key, '$.a');
+            $this->assertEquals('[[2,3,4]]', $getResult);
         } finally {
             $this->valkey_glide->del($key);
         }

--- a/tests/ValkeyGlideClusterJsonTest.php
+++ b/tests/ValkeyGlideClusterJsonTest.php
@@ -239,4 +239,338 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
             $this->valkey_glide->del($key);
         }
     }
+
+    public function testJsonDel()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "nested": {"a": 2, "b": 3}}');
+            $result = $this->valkey_glide->jsonDel($key, '$..a');
+            $this->assertEquals(2, $result);
+
+            $this->valkey_glide->jsonSet($key, '$', '{"x": 1}');
+            $result = $this->valkey_glide->jsonDel($key);
+            $this->assertEquals(1, $result);
+
+            $result = $this->valkey_glide->jsonDel('non_existing_key_' . uniqid());
+            $this->assertEquals(0, $result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonForget()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": 2}');
+            $result = $this->valkey_glide->jsonForget($key, '$.a');
+            $this->assertEquals(1, $result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonClear()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": [1, 2, 3]}');
+            $result = $this->valkey_glide->jsonClear($key, '$.*');
+            $this->assertEquals(2, $result);
+
+            $result = $this->valkey_glide->jsonClear($key, '$.*');
+            $this->assertEquals(0, $result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonMGet()
+    {
+        $key1 = '{json}:mget1:' . uniqid();
+        $key2 = '{json}:mget2:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key1, '$', '{"a": 1}');
+            $this->valkey_glide->jsonSet($key2, '$', '{"a": 2}');
+
+            $result = $this->valkey_glide->jsonMGet([$key1, $key2, 'non_existing_' . uniqid()], '$.a');
+            $this->assertIsArray($result);
+            $this->assertCount(3, $result);
+            $this->assertEquals('[1]', $result[0]);
+            $this->assertEquals('[2]', $result[1]);
+            $this->assertEquals(null, $result[2]);
+        } finally {
+            $this->valkey_glide->del($key1);
+            $this->valkey_glide->del($key2);
+        }
+    }
+
+    public function testJsonType()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": "hello", "c": [1, 2]}');
+
+            $result = $this->valkey_glide->jsonType($key, '$.a');
+            $this->assertNotNull($result);
+
+            $result = $this->valkey_glide->jsonType($key, '$.c');
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonNumIncrBy()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": 2.5}');
+
+            $result = $this->valkey_glide->jsonNumIncrBy($key, '$.a', 10);
+            $this->assertEquals('[11]', $result);
+
+            $result = $this->valkey_glide->jsonNumIncrBy($key, '$.b', 0.5);
+            $this->assertEquals('[3]', $result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonNumMultBy()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 2, "b": 3}');
+
+            $result = $this->valkey_glide->jsonNumMultBy($key, '$.a', 5);
+            $this->assertEquals('[10]', $result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonToggle()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"bool": true, "nested": {"bool": false}}');
+
+            $result = $this->valkey_glide->jsonToggle($key, '$..bool');
+            $this->assertNotNull($result);
+
+            $getResult = $this->valkey_glide->jsonGet($key);
+            $this->assertTrue(strpos($getResult, 'false') !== false);
+            $this->assertTrue(strpos($getResult, 'true') !== false);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonStrAppend()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": "foo", "b": "bar"}');
+
+            $result = $this->valkey_glide->jsonStrAppend($key, '$.a', '"baz"');
+            $this->assertNotNull($result);
+
+            $getResult = $this->valkey_glide->jsonGet($key, '$.a');
+            $this->assertTrue(strpos($getResult, 'foobaz') !== false);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonStrLen()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": "hello"}');
+
+            $result = $this->valkey_glide->jsonStrLen($key, '$.a');
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonObjLen()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": {"x": 1, "y": 2}}');
+
+            $result = $this->valkey_glide->jsonObjLen($key);
+            $this->assertEquals(2, $result);
+
+            $result = $this->valkey_glide->jsonObjLen($key, '$.b');
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonObjKeys()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": 2}');
+
+            $result = $this->valkey_glide->jsonObjKeys($key);
+            $this->assertNotNull($result);
+
+            $result = $this->valkey_glide->jsonObjKeys('non_existing_key_' . uniqid());
+            $this->assertNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonArrAppend()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2]}');
+
+            $result = $this->valkey_glide->jsonArrAppend($key, '$.a', '3', '4');
+            $this->assertNotNull($result);
+
+            $getResult = $this->valkey_glide->jsonGet($key);
+            $this->assertTrue(strpos($getResult, '3') !== false);
+            $this->assertTrue(strpos($getResult, '4') !== false);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonArrInsert()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3]}');
+
+            $result = $this->valkey_glide->jsonArrInsert($key, '$.a', 1, '"x"');
+            $this->assertNotNull($result);
+
+            $getResult = $this->valkey_glide->jsonGet($key);
+            $this->assertTrue(strpos($getResult, 'x') !== false);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonArrIndex()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3, 2]}');
+
+            $result = $this->valkey_glide->jsonArrIndex($key, '$.a', '2');
+            $this->assertNotNull($result);
+
+            $result = $this->valkey_glide->jsonArrIndex($key, '$.a', '99');
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonArrLen()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3]}');
+
+            $result = $this->valkey_glide->jsonArrLen($key, '$.a');
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonArrPop()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": [10, 20, 30]}');
+
+            $result = $this->valkey_glide->jsonArrPop($key, '$.a');
+            $this->assertNotNull($result);
+
+            $this->valkey_glide->jsonSet($key, '$', '{"a": [10, 20, 30]}');
+            $result = $this->valkey_glide->jsonArrPop($key, '$.a', 0);
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonArrTrim()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3, 4, 5]}');
+
+            $result = $this->valkey_glide->jsonArrTrim($key, '$.a', 1, 3);
+            $this->assertNotNull($result);
+
+            $getResult = $this->valkey_glide->jsonGet($key);
+            $this->assertTrue(strpos($getResult, '2') !== false);
+            $this->assertTrue(strpos($getResult, '3') !== false);
+            $this->assertTrue(strpos($getResult, '4') !== false);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonResp()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": [1, 2]}');
+
+            $result = $this->valkey_glide->jsonResp($key);
+            $this->assertNotNull($result);
+
+            $result = $this->valkey_glide->jsonResp('non_existing_key_' . uniqid());
+            $this->assertNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonDebugMemory()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": "hello"}');
+
+            $result = $this->valkey_glide->jsonDebugMemory($key);
+            $this->assertNotNull($result);
+
+            $result = $this->valkey_glide->jsonDebugMemory($key, '$.a');
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonDebugFields()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": [1, 2, 3]}');
+
+            $result = $this->valkey_glide->jsonDebugFields($key);
+            $this->assertNotNull($result);
+
+            $result = $this->valkey_glide->jsonDebugFields($key, '$.b');
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
 }

--- a/tests/ValkeyGlideClusterJsonTest.php
+++ b/tests/ValkeyGlideClusterJsonTest.php
@@ -197,7 +197,7 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
                 ->indent('  ')
                 ->newline("\n")
                 ->space(' ');
-            $value2 = $this->valkey_glide->jsonGet($key, '$', $opts);
+            $value2 = $this->valkey_glide->jsonGet($key, '$', $opts->toArray());
             $this->assertNotEquals(false, $value2);
             $this->assertTrue(strpos($value2, "\n") !== false);
             $this->assertEquals($value, $value2);
@@ -528,10 +528,13 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
     {
         $key = '{json}:' . uniqid();
         try {
-            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": [1, 2]}');
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1}');
 
             $result = $this->valkey_glide->jsonResp($key);
-            $this->assertNotNull($result);
+            $this->assertIsArray($result);
+            $this->assertEquals('{', $result[0]);
+            $this->assertEquals('a', $result[1][0]);
+            $this->assertEquals(1, $result[1][1]);
 
             $result = $this->valkey_glide->jsonResp('non_existing_key_' . uniqid());
             $this->assertNull($result);
@@ -547,10 +550,12 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": "hello"}');
 
             $result = $this->valkey_glide->jsonDebugMemory($key);
-            $this->assertNotNull($result);
+            $this->assertIsInt($result);
+            $this->assertTrue($result > 0);
 
             $result = $this->valkey_glide->jsonDebugMemory($key, '$.a');
-            $this->assertNotNull($result);
+            $this->assertIsArray($result);
+            $this->assertTrue($result[0] > 0);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -563,10 +568,12 @@ class ValkeyGlideClusterJsonTest extends ValkeyGlideClusterBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": [1, 2, 3]}');
 
             $result = $this->valkey_glide->jsonDebugFields($key);
-            $this->assertNotNull($result);
+            $this->assertIsInt($result);
+            $this->assertEquals(5, $result);
 
             $result = $this->valkey_glide->jsonDebugFields($key, '$.b');
-            $this->assertNotNull($result);
+            $this->assertIsArray($result);
+            $this->assertEquals(3, $result[0]);
         } finally {
             $this->valkey_glide->del($key);
         }

--- a/tests/ValkeyGlideJsonTest.php
+++ b/tests/ValkeyGlideJsonTest.php
@@ -240,4 +240,338 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
             $this->valkey_glide->del($key);
         }
     }
+
+    public function testJsonDel()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "nested": {"a": 2, "b": 3}}');
+            $result = $this->valkey_glide->jsonDel($key, '$..a');
+            $this->assertEquals(2, $result);
+
+            $this->valkey_glide->jsonSet($key, '$', '{"x": 1}');
+            $result = $this->valkey_glide->jsonDel($key);
+            $this->assertEquals(1, $result);
+
+            $result = $this->valkey_glide->jsonDel('non_existing_key_' . uniqid());
+            $this->assertEquals(0, $result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonForget()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": 2}');
+            $result = $this->valkey_glide->jsonForget($key, '$.a');
+            $this->assertEquals(1, $result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonClear()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": [1, 2, 3]}');
+            $result = $this->valkey_glide->jsonClear($key, '$.*');
+            $this->assertEquals(2, $result);
+
+            $result = $this->valkey_glide->jsonClear($key, '$.*');
+            $this->assertEquals(0, $result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonMGet()
+    {
+        $key1 = '{json}:mget1:' . uniqid();
+        $key2 = '{json}:mget2:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key1, '$', '{"a": 1}');
+            $this->valkey_glide->jsonSet($key2, '$', '{"a": 2}');
+
+            $result = $this->valkey_glide->jsonMGet([$key1, $key2, 'non_existing_' . uniqid()], '$.a');
+            $this->assertIsArray($result);
+            $this->assertCount(3, $result);
+            $this->assertEquals('[1]', $result[0]);
+            $this->assertEquals('[2]', $result[1]);
+            $this->assertEquals(null, $result[2]);
+        } finally {
+            $this->valkey_glide->del($key1);
+            $this->valkey_glide->del($key2);
+        }
+    }
+
+    public function testJsonType()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": "hello", "c": [1, 2]}');
+
+            $result = $this->valkey_glide->jsonType($key, '$.a');
+            $this->assertNotNull($result);
+
+            $result = $this->valkey_glide->jsonType($key, '$.c');
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonNumIncrBy()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": 2.5}');
+
+            $result = $this->valkey_glide->jsonNumIncrBy($key, '$.a', 10);
+            $this->assertEquals('[11]', $result);
+
+            $result = $this->valkey_glide->jsonNumIncrBy($key, '$.b', 0.5);
+            $this->assertEquals('[3]', $result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonNumMultBy()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 2, "b": 3}');
+
+            $result = $this->valkey_glide->jsonNumMultBy($key, '$.a', 5);
+            $this->assertEquals('[10]', $result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonToggle()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"bool": true, "nested": {"bool": false}}');
+
+            $result = $this->valkey_glide->jsonToggle($key, '$..bool');
+            $this->assertNotNull($result);
+
+            $getResult = $this->valkey_glide->jsonGet($key);
+            $this->assertTrue(strpos($getResult, 'false') !== false);
+            $this->assertTrue(strpos($getResult, 'true') !== false);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonStrAppend()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": "foo", "b": "bar"}');
+
+            $result = $this->valkey_glide->jsonStrAppend($key, '$.a', '"baz"');
+            $this->assertNotNull($result);
+
+            $getResult = $this->valkey_glide->jsonGet($key, '$.a');
+            $this->assertTrue(strpos($getResult, 'foobaz') !== false);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonStrLen()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": "hello"}');
+
+            $result = $this->valkey_glide->jsonStrLen($key, '$.a');
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonObjLen()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": {"x": 1, "y": 2}}');
+
+            $result = $this->valkey_glide->jsonObjLen($key);
+            $this->assertEquals(2, $result);
+
+            $result = $this->valkey_glide->jsonObjLen($key, '$.b');
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonObjKeys()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": 2}');
+
+            $result = $this->valkey_glide->jsonObjKeys($key);
+            $this->assertNotNull($result);
+
+            $result = $this->valkey_glide->jsonObjKeys('non_existing_key_' . uniqid());
+            $this->assertNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonArrAppend()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2]}');
+
+            $result = $this->valkey_glide->jsonArrAppend($key, '$.a', '3', '4');
+            $this->assertNotNull($result);
+
+            $getResult = $this->valkey_glide->jsonGet($key);
+            $this->assertTrue(strpos($getResult, '3') !== false);
+            $this->assertTrue(strpos($getResult, '4') !== false);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonArrInsert()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3]}');
+
+            $result = $this->valkey_glide->jsonArrInsert($key, '$.a', 1, '"x"');
+            $this->assertNotNull($result);
+
+            $getResult = $this->valkey_glide->jsonGet($key);
+            $this->assertTrue(strpos($getResult, 'x') !== false);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonArrIndex()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3, 2]}');
+
+            $result = $this->valkey_glide->jsonArrIndex($key, '$.a', '2');
+            $this->assertNotNull($result);
+
+            $result = $this->valkey_glide->jsonArrIndex($key, '$.a', '99');
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonArrLen()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3]}');
+
+            $result = $this->valkey_glide->jsonArrLen($key, '$.a');
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonArrPop()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": [10, 20, 30]}');
+
+            $result = $this->valkey_glide->jsonArrPop($key, '$.a');
+            $this->assertNotNull($result);
+
+            $this->valkey_glide->jsonSet($key, '$', '{"a": [10, 20, 30]}');
+            $result = $this->valkey_glide->jsonArrPop($key, '$.a', 0);
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonArrTrim()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3, 4, 5]}');
+
+            $result = $this->valkey_glide->jsonArrTrim($key, '$.a', 1, 3);
+            $this->assertNotNull($result);
+
+            $getResult = $this->valkey_glide->jsonGet($key);
+            $this->assertTrue(strpos($getResult, '2') !== false);
+            $this->assertTrue(strpos($getResult, '3') !== false);
+            $this->assertTrue(strpos($getResult, '4') !== false);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonResp()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": [1, 2]}');
+
+            $result = $this->valkey_glide->jsonResp($key);
+            $this->assertNotNull($result);
+
+            $result = $this->valkey_glide->jsonResp('non_existing_key_' . uniqid());
+            $this->assertNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonDebugMemory()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": "hello"}');
+
+            $result = $this->valkey_glide->jsonDebugMemory($key);
+            $this->assertNotNull($result);
+
+            $result = $this->valkey_glide->jsonDebugMemory($key, '$.a');
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
+
+    public function testJsonDebugFields()
+    {
+        $key = '{json}:' . uniqid();
+        try {
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": [1, 2, 3]}');
+
+            $result = $this->valkey_glide->jsonDebugFields($key);
+            $this->assertNotNull($result);
+
+            $result = $this->valkey_glide->jsonDebugFields($key, '$.b');
+            $this->assertNotNull($result);
+        } finally {
+            $this->valkey_glide->del($key);
+        }
+    }
 }

--- a/tests/ValkeyGlideJsonTest.php
+++ b/tests/ValkeyGlideJsonTest.php
@@ -197,7 +197,7 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
                 ->indent('  ')
                 ->newline("\n")
                 ->space(' ');
-            $value2 = $this->valkey_glide->jsonGet($key, '$', $opts);
+            $value2 = $this->valkey_glide->jsonGet($key, '$', $opts->toArray());
             $this->assertNotEquals(false, $value2);
             $this->assertTrue(strpos($value2, "\n") !== false);
             $this->assertEquals($value, $value2);
@@ -529,10 +529,13 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
     {
         $key = '{json}:' . uniqid();
         try {
-            $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": [1, 2]}');
+            $this->valkey_glide->jsonSet($key, '$', '{"a": 1}');
 
             $result = $this->valkey_glide->jsonResp($key);
-            $this->assertNotNull($result);
+            $this->assertIsArray($result);
+            $this->assertEquals('{', $result[0]);
+            $this->assertEquals('a', $result[1][0]);
+            $this->assertEquals(1, $result[1][1]);
 
             $result = $this->valkey_glide->jsonResp('non_existing_key_' . uniqid());
             $this->assertNull($result);
@@ -548,10 +551,12 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": "hello"}');
 
             $result = $this->valkey_glide->jsonDebugMemory($key);
-            $this->assertNotNull($result);
+            $this->assertIsInt($result);
+            $this->assertTrue($result > 0);
 
             $result = $this->valkey_glide->jsonDebugMemory($key, '$.a');
-            $this->assertNotNull($result);
+            $this->assertIsArray($result);
+            $this->assertTrue($result[0] > 0);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -564,10 +569,12 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": [1, 2, 3]}');
 
             $result = $this->valkey_glide->jsonDebugFields($key);
-            $this->assertNotNull($result);
+            $this->assertIsInt($result);
+            $this->assertEquals(5, $result);
 
             $result = $this->valkey_glide->jsonDebugFields($key, '$.b');
-            $this->assertNotNull($result);
+            $this->assertIsArray($result);
+            $this->assertEquals(3, $result[0]);
         } finally {
             $this->valkey_glide->del($key);
         }

--- a/tests/ValkeyGlideJsonTest.php
+++ b/tests/ValkeyGlideJsonTest.php
@@ -314,10 +314,13 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": "hello", "c": [1, 2]}');
 
             $result = $this->valkey_glide->jsonType($key, '$.a');
-            $this->assertNotNull($result);
+            $this->assertEquals(['integer'], $result);
+
+            $result = $this->valkey_glide->jsonType($key, '$.b');
+            $this->assertEquals(['string'], $result);
 
             $result = $this->valkey_glide->jsonType($key, '$.c');
-            $this->assertNotNull($result);
+            $this->assertEquals(['array'], $result);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -359,11 +362,9 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"bool": true, "nested": {"bool": false}}');
 
             $result = $this->valkey_glide->jsonToggle($key, '$..bool');
-            $this->assertNotNull($result);
-
-            $getResult = $this->valkey_glide->jsonGet($key);
-            $this->assertTrue(strpos($getResult, 'false') !== false);
-            $this->assertTrue(strpos($getResult, 'true') !== false);
+            $this->assertIsArray($result);
+            $this->assertEquals(false, $result[0]);
+            $this->assertEquals(true, $result[1]);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -373,13 +374,13 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
     {
         $key = '{json}:' . uniqid();
         try {
-            $this->valkey_glide->jsonSet($key, '$', '{"a": "foo", "b": "bar"}');
+            $this->valkey_glide->jsonSet($key, '$', '{"a": "foo"}');
 
-            $result = $this->valkey_glide->jsonStrAppend($key, '$.a', '"baz"');
-            $this->assertNotNull($result);
+            $result = $this->valkey_glide->jsonStrAppend($key, '$.a', '"bar"');
+            $this->assertEquals([6], $result);
 
             $getResult = $this->valkey_glide->jsonGet($key, '$.a');
-            $this->assertTrue(strpos($getResult, 'foobaz') !== false);
+            $this->assertTrue(strpos($getResult, 'foobar') !== false);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -392,7 +393,7 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": "hello"}');
 
             $result = $this->valkey_glide->jsonStrLen($key, '$.a');
-            $this->assertNotNull($result);
+            $this->assertEquals([5], $result);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -408,7 +409,7 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
             $this->assertEquals(2, $result);
 
             $result = $this->valkey_glide->jsonObjLen($key, '$.b');
-            $this->assertNotNull($result);
+            $this->assertEquals([2], $result);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -421,7 +422,7 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": 1, "b": 2}');
 
             $result = $this->valkey_glide->jsonObjKeys($key);
-            $this->assertNotNull($result);
+            $this->assertEquals(['a', 'b'], $result);
 
             $result = $this->valkey_glide->jsonObjKeys('non_existing_key_' . uniqid());
             $this->assertNull($result);
@@ -437,11 +438,10 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2]}');
 
             $result = $this->valkey_glide->jsonArrAppend($key, '$.a', '3', '4');
-            $this->assertNotNull($result);
+            $this->assertEquals([4], $result);
 
-            $getResult = $this->valkey_glide->jsonGet($key);
-            $this->assertTrue(strpos($getResult, '3') !== false);
-            $this->assertTrue(strpos($getResult, '4') !== false);
+            $getResult = $this->valkey_glide->jsonGet($key, '$.a');
+            $this->assertEquals('[[1,2,3,4]]', $getResult);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -454,10 +454,10 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3]}');
 
             $result = $this->valkey_glide->jsonArrInsert($key, '$.a', 1, '"x"');
-            $this->assertNotNull($result);
+            $this->assertEquals([4], $result);
 
-            $getResult = $this->valkey_glide->jsonGet($key);
-            $this->assertTrue(strpos($getResult, 'x') !== false);
+            $getResult = $this->valkey_glide->jsonGet($key, '$.a');
+            $this->assertEquals('[[1,"x",2,3]]', $getResult);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -470,10 +470,10 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3, 2]}');
 
             $result = $this->valkey_glide->jsonArrIndex($key, '$.a', '2');
-            $this->assertNotNull($result);
+            $this->assertEquals([1], $result);
 
             $result = $this->valkey_glide->jsonArrIndex($key, '$.a', '99');
-            $this->assertNotNull($result);
+            $this->assertEquals([-1], $result);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -486,7 +486,7 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3]}');
 
             $result = $this->valkey_glide->jsonArrLen($key, '$.a');
-            $this->assertNotNull($result);
+            $this->assertEquals([3], $result);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -499,11 +499,11 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": [10, 20, 30]}');
 
             $result = $this->valkey_glide->jsonArrPop($key, '$.a');
-            $this->assertNotNull($result);
+            $this->assertEquals(['30'], $result);
 
             $this->valkey_glide->jsonSet($key, '$', '{"a": [10, 20, 30]}');
             $result = $this->valkey_glide->jsonArrPop($key, '$.a', 0);
-            $this->assertNotNull($result);
+            $this->assertEquals(['10'], $result);
         } finally {
             $this->valkey_glide->del($key);
         }
@@ -516,12 +516,10 @@ class ValkeyGlideJsonTest extends ValkeyGlideBaseTest
             $this->valkey_glide->jsonSet($key, '$', '{"a": [1, 2, 3, 4, 5]}');
 
             $result = $this->valkey_glide->jsonArrTrim($key, '$.a', 1, 3);
-            $this->assertNotNull($result);
+            $this->assertEquals([3], $result);
 
-            $getResult = $this->valkey_glide->jsonGet($key);
-            $this->assertTrue(strpos($getResult, '2') !== false);
-            $this->assertTrue(strpos($getResult, '3') !== false);
-            $this->assertTrue(strpos($getResult, '4') !== false);
+            $getResult = $this->valkey_glide->jsonGet($key, '$.a');
+            $this->assertEquals('[[2,3,4]]', $getResult);
         } finally {
             $this->valkey_glide->del($key);
         }

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -4452,67 +4452,355 @@ class ValkeyGlide
      */
     public function jsonGet(string $key, string|array $paths = '$', object|array|null $options = null): ValkeyGlide|string|false|null;
 
-    /** @see https://valkey.io/commands/json.del */
+    /**
+     * Delete the JSON value at the specified path stored at key.
+     *
+     * @see https://valkey.io/commands/json.del
+     *
+     * @param string $key  The key of the JSON document.
+     * @param string $path Optional. The path within the JSON document. If not provided, deletes the entire document.
+     *
+     * @return ValkeyGlide|int|false The number of paths deleted. 0 if the key or path doesn't exist. False on failure.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": 1, "nested": {"a": 2}}');
+     * $valkey_glide->jsonDel('doc', '$..a'); // 2
+     * $valkey_glide->jsonDel('doc');         // 1 (deletes entire doc)
+     */
     public function jsonDel(string $key, string $path = ''): ValkeyGlide|int|false;
 
-    /** @see https://valkey.io/commands/json.forget */
+    /**
+     * Delete the JSON value at the specified path. Alias for jsonDel.
+     *
+     * @see https://valkey.io/commands/json.forget
+     * @see ValkeyGlide::jsonDel()
+     *
+     * @param string $key  The key of the JSON document.
+     * @param string $path Optional. The path within the JSON document.
+     *
+     * @return ValkeyGlide|int|false The number of paths deleted. 0 if the key or path doesn't exist. False on failure.
+     */
     public function jsonForget(string $key, string $path = ''): ValkeyGlide|int|false;
 
-    /** @see https://valkey.io/commands/json.clear */
+    /**
+     * Clear arrays/objects at the specified path. Numeric values are set to 0.
+     *
+     * @see https://valkey.io/commands/json.clear
+     *
+     * @param string $key  The key of the JSON document.
+     * @param string $path Optional. The path within the JSON document. Defaults to root.
+     *
+     * @return ValkeyGlide|int|false The number of values cleared. 0 if already empty. False on failure.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": 1, "b": [1, 2, 3]}');
+     * $valkey_glide->jsonClear('doc', '$.*'); // 2
+     */
     public function jsonClear(string $key, string $path = ''): ValkeyGlide|int|false;
 
-    /** @see https://valkey.io/commands/json.mget */
+    /**
+     * Retrieve JSON values at the specified path from multiple keys.
+     *
+     * @see https://valkey.io/commands/json.mget
+     *
+     * @param array  $keys The keys of the JSON documents.
+     * @param string $path The path within the JSON documents.
+     *
+     * @return ValkeyGlide|array|false An array of JSON strings for each key. Null elements for keys that don't exist.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc1', '$', '{"a": 1}');
+     * $valkey_glide->jsonSet('doc2', '$', '{"a": 2}');
+     * $valkey_glide->jsonMGet(['doc1', 'doc2', 'missing'], '$.a'); // ['[1]', '[2]', null]
+     */
     public function jsonMGet(array $keys, string $path): ValkeyGlide|array|false;
 
-    /** @see https://valkey.io/commands/json.type */
+    /**
+     * Report the type of the JSON value at the specified path.
+     *
+     * @see https://valkey.io/commands/json.type
+     *
+     * @param string $key  The key of the JSON document.
+     * @param string $path Optional. The path within the JSON document.
+     *
+     * @return ValkeyGlide|array|string|false|null For JSONPath: array of type strings. For legacy path: a type string.
+     *                                             Null if the key doesn't exist. False on failure.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": 1, "b": "hello"}');
+     * $valkey_glide->jsonType('doc', '$.a'); // ['integer']
+     */
     public function jsonType(string $key, string $path = ''): ValkeyGlide|array|string|false|null;
 
-    /** @see https://valkey.io/commands/json.numincrby */
+    /**
+     * Increment the numeric value at the specified path by the given number.
+     *
+     * @see https://valkey.io/commands/json.numincrby
+     *
+     * @param string $key    The key of the JSON document.
+     * @param string $path   The path within the JSON document.
+     * @param float  $number The number to increment by.
+     *
+     * @return ValkeyGlide|string|false|null A string representation of the new value(s). Null for non-numeric paths.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": 1}');
+     * $valkey_glide->jsonNumIncrBy('doc', '$.a', 10); // '[11]'
+     */
     public function jsonNumIncrBy(string $key, string $path, float $number): ValkeyGlide|string|false|null;
 
-    /** @see https://valkey.io/commands/json.nummultby */
+    /**
+     * Multiply the numeric value at the specified path by the given number.
+     *
+     * @see https://valkey.io/commands/json.nummultby
+     *
+     * @param string $key    The key of the JSON document.
+     * @param string $path   The path within the JSON document.
+     * @param float  $number The number to multiply by.
+     *
+     * @return ValkeyGlide|string|false|null A string representation of the new value(s). Null for non-numeric paths.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": 2}');
+     * $valkey_glide->jsonNumMultBy('doc', '$.a', 5); // '[10]'
+     */
     public function jsonNumMultBy(string $key, string $path, float $number): ValkeyGlide|string|false|null;
 
-    /** @see https://valkey.io/commands/json.toggle */
+    /**
+     * Toggle a boolean value at the specified path.
+     *
+     * @see https://valkey.io/commands/json.toggle
+     *
+     * @param string $key  The key of the JSON document.
+     * @param string $path Optional. The path within the JSON document.
+     *
+     * @return ValkeyGlide|array|bool|false|null For JSONPath: array of booleans. For legacy path: the toggled value.
+     *                                           Null for non-boolean paths. False on failure.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"flag": true}');
+     * $valkey_glide->jsonToggle('doc', '$.flag'); // [false]
+     */
     public function jsonToggle(string $key, string $path = ''): ValkeyGlide|array|bool|false|null;
 
-    /** @see https://valkey.io/commands/json.strappend */
+    /**
+     * Append a string to the string value at the specified path.
+     *
+     * @see https://valkey.io/commands/json.strappend
+     *
+     * @param string $key         The key of the JSON document.
+     * @param string $pathOrValue When 3 args: the path. When 2 args: the JSON string to append.
+     * @param string $value       Optional. The JSON-encoded string to append (e.g., '"baz"').
+     *
+     * @return ValkeyGlide|array|int|false|null For JSONPath: array of new string lengths. For legacy path: the new length.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": "foo"}');
+     * $valkey_glide->jsonStrAppend('doc', '$.a', '"bar"'); // [6]
+     */
     public function jsonStrAppend(string $key, string $pathOrValue, string $value = ''): ValkeyGlide|array|int|false|null;
 
-    /** @see https://valkey.io/commands/json.strlen */
+    /**
+     * Return the length of the string at the specified path.
+     *
+     * @see https://valkey.io/commands/json.strlen
+     *
+     * @param string $key  The key of the JSON document.
+     * @param string $path Optional. The path within the JSON document.
+     *
+     * @return ValkeyGlide|array|int|false|null For JSONPath: array of lengths. For legacy path: the string length.
+     *                                          Null if the key doesn't exist. False on failure.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": "hello"}');
+     * $valkey_glide->jsonStrLen('doc', '$.a'); // [5]
+     */
     public function jsonStrLen(string $key, string $path = ''): ValkeyGlide|array|int|false|null;
 
-    /** @see https://valkey.io/commands/json.objlen */
+    /**
+     * Return the number of keys in the object at the specified path.
+     *
+     * @see https://valkey.io/commands/json.objlen
+     *
+     * @param string $key  The key of the JSON document.
+     * @param string $path Optional. The path within the JSON document.
+     *
+     * @return ValkeyGlide|array|int|false|null For JSONPath: array of object sizes. For legacy path: the object size.
+     *                                          Null if the key doesn't exist. False on failure.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": 1, "b": 2}');
+     * $valkey_glide->jsonObjLen('doc'); // 2
+     */
     public function jsonObjLen(string $key, string $path = ''): ValkeyGlide|array|int|false|null;
 
-    /** @see https://valkey.io/commands/json.objkeys */
+    /**
+     * Return the key names in the object at the specified path.
+     *
+     * @see https://valkey.io/commands/json.objkeys
+     *
+     * @param string $key  The key of the JSON document.
+     * @param string $path Optional. The path within the JSON document.
+     *
+     * @return ValkeyGlide|array|false|null For JSONPath: nested array of key names. For legacy path: array of key names.
+     *                                      Null if the key doesn't exist. False on failure.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": 1, "b": 2}');
+     * $valkey_glide->jsonObjKeys('doc'); // ['a', 'b']
+     */
     public function jsonObjKeys(string $key, string $path = ''): ValkeyGlide|array|false|null;
 
-    /** @see https://valkey.io/commands/json.resp */
+    /**
+     * Return the JSON document in RESP format.
+     *
+     * @see https://valkey.io/commands/json.resp
+     *
+     * @param string $key  The key of the JSON document.
+     * @param string $path Optional. The path within the JSON document.
+     *
+     * @return ValkeyGlide|array|false|null The RESP representation. Null if the key doesn't exist. False on failure.
+     */
     public function jsonResp(string $key, string $path = ''): ValkeyGlide|array|false|null;
 
-    /** @see https://valkey.io/commands/json.debug-memory */
+    /**
+     * Report memory usage in bytes for the JSON value.
+     *
+     * @see https://valkey.io/commands/json.debug-memory
+     *
+     * @param string $key  The key of the JSON document.
+     * @param string $path Optional. The path within the JSON document.
+     *
+     * @return ValkeyGlide|array|int|false|null Memory usage in bytes. Null if the key doesn't exist. False on failure.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": 1}');
+     * $valkey_glide->jsonDebugMemory('doc'); // e.g., 72
+     */
     public function jsonDebugMemory(string $key, string $path = ''): ValkeyGlide|array|int|false|null;
 
-    /** @see https://valkey.io/commands/json.debug-fields */
+    /**
+     * Report the number of fields in the JSON value.
+     *
+     * @see https://valkey.io/commands/json.debug-fields
+     *
+     * @param string $key  The key of the JSON document.
+     * @param string $path Optional. The path within the JSON document.
+     *
+     * @return ValkeyGlide|array|int|false|null Number of fields. Null if the key doesn't exist. False on failure.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": 1, "b": [1, 2, 3]}');
+     * $valkey_glide->jsonDebugFields('doc'); // 6
+     */
     public function jsonDebugFields(string $key, string $path = ''): ValkeyGlide|array|int|false|null;
 
-    /** @see https://valkey.io/commands/json.arrappend */
+    /**
+     * Append one or more values to the JSON array at the specified path.
+     *
+     * @see https://valkey.io/commands/json.arrappend
+     *
+     * @param string $key    The key of the JSON document.
+     * @param string $path   The path to the array within the JSON document.
+     * @param string ...$values The JSON values to append.
+     *
+     * @return ValkeyGlide|array|int|false For JSONPath: array of new lengths. For legacy path: the new length.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": [1, 2]}');
+     * $valkey_glide->jsonArrAppend('doc', '$.a', '3', '4'); // [4]
+     */
     public function jsonArrAppend(string $key, string $path, string ...$values): ValkeyGlide|array|int|false;
 
-    /** @see https://valkey.io/commands/json.arrinsert */
+    /**
+     * Insert one or more values into the array before the given index.
+     *
+     * @see https://valkey.io/commands/json.arrinsert
+     *
+     * @param string $key       The key of the JSON document.
+     * @param string $path      The path to the array within the JSON document.
+     * @param int    $index     The array index before which values are inserted.
+     * @param string ...$values The JSON values to insert.
+     *
+     * @return ValkeyGlide|array|int|false For JSONPath: array of new lengths. For legacy path: the new length.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": [1, 2, 3]}');
+     * $valkey_glide->jsonArrInsert('doc', '$.a', 1, '"x"'); // [4]
+     */
     public function jsonArrInsert(string $key, string $path, int $index, string ...$values): ValkeyGlide|array|int|false;
 
-    /** @see https://valkey.io/commands/json.arrindex */
+    /**
+     * Search for the first occurrence of a scalar value in the array.
+     *
+     * @see https://valkey.io/commands/json.arrindex
+     *
+     * @param string $key    The key of the JSON document.
+     * @param string $path   The path to the array within the JSON document.
+     * @param string $scalar The JSON scalar value to search for.
+     * @param int    $start  Optional. Start index (inclusive). Default 0.
+     * @param int    $end    Optional. End index (exclusive). Default 0 (end of array).
+     *
+     * @return ValkeyGlide|array|int|false For JSONPath: array of indices (-1 if not found). For legacy path: the index.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": [1, 2, 3, 2]}');
+     * $valkey_glide->jsonArrIndex('doc', '$.a', '2'); // [1]
+     */
     public function jsonArrIndex(string $key, string $path, string $scalar, int $start = 0, int $end = 0): ValkeyGlide|array|int|false;
 
-    /** @see https://valkey.io/commands/json.arrpop */
+    /**
+     * Pop an element from the array.
+     *
+     * @see https://valkey.io/commands/json.arrpop
+     *
+     * @param string $key   The key of the JSON document.
+     * @param string $path  Optional. The path to the array.
+     * @param int    $index Optional. The index to pop. Default -1 (last element).
+     *
+     * @return ValkeyGlide|array|string|false|null For JSONPath: array of popped values. For legacy path: the popped value.
+     *                                             Null if the array is empty. False on failure.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": [10, 20, 30]}');
+     * $valkey_glide->jsonArrPop('doc', '$.a');    // ['30']
+     * $valkey_glide->jsonArrPop('doc', '$.a', 0); // ['10']
+     */
     public function jsonArrPop(string $key, string $path = '', int $index = 0): ValkeyGlide|array|string|false|null;
 
-    /** @see https://valkey.io/commands/json.arrtrim */
+    /**
+     * Trim the array to a subarray [start, end], both inclusive.
+     *
+     * @see https://valkey.io/commands/json.arrtrim
+     *
+     * @param string $key   The key of the JSON document.
+     * @param string $path  The path to the array within the JSON document.
+     * @param int    $start The start index (inclusive).
+     * @param int    $end   The end index (inclusive).
+     *
+     * @return ValkeyGlide|array|int|false For JSONPath: array of new lengths. For legacy path: the new length.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": [1, 2, 3, 4, 5]}');
+     * $valkey_glide->jsonArrTrim('doc', '$.a', 1, 3); // [3] (array becomes [2, 3, 4])
+     */
     public function jsonArrTrim(string $key, string $path, int $start, int $end): ValkeyGlide|array|int|false;
 
-    /** @see https://valkey.io/commands/json.arrlen */
+    /**
+     * Return the length of the array at the specified path.
+     *
+     * @see https://valkey.io/commands/json.arrlen
+     *
+     * @param string $key  The key of the JSON document.
+     * @param string $path Optional. The path within the JSON document.
+     *
+     * @return ValkeyGlide|array|int|false|null For JSONPath: array of lengths. For legacy path: the length.
+     *                                          Null if the key doesn't exist. False on failure.
+     *
+     * @example
+     * $valkey_glide->jsonSet('doc', '$', '{"a": [1, 2, 3]}');
+     * $valkey_glide->jsonArrLen('doc', '$.a'); // [3]
+     */
     public function jsonArrLen(string $key, string $path = ''): ValkeyGlide|array|int|false|null;
 }
 

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -4450,7 +4450,7 @@ class ValkeyGlide
      * $valkey_glide->jsonGet('doc', '$', ['indent' => '  ', 'newline' => "\n", 'space' => ' ']);
      * $valkey_glide->jsonGet('doc', '$', JsonGetOptions::builder()->indent('  ')->newline("\n")->space(' '));
      */
-    public function jsonGet(string $key, string|array $paths = '$', object|array|null $options = null): ValkeyGlide|string|false|null;
+    public function jsonGet(string $key, string|array $paths = '$', ?array $options = null): ValkeyGlide|string|false|null;
 
     /**
      * Delete the JSON value at the specified path stored at key.

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -4434,10 +4434,12 @@ class ValkeyGlide
      *
      * @see https://valkey.io/commands/json.get
      *
-     * @param string       $key   The key of the JSON document.
-     * @param string|array $paths Optional. A path or array of paths within the JSON document.
-     *                            If not provided, returns the entire document.
-     *                            Supports JSONPath (starting with '$') and legacy path syntax.
+     * @param string       $key     The key of the JSON document.
+     * @param string|array $paths   Optional. A path or array of paths within the JSON document.
+     *                              If not provided, returns the entire document.
+     *                              Supports JSONPath (starting with '$') and legacy path syntax.
+     * @param array|null   $options Optional. Formatting options array with keys: 'indent', 'newline', 'space'.
+     *                              Use JsonGetOptions::builder()->...->toArray() or pass an array directly.
      *
      * @return ValkeyGlide|string|false|null The JSON string representation of the value(s) at the path(s).
      *                                       Null if the key doesn't exist. False on failure.
@@ -4448,7 +4450,7 @@ class ValkeyGlide
      * $valkey_glide->jsonGet('doc', '$.a');       // '[1]'
      * $valkey_glide->jsonGet('doc', ['$.a', '$.b']); // '{"$.a":[1],"$.b":[2]}'
      * $valkey_glide->jsonGet('doc', '$', ['indent' => '  ', 'newline' => "\n", 'space' => ' ']);
-     * $valkey_glide->jsonGet('doc', '$', JsonGetOptions::builder()->indent('  ')->newline("\n")->space(' '));
+     * $valkey_glide->jsonGet('doc', '$', JsonGetOptions::builder()->indent('  ')->newline("\n")->space(' ')->toArray());
      */
     public function jsonGet(string $key, string|array $paths = '$', ?array $options = null): ValkeyGlide|string|false|null;
 

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -4702,7 +4702,7 @@ class ValkeyGlide
      *
      * @param string $key    The key of the JSON document.
      * @param string $path   The path to the array within the JSON document.
-     * @param string ...$values The JSON values to append.
+     * @param string $values The JSON values to append.
      *
      * @return ValkeyGlide|array|int|false For JSONPath: array of new lengths. For legacy path: the new length.
      *
@@ -4720,7 +4720,7 @@ class ValkeyGlide
      * @param string $key       The key of the JSON document.
      * @param string $path      The path to the array within the JSON document.
      * @param int    $index     The array index before which values are inserted.
-     * @param string ...$values The JSON values to insert.
+     * @param string $values The JSON values to insert.
      *
      * @return ValkeyGlide|array|int|false For JSONPath: array of new lengths. For legacy path: the new length.
      *

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -4766,7 +4766,7 @@ class ValkeyGlide
      * $valkey_glide->jsonArrPop('doc', '$.a');    // ['30']
      * $valkey_glide->jsonArrPop('doc', '$.a', 0); // ['10']
      */
-    public function jsonArrPop(string $key, string $path = '', int $index = 0): ValkeyGlide|array|string|false|null;
+    public function jsonArrPop(string $key, string $path = '', int $index = -1): ValkeyGlide|array|string|false|null;
 
     /**
      * Trim the array to a subarray [start, end], both inclusive.

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -4451,6 +4451,69 @@ class ValkeyGlide
      * $valkey_glide->jsonGet('doc', '$', JsonGetOptions::builder()->indent('  ')->newline("\n")->space(' '));
      */
     public function jsonGet(string $key, string|array $paths = '$', object|array|null $options = null): ValkeyGlide|string|false|null;
+
+    /** @see https://valkey.io/commands/json.del */
+    public function jsonDel(string $key, string $path = ''): ValkeyGlide|int|false;
+
+    /** @see https://valkey.io/commands/json.forget */
+    public function jsonForget(string $key, string $path = ''): ValkeyGlide|int|false;
+
+    /** @see https://valkey.io/commands/json.clear */
+    public function jsonClear(string $key, string $path = ''): ValkeyGlide|int|false;
+
+    /** @see https://valkey.io/commands/json.mget */
+    public function jsonMGet(array $keys, string $path): ValkeyGlide|array|false;
+
+    /** @see https://valkey.io/commands/json.type */
+    public function jsonType(string $key, string $path = ''): ValkeyGlide|array|string|false|null;
+
+    /** @see https://valkey.io/commands/json.numincrby */
+    public function jsonNumIncrBy(string $key, string $path, float $number): ValkeyGlide|string|false|null;
+
+    /** @see https://valkey.io/commands/json.nummultby */
+    public function jsonNumMultBy(string $key, string $path, float $number): ValkeyGlide|string|false|null;
+
+    /** @see https://valkey.io/commands/json.toggle */
+    public function jsonToggle(string $key, string $path = ''): ValkeyGlide|array|bool|false|null;
+
+    /** @see https://valkey.io/commands/json.strappend */
+    public function jsonStrAppend(string $key, string $pathOrValue, string $value = ''): ValkeyGlide|array|int|false|null;
+
+    /** @see https://valkey.io/commands/json.strlen */
+    public function jsonStrLen(string $key, string $path = ''): ValkeyGlide|array|int|false|null;
+
+    /** @see https://valkey.io/commands/json.objlen */
+    public function jsonObjLen(string $key, string $path = ''): ValkeyGlide|array|int|false|null;
+
+    /** @see https://valkey.io/commands/json.objkeys */
+    public function jsonObjKeys(string $key, string $path = ''): ValkeyGlide|array|false|null;
+
+    /** @see https://valkey.io/commands/json.resp */
+    public function jsonResp(string $key, string $path = ''): ValkeyGlide|array|false|null;
+
+    /** @see https://valkey.io/commands/json.debug-memory */
+    public function jsonDebugMemory(string $key, string $path = ''): ValkeyGlide|array|int|false|null;
+
+    /** @see https://valkey.io/commands/json.debug-fields */
+    public function jsonDebugFields(string $key, string $path = ''): ValkeyGlide|array|int|false|null;
+
+    /** @see https://valkey.io/commands/json.arrappend */
+    public function jsonArrAppend(string $key, string $path, string ...$values): ValkeyGlide|array|int|false;
+
+    /** @see https://valkey.io/commands/json.arrinsert */
+    public function jsonArrInsert(string $key, string $path, int $index, string ...$values): ValkeyGlide|array|int|false;
+
+    /** @see https://valkey.io/commands/json.arrindex */
+    public function jsonArrIndex(string $key, string $path, string $scalar, int $start = 0, int $end = 0): ValkeyGlide|array|int|false;
+
+    /** @see https://valkey.io/commands/json.arrpop */
+    public function jsonArrPop(string $key, string $path = '', int $index = 0): ValkeyGlide|array|string|false|null;
+
+    /** @see https://valkey.io/commands/json.arrtrim */
+    public function jsonArrTrim(string $key, string $path, int $start, int $end): ValkeyGlide|array|int|false;
+
+    /** @see https://valkey.io/commands/json.arrlen */
+    public function jsonArrLen(string $key, string $path = ''): ValkeyGlide|array|int|false|null;
 }
 
 class ValkeyGlideException extends RuntimeException

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -1220,5 +1220,27 @@ JSON_SET_METHOD_IMPL(ValkeyGlideCluster)
 JSON_GET_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
+JSON_DEL_METHOD_IMPL(ValkeyGlideCluster)
+JSON_FORGET_METHOD_IMPL(ValkeyGlideCluster)
+JSON_CLEAR_METHOD_IMPL(ValkeyGlideCluster)
+JSON_MGET_METHOD_IMPL(ValkeyGlideCluster)
+JSON_TYPE_METHOD_IMPL(ValkeyGlideCluster)
+JSON_NUMINCRBY_METHOD_IMPL(ValkeyGlideCluster)
+JSON_NUMMULTBY_METHOD_IMPL(ValkeyGlideCluster)
+JSON_TOGGLE_METHOD_IMPL(ValkeyGlideCluster)
+JSON_STRAPPEND_METHOD_IMPL(ValkeyGlideCluster)
+JSON_STRLEN_METHOD_IMPL(ValkeyGlideCluster)
+JSON_OBJLEN_METHOD_IMPL(ValkeyGlideCluster)
+JSON_OBJKEYS_METHOD_IMPL(ValkeyGlideCluster)
+JSON_RESP_METHOD_IMPL(ValkeyGlideCluster)
+JSON_DEBUG_MEMORY_METHOD_IMPL(ValkeyGlideCluster)
+JSON_DEBUG_FIELDS_METHOD_IMPL(ValkeyGlideCluster)
+JSON_ARRAPPEND_METHOD_IMPL(ValkeyGlideCluster)
+JSON_ARRINSERT_METHOD_IMPL(ValkeyGlideCluster)
+JSON_ARRINDEX_METHOD_IMPL(ValkeyGlideCluster)
+JSON_ARRPOP_METHOD_IMPL(ValkeyGlideCluster)
+JSON_ARRTRIM_METHOD_IMPL(ValkeyGlideCluster)
+JSON_ARRLEN_METHOD_IMPL(ValkeyGlideCluster)
+
 #endif /* PHP_REDIS_CLUSTER_C */
 /* vim: set tabstop=4 softtabstop=4 expandtab shiftwidth=4: */

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -1220,27 +1220,93 @@ JSON_SET_METHOD_IMPL(ValkeyGlideCluster)
 JSON_GET_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
+/* {{{ proto int ValkeyGlideCluster::jsonDel(string key [, string path]) */
 JSON_DEL_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto int ValkeyGlideCluster::jsonForget(string key [, string path]) */
 JSON_FORGET_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto int ValkeyGlideCluster::jsonClear(string key [, string path]) */
 JSON_CLEAR_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto array ValkeyGlideCluster::jsonMGet(array keys, string path) */
 JSON_MGET_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlideCluster::jsonType(string key [, string path]) */
 JSON_TYPE_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto string ValkeyGlideCluster::jsonNumIncrBy(string key, string path, float number) */
 JSON_NUMINCRBY_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto string ValkeyGlideCluster::jsonNumMultBy(string key, string path, float number) */
 JSON_NUMMULTBY_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlideCluster::jsonToggle(string key [, string path]) */
 JSON_TOGGLE_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlideCluster::jsonStrAppend(string key, string pathOrValue [, string
+ * value])
+ */
 JSON_STRAPPEND_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlideCluster::jsonStrLen(string key [, string path]) */
 JSON_STRLEN_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlideCluster::jsonObjLen(string key [, string path]) */
 JSON_OBJLEN_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlideCluster::jsonObjKeys(string key [, string path]) */
 JSON_OBJKEYS_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlideCluster::jsonResp(string key [, string path]) */
 JSON_RESP_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlideCluster::jsonDebugMemory(string key [, string path]) */
 JSON_DEBUG_MEMORY_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlideCluster::jsonDebugFields(string key [, string path]) */
 JSON_DEBUG_FIELDS_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlideCluster::jsonArrAppend(string key, string path, string ...values) */
 JSON_ARRAPPEND_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlideCluster::jsonArrInsert(string key, string path, int index, string
+ * ...values) */
 JSON_ARRINSERT_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlideCluster::jsonArrIndex(string key, string path, string scalar [, int
+ * start [, int end]]) */
 JSON_ARRINDEX_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlideCluster::jsonArrPop(string key [, string path [, int index]]) */
 JSON_ARRPOP_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlideCluster::jsonArrTrim(string key, string path, int start, int end) */
 JSON_ARRTRIM_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlideCluster::jsonArrLen(string key [, string path]) */
 JSON_ARRLEN_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
 
 #endif /* PHP_REDIS_CLUSTER_C */
 /* vim: set tabstop=4 softtabstop=4 expandtab shiftwidth=4: */

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1487,4 +1487,67 @@ class ValkeyGlideCluster
      * @see ValkeyGlide::jsonGet
      */
     public function jsonGet(string $key, string|array $paths = '$', object|array|null $options = null): ValkeyGlideCluster|string|false|null;
+
+    /** @see ValkeyGlide::jsonDel */
+    public function jsonDel(string $key, string $path = ''): ValkeyGlideCluster|int|false;
+
+    /** @see ValkeyGlide::jsonForget */
+    public function jsonForget(string $key, string $path = ''): ValkeyGlideCluster|int|false;
+
+    /** @see ValkeyGlide::jsonClear */
+    public function jsonClear(string $key, string $path = ''): ValkeyGlideCluster|int|false;
+
+    /** @see ValkeyGlide::jsonMGet */
+    public function jsonMGet(array $keys, string $path): ValkeyGlideCluster|array|false;
+
+    /** @see ValkeyGlide::jsonType */
+    public function jsonType(string $key, string $path = ''): ValkeyGlideCluster|array|string|false|null;
+
+    /** @see ValkeyGlide::jsonNumIncrBy */
+    public function jsonNumIncrBy(string $key, string $path, float $number): ValkeyGlideCluster|string|false|null;
+
+    /** @see ValkeyGlide::jsonNumMultBy */
+    public function jsonNumMultBy(string $key, string $path, float $number): ValkeyGlideCluster|string|false|null;
+
+    /** @see ValkeyGlide::jsonToggle */
+    public function jsonToggle(string $key, string $path = ''): ValkeyGlideCluster|array|bool|false|null;
+
+    /** @see ValkeyGlide::jsonStrAppend */
+    public function jsonStrAppend(string $key, string $pathOrValue, string $value = ''): ValkeyGlideCluster|array|int|false|null;
+
+    /** @see ValkeyGlide::jsonStrLen */
+    public function jsonStrLen(string $key, string $path = ''): ValkeyGlideCluster|array|int|false|null;
+
+    /** @see ValkeyGlide::jsonObjLen */
+    public function jsonObjLen(string $key, string $path = ''): ValkeyGlideCluster|array|int|false|null;
+
+    /** @see ValkeyGlide::jsonObjKeys */
+    public function jsonObjKeys(string $key, string $path = ''): ValkeyGlideCluster|array|false|null;
+
+    /** @see ValkeyGlide::jsonResp */
+    public function jsonResp(string $key, string $path = ''): ValkeyGlideCluster|array|false|null;
+
+    /** @see ValkeyGlide::jsonDebugMemory */
+    public function jsonDebugMemory(string $key, string $path = ''): ValkeyGlideCluster|array|int|false|null;
+
+    /** @see ValkeyGlide::jsonDebugFields */
+    public function jsonDebugFields(string $key, string $path = ''): ValkeyGlideCluster|array|int|false|null;
+
+    /** @see ValkeyGlide::jsonArrAppend */
+    public function jsonArrAppend(string $key, string $path, string ...$values): ValkeyGlideCluster|array|int|false;
+
+    /** @see ValkeyGlide::jsonArrInsert */
+    public function jsonArrInsert(string $key, string $path, int $index, string ...$values): ValkeyGlideCluster|array|int|false;
+
+    /** @see ValkeyGlide::jsonArrIndex */
+    public function jsonArrIndex(string $key, string $path, string $scalar, int $start = 0, int $end = 0): ValkeyGlideCluster|array|int|false;
+
+    /** @see ValkeyGlide::jsonArrPop */
+    public function jsonArrPop(string $key, string $path = '', int $index = 0): ValkeyGlideCluster|array|string|false|null;
+
+    /** @see ValkeyGlide::jsonArrTrim */
+    public function jsonArrTrim(string $key, string $path, int $start, int $end): ValkeyGlideCluster|array|int|false;
+
+    /** @see ValkeyGlide::jsonArrLen */
+    public function jsonArrLen(string $key, string $path = ''): ValkeyGlideCluster|array|int|false|null;
 }

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1486,7 +1486,7 @@ class ValkeyGlideCluster
     /**
      * @see ValkeyGlide::jsonGet
      */
-    public function jsonGet(string $key, string|array $paths = '$', object|array|null $options = null): ValkeyGlideCluster|string|false|null;
+    public function jsonGet(string $key, string|array $paths = '$', ?array $options = null): ValkeyGlideCluster|string|false|null;
 
     /** @see ValkeyGlide::jsonDel */
     public function jsonDel(string $key, string $path = ''): ValkeyGlideCluster|int|false;

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1543,7 +1543,7 @@ class ValkeyGlideCluster
     public function jsonArrIndex(string $key, string $path, string $scalar, int $start = 0, int $end = 0): ValkeyGlideCluster|array|int|false;
 
     /** @see ValkeyGlide::jsonArrPop */
-    public function jsonArrPop(string $key, string $path = '', int $index = 0): ValkeyGlideCluster|array|string|false|null;
+    public function jsonArrPop(string $key, string $path = '', int $index = -1): ValkeyGlideCluster|array|string|false|null;
 
     /** @see ValkeyGlide::jsonArrTrim */
     public function jsonArrTrim(string $key, string $path, int $start, int $end): ValkeyGlideCluster|array|int|false;

--- a/valkey_glide_json_common.c
+++ b/valkey_glide_json_common.c
@@ -1085,10 +1085,8 @@ int execute_json_arrindex_command(zval*             object,
     char*                path   = NULL;
     char*                scalar = NULL;
     size_t               key_len, path_len, scalar_len;
-    zend_long            start     = 0;
-    zend_long            end       = 0;
-    zend_bool            has_start = 0;
-    zend_bool            has_end   = 0;
+    zend_long            start = 0;
+    zend_long            end   = 0;
 
     if (zend_parse_method_parameters(argc,
                                      object,
@@ -1193,7 +1191,7 @@ int execute_json_arrpop_command(zval* object, int argc, zval* return_value, zend
     char*                key  = NULL;
     char*                path = NULL;
     size_t               key_len, path_len = 0;
-    zend_long            index = 0;
+    zend_long            index = -1;
 
     if (zend_parse_method_parameters(
             argc, object, "Os|sl", &object, ce, &key, &key_len, &path, &path_len, &index) ==

--- a/valkey_glide_json_common.c
+++ b/valkey_glide_json_common.c
@@ -573,6 +573,11 @@ int execute_json_mget_command(zval* object, int argc, zval* return_value, zend_c
             return 0;
         }
         if (result->response) {
+            if (result->response->response_type == Null) {
+                ZVAL_NULL(return_value);
+                free_command_result(result);
+                return 1;
+            }
             if (command_response_to_zval(
                     result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
                 free_command_result(result);
@@ -608,7 +613,19 @@ static int execute_json_num_command(
     }
 
     char   num_buf[64];
-    size_t num_len = snprintf(num_buf, sizeof(num_buf), "%g", number);
+    size_t num_len = snprintf(num_buf, sizeof(num_buf), "%.17g", number);
+    /* Strip trailing zeros after decimal point for cleaner output */
+    if (strchr(num_buf, '.')) {
+        char* p = num_buf + num_len - 1;
+        while (*p == '0') {
+            p--;
+        }
+        if (*p == '.') {
+            p--;
+        }
+        num_len          = (size_t) (p - num_buf + 1);
+        num_buf[num_len] = '\0';
+    }
 
     uintptr_t     cmd_args[3] = {(uintptr_t) key, (uintptr_t) path, (uintptr_t) num_buf};
     unsigned long cmd_lens[3] = {key_len, path_len, num_len};
@@ -746,6 +763,11 @@ int execute_json_strappend_command(zval*             object,
             return 0;
         }
         if (result->response) {
+            if (result->response->response_type == Null) {
+                ZVAL_NULL(return_value);
+                free_command_result(result);
+                return 1;
+            }
             if (command_response_to_zval(
                     result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
                 free_command_result(result);
@@ -821,6 +843,11 @@ static int execute_json_debug_command(zval*             object,
             return 0;
         }
         if (result->response) {
+            if (result->response->response_type == Null) {
+                ZVAL_NULL(return_value);
+                free_command_result(result);
+                return 1;
+            }
             if (command_response_to_zval(
                     result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
                 free_command_result(result);
@@ -926,6 +953,11 @@ int execute_json_arrappend_command(zval*             object,
             return 0;
         }
         if (result->response) {
+            if (result->response->response_type == Null) {
+                ZVAL_NULL(return_value);
+                free_command_result(result);
+                return 1;
+            }
             if (command_response_to_zval(
                     result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
                 free_command_result(result);
@@ -1024,6 +1056,11 @@ int execute_json_arrinsert_command(zval*             object,
             return 0;
         }
         if (result->response) {
+            if (result->response->response_type == Null) {
+                ZVAL_NULL(return_value);
+                free_command_result(result);
+                return 1;
+            }
             if (command_response_to_zval(
                     result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
                 free_command_result(result);
@@ -1131,6 +1168,11 @@ int execute_json_arrindex_command(zval*             object,
             return 0;
         }
         if (result->response) {
+            if (result->response->response_type == Null) {
+                ZVAL_NULL(return_value);
+                free_command_result(result);
+                return 1;
+            }
             if (command_response_to_zval(
                     result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
                 free_command_result(result);
@@ -1213,6 +1255,11 @@ int execute_json_arrpop_command(zval* object, int argc, zval* return_value, zend
             return 0;
         }
         if (result->response) {
+            if (result->response->response_type == Null) {
+                ZVAL_NULL(return_value);
+                free_command_result(result);
+                return 1;
+            }
             if (command_response_to_zval(
                     result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
                 free_command_result(result);
@@ -1275,6 +1322,11 @@ int execute_json_arrtrim_command(zval* object, int argc, zval* return_value, zen
             return 0;
         }
         if (result->response) {
+            if (result->response->response_type == Null) {
+                ZVAL_NULL(return_value);
+                free_command_result(result);
+                return 1;
+            }
             if (command_response_to_zval(
                     result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
                 free_command_result(result);

--- a/valkey_glide_json_common.c
+++ b/valkey_glide_json_common.c
@@ -378,3 +378,910 @@ int execute_json_get_command(zval* object, int argc, zval* return_value, zend_cl
 
     return 0;
 }
+
+/* ====================================================================
+ * GENERIC JSON HELPERS
+ * ==================================================================== */
+
+/**
+ * Batch result processor for JSON commands returning mixed types.
+ * Uses command_response_to_zval for generic conversion.
+ */
+static int process_json_mixed_result(CommandResponse* response, void* output, zval* return_value) {
+    if (!response || !return_value) {
+        return 0;
+    }
+    return command_response_to_zval(
+        response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false);
+}
+
+/**
+ * Generic executor for JSON commands with pattern: key [path]
+ * Returns mixed (int, array, string, null) via command_response_to_zval.
+ */
+static int execute_json_key_path_command(
+    zval* object, int argc, zval* return_value, zend_class_entry* ce, enum RequestType cmd_type) {
+    valkey_glide_object* valkey_glide;
+    char*                key  = NULL;
+    char*                path = NULL;
+    size_t               key_len, path_len = 0;
+
+    if (zend_parse_method_parameters(
+            argc, object, "Os|s", &object, ce, &key, &key_len, &path, &path_len) == FAILURE) {
+        return 0;
+    }
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    unsigned long arg_count   = (path && path_len > 0) ? 2 : 1;
+    uintptr_t     cmd_args[2] = {(uintptr_t) key, (uintptr_t) path};
+    unsigned long cmd_lens[2] = {key_len, path_len};
+
+    if (valkey_glide->is_in_batch_mode) {
+        int res = buffer_command_for_batch(
+            valkey_glide, cmd_type, cmd_args, cmd_lens, arg_count, NULL, process_json_mixed_result);
+        if (res) {
+            ZVAL_COPY(return_value, object);
+            return 1;
+        }
+        return 0;
+    }
+
+    CommandResult* result =
+        execute_command(valkey_glide->glide_client, cmd_type, arg_count, cmd_args, cmd_lens);
+
+    if (result) {
+        if (result->command_error) {
+            zend_throw_exception(
+                get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+            free_command_result(result);
+            return 0;
+        }
+        if (result->response) {
+            if (result->response->response_type == Null) {
+                ZVAL_NULL(return_value);
+                free_command_result(result);
+                return 1;
+            }
+            if (command_response_to_zval(
+                    result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
+                free_command_result(result);
+                return 1;
+            }
+        }
+        free_command_result(result);
+    }
+    return 0;
+}
+
+/* ====================================================================
+ * JSON.DEL / JSON.FORGET / JSON.CLEAR
+ * ==================================================================== */
+
+int execute_json_del_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    return execute_json_key_path_command(object, argc, return_value, ce, JsonDel);
+}
+
+int execute_json_forget_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    return execute_json_key_path_command(object, argc, return_value, ce, JsonForget);
+}
+
+int execute_json_clear_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    return execute_json_key_path_command(object, argc, return_value, ce, JsonClear);
+}
+
+/* ====================================================================
+ * JSON.TYPE / JSON.TOGGLE / JSON.ARRLEN / JSON.STRLEN
+ * JSON.OBJLEN / JSON.OBJKEYS / JSON.RESP
+ * ==================================================================== */
+
+int execute_json_type_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    return execute_json_key_path_command(object, argc, return_value, ce, JsonType);
+}
+
+int execute_json_toggle_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    return execute_json_key_path_command(object, argc, return_value, ce, JsonToggle);
+}
+
+int execute_json_arrlen_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    return execute_json_key_path_command(object, argc, return_value, ce, JsonArrLen);
+}
+
+int execute_json_strlen_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    return execute_json_key_path_command(object, argc, return_value, ce, JsonStrLen);
+}
+
+int execute_json_objlen_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    return execute_json_key_path_command(object, argc, return_value, ce, JsonObjLen);
+}
+
+int execute_json_objkeys_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    return execute_json_key_path_command(object, argc, return_value, ce, JsonObjKeys);
+}
+
+int execute_json_resp_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    return execute_json_key_path_command(object, argc, return_value, ce, JsonResp);
+}
+
+/* ====================================================================
+ * JSON.MGET — keys... path
+ * ==================================================================== */
+
+int execute_json_mget_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    zval*                keys_param = NULL;
+    char*                path       = NULL;
+    size_t               path_len;
+
+    if (zend_parse_method_parameters(
+            argc, object, "Oas", &object, ce, &keys_param, &path, &path_len) == FAILURE) {
+        return 0;
+    }
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    HashTable*    ht        = Z_ARRVAL_P(keys_param);
+    int           key_count = zend_hash_num_elements(ht);
+    unsigned long arg_count = key_count + 1; /* keys... + path */
+
+    uintptr_t*     cmd_args = (uintptr_t*) emalloc(arg_count * sizeof(uintptr_t));
+    unsigned long* cmd_lens = (unsigned long*) emalloc(arg_count * sizeof(unsigned long));
+
+    zval* val;
+    int   idx = 0;
+    ZEND_HASH_FOREACH_VAL(ht, val) {
+        if (Z_TYPE_P(val) != IS_STRING) {
+            convert_to_string(val);
+        }
+        cmd_args[idx] = (uintptr_t) Z_STRVAL_P(val);
+        cmd_lens[idx] = Z_STRLEN_P(val);
+        idx++;
+    }
+    ZEND_HASH_FOREACH_END();
+
+    cmd_args[idx] = (uintptr_t) path;
+    cmd_lens[idx] = path_len;
+
+    if (valkey_glide->is_in_batch_mode) {
+        int res = buffer_command_for_batch(
+            valkey_glide, JsonMGet, cmd_args, cmd_lens, arg_count, NULL, process_json_mixed_result);
+        efree(cmd_args);
+        efree(cmd_lens);
+        if (res) {
+            ZVAL_COPY(return_value, object);
+            return 1;
+        }
+        return 0;
+    }
+
+    CommandResult* result =
+        execute_command(valkey_glide->glide_client, JsonMGet, arg_count, cmd_args, cmd_lens);
+    efree(cmd_args);
+    efree(cmd_lens);
+
+    if (result) {
+        if (result->command_error) {
+            zend_throw_exception(
+                get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+            free_command_result(result);
+            return 0;
+        }
+        if (result->response) {
+            if (command_response_to_zval(
+                    result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
+                free_command_result(result);
+                return 1;
+            }
+        }
+        free_command_result(result);
+    }
+    return 0;
+}
+
+/* ====================================================================
+ * JSON.NUMINCRBY / JSON.NUMMULTBY — key path number → string
+ * ==================================================================== */
+
+static int execute_json_num_command(
+    zval* object, int argc, zval* return_value, zend_class_entry* ce, enum RequestType cmd_type) {
+    valkey_glide_object* valkey_glide;
+    char*                key  = NULL;
+    char*                path = NULL;
+    double               number;
+    size_t               key_len, path_len;
+
+    if (zend_parse_method_parameters(
+            argc, object, "Ossd", &object, ce, &key, &key_len, &path, &path_len, &number) ==
+        FAILURE) {
+        return 0;
+    }
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    char   num_buf[64];
+    size_t num_len = snprintf(num_buf, sizeof(num_buf), "%g", number);
+
+    uintptr_t     cmd_args[3] = {(uintptr_t) key, (uintptr_t) path, (uintptr_t) num_buf};
+    unsigned long cmd_lens[3] = {key_len, path_len, num_len};
+
+    if (valkey_glide->is_in_batch_mode) {
+        int res = buffer_command_for_batch(
+            valkey_glide, cmd_type, cmd_args, cmd_lens, 3, NULL, process_json_get_result);
+        if (res) {
+            ZVAL_COPY(return_value, object);
+            return 1;
+        }
+        return 0;
+    }
+
+    CommandResult* result =
+        execute_command(valkey_glide->glide_client, cmd_type, 3, cmd_args, cmd_lens);
+
+    if (result) {
+        if (result->command_error) {
+            zend_throw_exception(
+                get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+            free_command_result(result);
+            return 0;
+        }
+        if (result->response) {
+            if (result->response->response_type == Null) {
+                ZVAL_NULL(return_value);
+                free_command_result(result);
+                return 1;
+            }
+            if (result->response->string_value) {
+                RETVAL_STRINGL(result->response->string_value, result->response->string_value_len);
+                free_command_result(result);
+                return 1;
+            }
+        }
+        free_command_result(result);
+    }
+    return 0;
+}
+
+int execute_json_numincrby_command(zval*             object,
+                                   int               argc,
+                                   zval*             return_value,
+                                   zend_class_entry* ce) {
+    return execute_json_num_command(object, argc, return_value, ce, JsonNumIncrBy);
+}
+
+int execute_json_nummultby_command(zval*             object,
+                                   int               argc,
+                                   zval*             return_value,
+                                   zend_class_entry* ce) {
+    return execute_json_num_command(object, argc, return_value, ce, JsonNumMultBy);
+}
+
+/* ====================================================================
+ * JSON.STRAPPEND — key [path] value
+ * ==================================================================== */
+
+int execute_json_strappend_command(zval*             object,
+                                   int               argc,
+                                   zval*             return_value,
+                                   zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    char*                key   = NULL;
+    char*                path  = NULL;
+    char*                value = NULL;
+    size_t               key_len, path_len = 0, value_len;
+
+    /* Two forms: (key, value) or (key, path, value) */
+    if (zend_parse_method_parameters(argc,
+                                     object,
+                                     "Oss|s",
+                                     &object,
+                                     ce,
+                                     &key,
+                                     &key_len,
+                                     &path,
+                                     &path_len,
+                                     &value,
+                                     &value_len) == FAILURE) {
+        return 0;
+    }
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    uintptr_t     cmd_args[3];
+    unsigned long cmd_lens[3];
+    unsigned long arg_count;
+
+    if (value == NULL) {
+        /* 2 args: key, value (no path) */
+        cmd_args[0] = (uintptr_t) key;
+        cmd_lens[0] = key_len;
+        cmd_args[1] = (uintptr_t) path; /* path is actually the value */
+        cmd_lens[1] = path_len;
+        arg_count   = 2;
+    } else {
+        /* 3 args: key, path, value */
+        cmd_args[0] = (uintptr_t) key;
+        cmd_lens[0] = key_len;
+        cmd_args[1] = (uintptr_t) path;
+        cmd_lens[1] = path_len;
+        cmd_args[2] = (uintptr_t) value;
+        cmd_lens[2] = value_len;
+        arg_count   = 3;
+    }
+
+    if (valkey_glide->is_in_batch_mode) {
+        int res = buffer_command_for_batch(valkey_glide,
+                                           JsonStrAppend,
+                                           cmd_args,
+                                           cmd_lens,
+                                           arg_count,
+                                           NULL,
+                                           process_json_mixed_result);
+        if (res) {
+            ZVAL_COPY(return_value, object);
+            return 1;
+        }
+        return 0;
+    }
+
+    CommandResult* result =
+        execute_command(valkey_glide->glide_client, JsonStrAppend, arg_count, cmd_args, cmd_lens);
+
+    if (result) {
+        if (result->command_error) {
+            zend_throw_exception(
+                get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+            free_command_result(result);
+            return 0;
+        }
+        if (result->response) {
+            if (command_response_to_zval(
+                    result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
+                free_command_result(result);
+                return 1;
+            }
+        }
+        free_command_result(result);
+    }
+    return 0;
+}
+
+/* ====================================================================
+ * JSON.DEBUG MEMORY / JSON.DEBUG FIELDS — subcmd key [path]
+ * ==================================================================== */
+
+static int execute_json_debug_command(zval*             object,
+                                      int               argc,
+                                      zval*             return_value,
+                                      zend_class_entry* ce,
+                                      const char*       subcmd,
+                                      size_t            subcmd_len) {
+    valkey_glide_object* valkey_glide;
+    char*                key  = NULL;
+    char*                path = NULL;
+    size_t               key_len, path_len = 0;
+
+    if (zend_parse_method_parameters(
+            argc, object, "Os|s", &object, ce, &key, &key_len, &path, &path_len) == FAILURE) {
+        return 0;
+    }
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    unsigned long arg_count = (path && path_len > 0) ? 3 : 2;
+    uintptr_t     cmd_args[3];
+    unsigned long cmd_lens[3];
+
+    cmd_args[0] = (uintptr_t) subcmd;
+    cmd_lens[0] = subcmd_len;
+    cmd_args[1] = (uintptr_t) key;
+    cmd_lens[1] = key_len;
+    if (path && path_len > 0) {
+        cmd_args[2] = (uintptr_t) path;
+        cmd_lens[2] = path_len;
+    }
+
+    if (valkey_glide->is_in_batch_mode) {
+        int res = buffer_command_for_batch(valkey_glide,
+                                           JsonDebug,
+                                           cmd_args,
+                                           cmd_lens,
+                                           arg_count,
+                                           NULL,
+                                           process_json_mixed_result);
+        if (res) {
+            ZVAL_COPY(return_value, object);
+            return 1;
+        }
+        return 0;
+    }
+
+    CommandResult* result =
+        execute_command(valkey_glide->glide_client, JsonDebug, arg_count, cmd_args, cmd_lens);
+
+    if (result) {
+        if (result->command_error) {
+            zend_throw_exception(
+                get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+            free_command_result(result);
+            return 0;
+        }
+        if (result->response) {
+            if (command_response_to_zval(
+                    result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
+                free_command_result(result);
+                return 1;
+            }
+        }
+        free_command_result(result);
+    }
+    return 0;
+}
+
+int execute_json_debug_memory_command(zval*             object,
+                                      int               argc,
+                                      zval*             return_value,
+                                      zend_class_entry* ce) {
+    return execute_json_debug_command(object, argc, return_value, ce, "MEMORY", 6);
+}
+
+int execute_json_debug_fields_command(zval*             object,
+                                      int               argc,
+                                      zval*             return_value,
+                                      zend_class_entry* ce) {
+    return execute_json_debug_command(object, argc, return_value, ce, "FIELDS", 6);
+}
+
+/* ====================================================================
+ * JSON.ARRAPPEND — key path value [value ...]
+ * ==================================================================== */
+
+int execute_json_arrappend_command(zval*             object,
+                                   int               argc,
+                                   zval*             return_value,
+                                   zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    char*                key  = NULL;
+    char*                path = NULL;
+    size_t               key_len, path_len;
+    zval*                values     = NULL;
+    int                  values_cnt = 0;
+
+    if (zend_parse_method_parameters(argc,
+                                     object,
+                                     "Oss+",
+                                     &object,
+                                     ce,
+                                     &key,
+                                     &key_len,
+                                     &path,
+                                     &path_len,
+                                     &values,
+                                     &values_cnt) == FAILURE) {
+        return 0;
+    }
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    unsigned long  arg_count = 2 + values_cnt;
+    uintptr_t*     cmd_args  = (uintptr_t*) emalloc(arg_count * sizeof(uintptr_t));
+    unsigned long* cmd_lens  = (unsigned long*) emalloc(arg_count * sizeof(unsigned long));
+
+    cmd_args[0] = (uintptr_t) key;
+    cmd_lens[0] = key_len;
+    cmd_args[1] = (uintptr_t) path;
+    cmd_lens[1] = path_len;
+    for (int i = 0; i < values_cnt; i++) {
+        if (Z_TYPE(values[i]) != IS_STRING) {
+            convert_to_string(&values[i]);
+        }
+        cmd_args[2 + i] = (uintptr_t) Z_STRVAL(values[i]);
+        cmd_lens[2 + i] = Z_STRLEN(values[i]);
+    }
+
+    if (valkey_glide->is_in_batch_mode) {
+        int res = buffer_command_for_batch(valkey_glide,
+                                           JsonArrAppend,
+                                           cmd_args,
+                                           cmd_lens,
+                                           arg_count,
+                                           NULL,
+                                           process_json_mixed_result);
+        efree(cmd_args);
+        efree(cmd_lens);
+        if (res) {
+            ZVAL_COPY(return_value, object);
+            return 1;
+        }
+        return 0;
+    }
+
+    CommandResult* result =
+        execute_command(valkey_glide->glide_client, JsonArrAppend, arg_count, cmd_args, cmd_lens);
+    efree(cmd_args);
+    efree(cmd_lens);
+
+    if (result) {
+        if (result->command_error) {
+            zend_throw_exception(
+                get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+            free_command_result(result);
+            return 0;
+        }
+        if (result->response) {
+            if (command_response_to_zval(
+                    result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
+                free_command_result(result);
+                return 1;
+            }
+        }
+        free_command_result(result);
+    }
+    return 0;
+}
+
+/* ====================================================================
+ * JSON.ARRINSERT — key path index value [value ...]
+ * ==================================================================== */
+
+int execute_json_arrinsert_command(zval*             object,
+                                   int               argc,
+                                   zval*             return_value,
+                                   zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    char*                key  = NULL;
+    char*                path = NULL;
+    zend_long            index;
+    size_t               key_len, path_len;
+    zval*                values     = NULL;
+    int                  values_cnt = 0;
+
+    if (zend_parse_method_parameters(argc,
+                                     object,
+                                     "Ossl+",
+                                     &object,
+                                     ce,
+                                     &key,
+                                     &key_len,
+                                     &path,
+                                     &path_len,
+                                     &index,
+                                     &values,
+                                     &values_cnt) == FAILURE) {
+        return 0;
+    }
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    char   idx_buf[24];
+    size_t idx_len = snprintf(idx_buf, sizeof(idx_buf), "%ld", (long) index);
+
+    unsigned long  arg_count = 3 + values_cnt;
+    uintptr_t*     cmd_args  = (uintptr_t*) emalloc(arg_count * sizeof(uintptr_t));
+    unsigned long* cmd_lens  = (unsigned long*) emalloc(arg_count * sizeof(unsigned long));
+
+    cmd_args[0] = (uintptr_t) key;
+    cmd_lens[0] = key_len;
+    cmd_args[1] = (uintptr_t) path;
+    cmd_lens[1] = path_len;
+    cmd_args[2] = (uintptr_t) idx_buf;
+    cmd_lens[2] = idx_len;
+    for (int i = 0; i < values_cnt; i++) {
+        if (Z_TYPE(values[i]) != IS_STRING) {
+            convert_to_string(&values[i]);
+        }
+        cmd_args[3 + i] = (uintptr_t) Z_STRVAL(values[i]);
+        cmd_lens[3 + i] = Z_STRLEN(values[i]);
+    }
+
+    if (valkey_glide->is_in_batch_mode) {
+        int res = buffer_command_for_batch(valkey_glide,
+                                           JsonArrInsert,
+                                           cmd_args,
+                                           cmd_lens,
+                                           arg_count,
+                                           NULL,
+                                           process_json_mixed_result);
+        efree(cmd_args);
+        efree(cmd_lens);
+        if (res) {
+            ZVAL_COPY(return_value, object);
+            return 1;
+        }
+        return 0;
+    }
+
+    CommandResult* result =
+        execute_command(valkey_glide->glide_client, JsonArrInsert, arg_count, cmd_args, cmd_lens);
+    efree(cmd_args);
+    efree(cmd_lens);
+
+    if (result) {
+        if (result->command_error) {
+            zend_throw_exception(
+                get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+            free_command_result(result);
+            return 0;
+        }
+        if (result->response) {
+            if (command_response_to_zval(
+                    result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
+                free_command_result(result);
+                return 1;
+            }
+        }
+        free_command_result(result);
+    }
+    return 0;
+}
+
+/* ====================================================================
+ * JSON.ARRINDEX — key path scalar [start [end]]
+ * ==================================================================== */
+
+int execute_json_arrindex_command(zval*             object,
+                                  int               argc,
+                                  zval*             return_value,
+                                  zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    char*                key    = NULL;
+    char*                path   = NULL;
+    char*                scalar = NULL;
+    size_t               key_len, path_len, scalar_len;
+    zend_long            start     = 0;
+    zend_long            end       = 0;
+    zend_bool            has_start = 0;
+    zend_bool            has_end   = 0;
+
+    if (zend_parse_method_parameters(argc,
+                                     object,
+                                     "Osss|ll",
+                                     &object,
+                                     ce,
+                                     &key,
+                                     &key_len,
+                                     &path,
+                                     &path_len,
+                                     &scalar,
+                                     &scalar_len,
+                                     &start,
+                                     &end) == FAILURE) {
+        return 0;
+    }
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    /* Determine how many optional args were passed */
+    /* argc counts user-visible args (key, path, scalar, [start], [end]) */
+
+    char   start_buf[24], end_buf[24];
+    size_t start_len = 0, end_len = 0;
+
+    uintptr_t     cmd_args[5];
+    unsigned long cmd_lens[5];
+    unsigned long arg_count = 3;
+
+    cmd_args[0] = (uintptr_t) key;
+    cmd_lens[0] = key_len;
+    cmd_args[1] = (uintptr_t) path;
+    cmd_lens[1] = path_len;
+    cmd_args[2] = (uintptr_t) scalar;
+    cmd_lens[2] = scalar_len;
+
+    /* argc is ZEND_NUM_ARGS() passed from the macro */
+    if (argc > 3) {
+        start_len   = snprintf(start_buf, sizeof(start_buf), "%ld", (long) start);
+        cmd_args[3] = (uintptr_t) start_buf;
+        cmd_lens[3] = start_len;
+        arg_count   = 4;
+    }
+    if (argc > 4) {
+        end_len     = snprintf(end_buf, sizeof(end_buf), "%ld", (long) end);
+        cmd_args[4] = (uintptr_t) end_buf;
+        cmd_lens[4] = end_len;
+        arg_count   = 5;
+    }
+
+    if (valkey_glide->is_in_batch_mode) {
+        int res = buffer_command_for_batch(valkey_glide,
+                                           JsonArrIndex,
+                                           cmd_args,
+                                           cmd_lens,
+                                           arg_count,
+                                           NULL,
+                                           process_json_mixed_result);
+        if (res) {
+            ZVAL_COPY(return_value, object);
+            return 1;
+        }
+        return 0;
+    }
+
+    CommandResult* result =
+        execute_command(valkey_glide->glide_client, JsonArrIndex, arg_count, cmd_args, cmd_lens);
+
+    if (result) {
+        if (result->command_error) {
+            zend_throw_exception(
+                get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+            free_command_result(result);
+            return 0;
+        }
+        if (result->response) {
+            if (command_response_to_zval(
+                    result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
+                free_command_result(result);
+                return 1;
+            }
+        }
+        free_command_result(result);
+    }
+    return 0;
+}
+
+/* ====================================================================
+ * JSON.ARRPOP — key [path [index]]
+ * ==================================================================== */
+
+int execute_json_arrpop_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    char*                key  = NULL;
+    char*                path = NULL;
+    size_t               key_len, path_len = 0;
+    zend_long            index = 0;
+
+    if (zend_parse_method_parameters(
+            argc, object, "Os|sl", &object, ce, &key, &key_len, &path, &path_len, &index) ==
+        FAILURE) {
+        return 0;
+    }
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    char   idx_buf[24];
+    size_t idx_len = 0;
+
+    uintptr_t     cmd_args[3];
+    unsigned long cmd_lens[3];
+    unsigned long arg_count = 1;
+
+    cmd_args[0] = (uintptr_t) key;
+    cmd_lens[0] = key_len;
+
+    if (path && path_len > 0) {
+        cmd_args[1] = (uintptr_t) path;
+        cmd_lens[1] = path_len;
+        arg_count   = 2;
+
+        if (argc > 2) {
+            idx_len     = snprintf(idx_buf, sizeof(idx_buf), "%ld", (long) index);
+            cmd_args[2] = (uintptr_t) idx_buf;
+            cmd_lens[2] = idx_len;
+            arg_count   = 3;
+        }
+    }
+
+    if (valkey_glide->is_in_batch_mode) {
+        int res = buffer_command_for_batch(valkey_glide,
+                                           JsonArrPop,
+                                           cmd_args,
+                                           cmd_lens,
+                                           arg_count,
+                                           NULL,
+                                           process_json_mixed_result);
+        if (res) {
+            ZVAL_COPY(return_value, object);
+            return 1;
+        }
+        return 0;
+    }
+
+    CommandResult* result =
+        execute_command(valkey_glide->glide_client, JsonArrPop, arg_count, cmd_args, cmd_lens);
+
+    if (result) {
+        if (result->command_error) {
+            zend_throw_exception(
+                get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+            free_command_result(result);
+            return 0;
+        }
+        if (result->response) {
+            if (command_response_to_zval(
+                    result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
+                free_command_result(result);
+                return 1;
+            }
+        }
+        free_command_result(result);
+    }
+    return 0;
+}
+
+/* ====================================================================
+ * JSON.ARRTRIM — key path start end
+ * ==================================================================== */
+
+int execute_json_arrtrim_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    char*                key  = NULL;
+    char*                path = NULL;
+    size_t               key_len, path_len;
+    zend_long            start, end;
+
+    if (zend_parse_method_parameters(
+            argc, object, "Ossll", &object, ce, &key, &key_len, &path, &path_len, &start, &end) ==
+        FAILURE) {
+        return 0;
+    }
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    char   start_buf[24], end_buf[24];
+    size_t start_len = snprintf(start_buf, sizeof(start_buf), "%ld", (long) start);
+    size_t end_len   = snprintf(end_buf, sizeof(end_buf), "%ld", (long) end);
+
+    uintptr_t cmd_args[4] = {
+        (uintptr_t) key, (uintptr_t) path, (uintptr_t) start_buf, (uintptr_t) end_buf};
+    unsigned long cmd_lens[4] = {key_len, path_len, start_len, end_len};
+
+    if (valkey_glide->is_in_batch_mode) {
+        int res = buffer_command_for_batch(
+            valkey_glide, JsonArrTrim, cmd_args, cmd_lens, 4, NULL, process_json_mixed_result);
+        if (res) {
+            ZVAL_COPY(return_value, object);
+            return 1;
+        }
+        return 0;
+    }
+
+    CommandResult* result =
+        execute_command(valkey_glide->glide_client, JsonArrTrim, 4, cmd_args, cmd_lens);
+
+    if (result) {
+        if (result->command_error) {
+            zend_throw_exception(
+                get_valkey_glide_exception_ce(), result->command_error->command_error_message, 0);
+            free_command_result(result);
+            return 0;
+        }
+        if (result->response) {
+            if (command_response_to_zval(
+                    result->response, return_value, COMMAND_RESPONSE_NOT_ASSOSIATIVE, false)) {
+                free_command_result(result);
+                return 1;
+            }
+        }
+        free_command_result(result);
+    }
+    return 0;
+}

--- a/valkey_glide_json_common.c
+++ b/valkey_glide_json_common.c
@@ -189,33 +189,16 @@ int execute_json_get_command(zval* object, int argc, zval* return_value, zend_cl
     zval*                paths_param   = NULL;
     zval*                options_param = NULL;
 
-    /* Parse parameters: key, optional paths (string or array), optional options (array or object)
-     */
+    /* Parse parameters: key, optional paths (string or array), optional options array */
     if (zend_parse_method_parameters(
-            argc, object, "Os|zz!", &object, ce, &key, &key_len, &paths_param, &options_param) ==
+            argc, object, "Os|za!", &object, ce, &key, &key_len, &paths_param, &options_param) ==
         FAILURE) {
         return 0;
     }
 
-    /* If options is an object with toArray(), call it to get the array */
-    zval options_arr;
-    ZVAL_UNDEF(&options_arr);
-    if (options_param && Z_TYPE_P(options_param) == IS_OBJECT) {
-        zval func_name;
-        ZVAL_STRING(&func_name, "toArray");
-        if (call_user_function(NULL, options_param, &func_name, &options_arr, 0, NULL) == SUCCESS &&
-            Z_TYPE(options_arr) == IS_ARRAY) {
-            options_param = &options_arr;
-        }
-        zval_ptr_dtor(&func_name);
-    }
-
-#define CLEANUP_OPTIONS_ARR() zval_ptr_dtor(&options_arr)
-
     /* Get ValkeyGlide object */
     valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
     if (!valkey_glide || !valkey_glide->glide_client) {
-        CLEANUP_OPTIONS_ARR();
         return 0;
     }
 
@@ -266,7 +249,6 @@ int execute_json_get_command(zval* object, int argc, zval* return_value, zend_cl
         use_array_paths = 1;
     } else {
         php_error_docref(NULL, E_WARNING, "jsonGet expects paths as string or array");
-        CLEANUP_OPTIONS_ARR();
         return 0;
     }
 
@@ -335,7 +317,6 @@ int execute_json_get_command(zval* object, int argc, zval* return_value, zend_cl
                                            process_json_get_result);
         efree(cmd_args);
         efree(cmd_args_len);
-        CLEANUP_OPTIONS_ARR();
         if (res) {
             ZVAL_COPY(return_value, object);
             return 1;
@@ -349,8 +330,6 @@ int execute_json_get_command(zval* object, int argc, zval* return_value, zend_cl
 
     efree(cmd_args);
     efree(cmd_args_len);
-    CLEANUP_OPTIONS_ARR();
-#undef CLEANUP_OPTIONS_ARR
 
     if (result) {
         if (result->command_error) {

--- a/valkey_glide_json_common.h
+++ b/valkey_glide_json_common.h
@@ -25,37 +25,96 @@
 
 int execute_json_set_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_json_get_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_json_del_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_json_forget_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_json_clear_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_json_mget_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_json_type_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_json_numincrby_command(zval*             object,
+                                   int               argc,
+                                   zval*             return_value,
+                                   zend_class_entry* ce);
+int execute_json_nummultby_command(zval*             object,
+                                   int               argc,
+                                   zval*             return_value,
+                                   zend_class_entry* ce);
+int execute_json_toggle_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_json_strappend_command(zval*             object,
+                                   int               argc,
+                                   zval*             return_value,
+                                   zend_class_entry* ce);
+int execute_json_strlen_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_json_objlen_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_json_objkeys_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_json_resp_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_json_debug_memory_command(zval*             object,
+                                      int               argc,
+                                      zval*             return_value,
+                                      zend_class_entry* ce);
+int execute_json_debug_fields_command(zval*             object,
+                                      int               argc,
+                                      zval*             return_value,
+                                      zend_class_entry* ce);
+int execute_json_arrappend_command(zval*             object,
+                                   int               argc,
+                                   zval*             return_value,
+                                   zend_class_entry* ce);
+int execute_json_arrinsert_command(zval*             object,
+                                   int               argc,
+                                   zval*             return_value,
+                                   zend_class_entry* ce);
+int execute_json_arrindex_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_json_arrpop_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_json_arrtrim_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_json_arrlen_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 
 /* ====================================================================
  * JSON METHOD MACROS
  * ==================================================================== */
 
-#define JSON_SET_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, jsonSet) {                                               \
-        if (execute_json_set_command(getThis(),                                     \
-                                     ZEND_NUM_ARGS(),                               \
-                                     return_value,                                  \
-                                     strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                         ? get_valkey_glide_cluster_ce()            \
-                                         : get_valkey_glide_ce())) {                \
-            return;                                                                 \
-        }                                                                           \
-        zval_dtor(return_value);                                                    \
-        RETURN_FALSE;                                                               \
+#define JSON_METHOD_CE(class_name)                                                  \
+    (strcmp(#class_name, "ValkeyGlideCluster") == 0 ? get_valkey_glide_cluster_ce() \
+                                                    : get_valkey_glide_ce())
+
+#define JSON_METHOD_IMPL(class_name, method_name, execute_fn)                                   \
+    PHP_METHOD(class_name, method_name) {                                                       \
+        if (execute_fn(getThis(), ZEND_NUM_ARGS(), return_value, JSON_METHOD_CE(class_name))) { \
+            return;                                                                             \
+        }                                                                                       \
+        zval_dtor(return_value);                                                                \
+        RETURN_FALSE;                                                                           \
     }
 
-#define JSON_GET_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, jsonGet) {                                               \
-        if (execute_json_get_command(getThis(),                                     \
-                                     ZEND_NUM_ARGS(),                               \
-                                     return_value,                                  \
-                                     strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                         ? get_valkey_glide_cluster_ce()            \
-                                         : get_valkey_glide_ce())) {                \
-            return;                                                                 \
-        }                                                                           \
-        zval_dtor(return_value);                                                    \
-        RETURN_FALSE;                                                               \
-    }
+#define JSON_SET_METHOD_IMPL(cn) JSON_METHOD_IMPL(cn, jsonSet, execute_json_set_command)
+#define JSON_GET_METHOD_IMPL(cn) JSON_METHOD_IMPL(cn, jsonGet, execute_json_get_command)
+#define JSON_DEL_METHOD_IMPL(cn) JSON_METHOD_IMPL(cn, jsonDel, execute_json_del_command)
+#define JSON_FORGET_METHOD_IMPL(cn) JSON_METHOD_IMPL(cn, jsonForget, execute_json_forget_command)
+#define JSON_CLEAR_METHOD_IMPL(cn) JSON_METHOD_IMPL(cn, jsonClear, execute_json_clear_command)
+#define JSON_MGET_METHOD_IMPL(cn) JSON_METHOD_IMPL(cn, jsonMGet, execute_json_mget_command)
+#define JSON_TYPE_METHOD_IMPL(cn) JSON_METHOD_IMPL(cn, jsonType, execute_json_type_command)
+#define JSON_NUMINCRBY_METHOD_IMPL(cn) \
+    JSON_METHOD_IMPL(cn, jsonNumIncrBy, execute_json_numincrby_command)
+#define JSON_NUMMULTBY_METHOD_IMPL(cn) \
+    JSON_METHOD_IMPL(cn, jsonNumMultBy, execute_json_nummultby_command)
+#define JSON_TOGGLE_METHOD_IMPL(cn) JSON_METHOD_IMPL(cn, jsonToggle, execute_json_toggle_command)
+#define JSON_STRAPPEND_METHOD_IMPL(cn) \
+    JSON_METHOD_IMPL(cn, jsonStrAppend, execute_json_strappend_command)
+#define JSON_STRLEN_METHOD_IMPL(cn) JSON_METHOD_IMPL(cn, jsonStrLen, execute_json_strlen_command)
+#define JSON_OBJLEN_METHOD_IMPL(cn) JSON_METHOD_IMPL(cn, jsonObjLen, execute_json_objlen_command)
+#define JSON_OBJKEYS_METHOD_IMPL(cn) JSON_METHOD_IMPL(cn, jsonObjKeys, execute_json_objkeys_command)
+#define JSON_RESP_METHOD_IMPL(cn) JSON_METHOD_IMPL(cn, jsonResp, execute_json_resp_command)
+#define JSON_DEBUG_MEMORY_METHOD_IMPL(cn) \
+    JSON_METHOD_IMPL(cn, jsonDebugMemory, execute_json_debug_memory_command)
+#define JSON_DEBUG_FIELDS_METHOD_IMPL(cn) \
+    JSON_METHOD_IMPL(cn, jsonDebugFields, execute_json_debug_fields_command)
+#define JSON_ARRAPPEND_METHOD_IMPL(cn) \
+    JSON_METHOD_IMPL(cn, jsonArrAppend, execute_json_arrappend_command)
+#define JSON_ARRINSERT_METHOD_IMPL(cn) \
+    JSON_METHOD_IMPL(cn, jsonArrInsert, execute_json_arrinsert_command)
+#define JSON_ARRINDEX_METHOD_IMPL(cn) \
+    JSON_METHOD_IMPL(cn, jsonArrIndex, execute_json_arrindex_command)
+#define JSON_ARRPOP_METHOD_IMPL(cn) JSON_METHOD_IMPL(cn, jsonArrPop, execute_json_arrpop_command)
+#define JSON_ARRTRIM_METHOD_IMPL(cn) JSON_METHOD_IMPL(cn, jsonArrTrim, execute_json_arrtrim_command)
+#define JSON_ARRLEN_METHOD_IMPL(cn) JSON_METHOD_IMPL(cn, jsonArrLen, execute_json_arrlen_command)
 
 #endif /* VALKEY_GLIDE_JSON_COMMON_H */

--- a/valkey_z_php_methods.c
+++ b/valkey_z_php_methods.c
@@ -863,24 +863,88 @@ JSON_SET_METHOD_IMPL(ValkeyGlide)
 JSON_GET_METHOD_IMPL(ValkeyGlide)
 /* }}} */
 
+/* {{{ proto int ValkeyGlide::jsonDel(string key [, string path]) */
 JSON_DEL_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto int ValkeyGlide::jsonForget(string key [, string path]) */
 JSON_FORGET_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto int ValkeyGlide::jsonClear(string key [, string path]) */
 JSON_CLEAR_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto array ValkeyGlide::jsonMGet(array keys, string path) */
 JSON_MGET_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlide::jsonType(string key [, string path]) */
 JSON_TYPE_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto string ValkeyGlide::jsonNumIncrBy(string key, string path, float number) */
 JSON_NUMINCRBY_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto string ValkeyGlide::jsonNumMultBy(string key, string path, float number) */
 JSON_NUMMULTBY_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlide::jsonToggle(string key [, string path]) */
 JSON_TOGGLE_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlide::jsonStrAppend(string key, string pathOrValue [, string value]) */
 JSON_STRAPPEND_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlide::jsonStrLen(string key [, string path]) */
 JSON_STRLEN_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlide::jsonObjLen(string key [, string path]) */
 JSON_OBJLEN_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlide::jsonObjKeys(string key [, string path]) */
 JSON_OBJKEYS_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlide::jsonResp(string key [, string path]) */
 JSON_RESP_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlide::jsonDebugMemory(string key [, string path]) */
 JSON_DEBUG_MEMORY_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlide::jsonDebugFields(string key [, string path]) */
 JSON_DEBUG_FIELDS_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlide::jsonArrAppend(string key, string path, string ...values) */
 JSON_ARRAPPEND_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlide::jsonArrInsert(string key, string path, int index, string ...values)
+ */
 JSON_ARRINSERT_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlide::jsonArrIndex(string key, string path, string scalar [, int start [,
+ * int end]]) */
 JSON_ARRINDEX_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlide::jsonArrPop(string key [, string path [, int index]]) */
 JSON_ARRPOP_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlide::jsonArrTrim(string key, string path, int start, int end) */
 JSON_ARRTRIM_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto mixed ValkeyGlide::jsonArrLen(string key [, string path]) */
 JSON_ARRLEN_METHOD_IMPL(ValkeyGlide)
+/* }}} */

--- a/valkey_z_php_methods.c
+++ b/valkey_z_php_methods.c
@@ -858,6 +858,29 @@ GETOPTION_METHOD_IMPL(ValkeyGlide)
 JSON_SET_METHOD_IMPL(ValkeyGlide)
 /* }}} */
 
-/* {{{ proto string ValkeyGlide::jsonGet(string key [, string|array paths]) */
+/* {{{ proto string ValkeyGlide::jsonGet(string key [, string|array paths [, array|object options]])
+ */
 JSON_GET_METHOD_IMPL(ValkeyGlide)
 /* }}} */
+
+JSON_DEL_METHOD_IMPL(ValkeyGlide)
+JSON_FORGET_METHOD_IMPL(ValkeyGlide)
+JSON_CLEAR_METHOD_IMPL(ValkeyGlide)
+JSON_MGET_METHOD_IMPL(ValkeyGlide)
+JSON_TYPE_METHOD_IMPL(ValkeyGlide)
+JSON_NUMINCRBY_METHOD_IMPL(ValkeyGlide)
+JSON_NUMMULTBY_METHOD_IMPL(ValkeyGlide)
+JSON_TOGGLE_METHOD_IMPL(ValkeyGlide)
+JSON_STRAPPEND_METHOD_IMPL(ValkeyGlide)
+JSON_STRLEN_METHOD_IMPL(ValkeyGlide)
+JSON_OBJLEN_METHOD_IMPL(ValkeyGlide)
+JSON_OBJKEYS_METHOD_IMPL(ValkeyGlide)
+JSON_RESP_METHOD_IMPL(ValkeyGlide)
+JSON_DEBUG_MEMORY_METHOD_IMPL(ValkeyGlide)
+JSON_DEBUG_FIELDS_METHOD_IMPL(ValkeyGlide)
+JSON_ARRAPPEND_METHOD_IMPL(ValkeyGlide)
+JSON_ARRINSERT_METHOD_IMPL(ValkeyGlide)
+JSON_ARRINDEX_METHOD_IMPL(ValkeyGlide)
+JSON_ARRPOP_METHOD_IMPL(ValkeyGlide)
+JSON_ARRTRIM_METHOD_IMPL(ValkeyGlide)
+JSON_ARRLEN_METHOD_IMPL(ValkeyGlide)


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

Adds all remaining JSON module commands for both standalone (ValkeyGlide) and cluster (ValkeyGlideCluster) clients. This is a follow-up to PR #184 which added jsonSet and jsonGet.

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide-php/issues/183

### Features / Behaviour Changes

21 new JSON commands:

| Category | Commands |
|---|---|
| Document | jsonDel, jsonForget, jsonClear, jsonMGet, jsonType |
| Numeric | jsonNumIncrBy, jsonNumMultBy |
| Boolean | jsonToggle |
| String | jsonStrAppend, jsonStrLen |
| Object | jsonObjLen, jsonObjKeys |
| Array | jsonArrAppend, jsonArrInsert, jsonArrIndex, jsonArrLen, jsonArrPop, jsonArrTrim |
| Debug | jsonDebugMemory, jsonDebugFields |
| Other | jsonResp |

### Implementation

Follows the pattern established in PR #184:
- Shared C implementation in valkey_glide_json_common.c / .h using a generic execute_json_key_path_command helper for commands with the common key [path] signature
- Refactored header macros to a single JSON_METHOD_IMPL(class_name, method_name, execute_fn) macro
- Method macros invoked in valkey_z_php_methods.c (standalone) and valkey_glide_cluster.c (cluster)
- Full PHPDoc blocks for all commands in valkey_glide.stub.php
- Proto documentation in both .c files
- Uses existing FFI request types 
- All commands support batch mode via buffer_command_for_batch

### Testing

Tested locally against valkey/valkey-bundle:latest Docker container.
```
DEBUG: valkey_version found: 9.0.3
DEBUG: redis_version found: 7.2.4
Connected to Valkey server version: 9.0.3
[PASSED]
testJsonSetWithPath       [PASSED]
testJsonSetNX             [PASSED]
testJsonSetXX             [PASSED]
testJsonGetNonExistingKey [PASSED]
testJsonGetMultiplePaths  [PASSED]
testJsonGetSinglePath     [PASSED]
testJsonSetNestedObject   [PASSED]
testJsonSetInvalidJson    Error executing command: SYNTAXERR: Failed to parse JSON string due to syntax error
[PASSED]
testJsonGetWithOptions    [PASSED]
testJsonGetInvalidPath    Error executing command: NONEXISTENT: JSON path does not exist
[PASSED]
testJsonSetOnWrongKeyType Error executing command: WRONGTYPE: Not a JSON document key
[PASSED]
testJsonDel               [PASSED]
testJsonForget            [PASSED]
testJsonClear             [PASSED]
testJsonMGet              [PASSED]
testJsonType              [PASSED]
testJsonNumIncrBy         [PASSED]
testJsonNumMultBy         [PASSED]
testJsonToggle            [PASSED]
testJsonStrAppend         [PASSED]
testJsonStrLen            [PASSED]
testJsonObjLen            [PASSED]
testJsonObjKeys           [PASSED]
testJsonArrAppend         [PASSED]
testJsonArrInsert         [PASSED]
testJsonArrIndex          [PASSED]
testJsonArrLen            [PASSED]
testJsonArrPop            [PASSED]
testJsonArrTrim           [PASSED]
testJsonResp              [PASSED]
testJsonDebugMemory       [PASSED]
testJsonDebugFields       [PASSED]


========================
Test Summary
Passed: 33
Failed: 0
Skipped: 0
Total: 33
========================

All tests passed. \o/
 - Completed in 3.60s
```
### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
