### PR TITLE
PHP: Add artifact signing

### DIFF
--- a/.github/workflows/publish-pecl.yml
+++ b/.github/workflows/publish-pecl.yml
@@ -2,6 +2,8 @@ name: Build and publish extension packages
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 on:
   release:
@@ -351,3 +353,9 @@ jobs:
           asset_path: ${{ steps.build-package.outputs.package-file }}
           asset_name: ${{ steps.build-package.outputs.package-file }}
           asset_content_type: application/gzip
+
+      - name: Attest package provenance
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.create-release == 'true')
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ steps.build-package.outputs.package-file }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* PHP: Pin all third-party GitHub Actions to SHA commit hashes to mitigate supply chain attacks (CWE-829)
 * PHP: Add FT.* (Vector Search) commands: ftCreate, ftDropIndex, ftList, ftSearch, ftAggregate, ftInfo, ftAliasAdd, ftAliasDel, ftAliasUpdate, ftAliasList for standalone and cluster clients ([#171](https://github.com/valkey-io/valkey-glide-php/pull/171))
 * PHP: Add JSON.SET and JSON.GET commands for standalone and cluster clients ([#184](https://github.com/valkey-io/valkey-glide-php/pull/184))
 * PHP: Add transparent compression support for string values ([#186](https://github.com/valkey-io/valkey-glide-php/pull/186))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-* PHP: Pin all third-party GitHub Actions to SHA commit hashes to mitigate supply chain attacks (CWE-829)
+* PHP: Add Sigstore-based artifact attestation for published PECL packages
 * PHP: Add FT.* (Vector Search) commands: ftCreate, ftDropIndex, ftList, ftSearch, ftAggregate, ftInfo, ftAliasAdd, ftAliasDel, ftAliasUpdate, ftAliasList for standalone and cluster clients ([#171](https://github.com/valkey-io/valkey-glide-php/pull/171))
 * PHP: Add JSON.SET and JSON.GET commands for standalone and cluster clients ([#184](https://github.com/valkey-io/valkey-glide-php/pull/184))
 * PHP: Add transparent compression support for string values ([#186](https://github.com/valkey-io/valkey-glide-php/pull/186))


### PR DESCRIPTION
### Summary

Add cryptographic artifact signing for published PECL packages using GitHub's built-in Sigstore-based attestation to enable integrity and provenance verification.

### Issue link

This Pull Request is linked to issue (URL): No issue

### Features / Behaviour Changes

Published release artifacts now have a Sigstore provenance attestation attached. Users can verify package authenticity with:
```
bash
gh attestation verify valkey_glide-<version>.tgz --owner valkey-io
```
No changes to existing build or publish behavior.

### Implementation

- Added id-token: write and attestations: write permissions to the workflow (required for Sigstore OIDC token and attestation storage)
- Added actions/attest-build-provenance@v2 step after the release asset upload, which generates a signed provenance statement binding the artifact to this repo, workflow, and commit



### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue - no issue
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
