### PR TITLE
Adding reusable test and nightly FMT

### DIFF
--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -6,7 +6,7 @@
     "ARCH": "x64",
     "TARGET": "x86_64-unknown-linux-gnu",
     "run": "always",
-    "languages": ["python", "node", "java", "go", "dotnet", "rust", "php"],
+    "languages": ["php"],
     "profiles": ["full"]
   },
   {
@@ -15,7 +15,7 @@
     "RUNNER": ["self-hosted", "Linux", "ARM64", "ephemeral"],
     "ARCH": "arm64",
     "TARGET": "aarch64-unknown-linux-gnu",
-    "languages": ["python", "node", "java", "go", "dotnet", "php"],
+    "languages": ["php"],
     "profiles": ["full"]
   },
   {
@@ -24,7 +24,7 @@
     "RUNNER": "macos-15",
     "ARCH": "arm64",
     "TARGET": "aarch64-apple-darwin",
-    "languages": ["python", "node", "java", "go", "dotnet", "php"],
+    "languages": ["php"],
     "profiles": []
   },
   {
@@ -38,35 +38,12 @@
     "comment": "Tests for all clients (CI) are skipped for that platform due to instability, but CD pipelines still run on it. See PR #3482 for details."
   },
   {
-    "OS": "ubuntu",
-    "NAMED_OS": "linux",
-    "ARCH": "arm64",
-    "TARGET": "aarch64-unknown-linux-musl",
-    "RUNNER": ["self-hosted", "Linux", "ARM64", "ephemeral"],
-    "IMAGE": "node:lts-alpine",
-    "CONTAINER_OPTIONS": "--user root --privileged --rm",
-    "languages": [],
-    "profiles": []
-  },
-  {
-    "OS": "ubuntu",
-    "NAMED_OS": "linux",
-    "ARCH": "x64",
-    "TARGET": "x86_64-unknown-linux-musl",
-    "RUNNER": "ubuntu-latest",
-    "IMAGE": "node:lts-alpine",
-    "CONTAINER_OPTIONS": "--user root --privileged",
-    "languages": ["node"],
-    "profiles": []
-  },
-  {
     "OS": "amazon-linux",
     "NAMED_OS": "linux",
     "RUNNER": "ubuntu-latest",
     "ARCH": "x64",
     "TARGET": "x86_64-unknown-linux-gnu",
     "IMAGE": "amazonlinux:latest",
-    "languages": ["python", "node", "java", "go", "dotnet"],
     "profiles": []
   }
 ]

--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -5,19 +5,18 @@
     "RUNNER": "ubuntu-24.04",
     "ARCH": "x64",
     "TARGET": "x86_64-unknown-linux-gnu",
-    "PACKAGE_MANAGERS": ["pypi", "npm", "maven", "pkg_go_dev"],
     "run": "always",
-    "languages": ["python", "node", "java", "go", "dotnet", "rust", "php"]
+    "languages": ["python", "node", "java", "go", "dotnet", "rust", "php"],
+    "profiles": ["full"]
   },
   {
     "OS": "ubuntu",
     "NAMED_OS": "linux",
     "RUNNER": ["self-hosted", "Linux", "ARM64", "ephemeral"],
-    "CD_RUNNER": "ubuntu-24.04-arm",
     "ARCH": "arm64",
     "TARGET": "aarch64-unknown-linux-gnu",
-    "PACKAGE_MANAGERS": ["pypi", "npm", "maven", "pkg_go_dev"],
-    "languages": ["python", "node", "java", "go", "dotnet", "php"]
+    "languages": ["python", "node", "java", "go", "dotnet", "php"],
+    "profiles": ["full"]
   },
   {
     "OS": "macos",
@@ -25,18 +24,17 @@
     "RUNNER": "macos-15",
     "ARCH": "arm64",
     "TARGET": "aarch64-apple-darwin",
-    "PACKAGE_MANAGERS": ["pypi", "npm", "maven", "pkg_go_dev"],
-    "languages": ["python", "node", "java", "go", "dotnet", "php"]
+    "languages": ["python", "node", "java", "go", "dotnet", "php"],
+    "profiles": ["full"]
   },
   {
     "OS": "macos",
     "NAMED_OS": "darwin",
     "RUNNER": "macos-13",
-    "CD_RUNNER": "macos-15",
     "ARCH": "x64",
     "TARGET": "x86_64-apple-darwin",
-    "PACKAGE_MANAGERS": ["pypi", "npm", "maven", "pkg_go_dev"],
     "languages": [],
+    "profiles": [],
     "comment": "Tests for all clients (CI) are skipped for that platform due to instability, but CD pipelines still run on it. See PR #3482 for details."
   },
   {
@@ -45,11 +43,10 @@
     "ARCH": "arm64",
     "TARGET": "aarch64-unknown-linux-musl",
     "RUNNER": ["self-hosted", "Linux", "ARM64", "ephemeral"],
-    "CD_RUNNER": "ubuntu-24.04-arm",
     "IMAGE": "node:lts-alpine",
     "CONTAINER_OPTIONS": "--user root --privileged --rm",
-    "PACKAGE_MANAGERS": ["npm"],
-    "languages": []
+    "languages": [],
+    "profiles": []
   },
   {
     "OS": "ubuntu",
@@ -59,8 +56,8 @@
     "RUNNER": "ubuntu-latest",
     "IMAGE": "node:lts-alpine",
     "CONTAINER_OPTIONS": "--user root --privileged",
-    "PACKAGE_MANAGERS": ["npm"],
-    "languages": ["node"]
+    "languages": ["node"],
+    "profiles": []
   },
   {
     "OS": "amazon-linux",
@@ -69,7 +66,7 @@
     "ARCH": "x64",
     "TARGET": "x86_64-unknown-linux-gnu",
     "IMAGE": "amazonlinux:latest",
-    "PACKAGE_MANAGERS": [],
-    "languages": ["python", "node", "java", "go", "dotnet"]
+    "languages": ["python", "node", "java", "go", "dotnet"],
+    "profiles": []
   }
 ]

--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -25,7 +25,7 @@
     "ARCH": "arm64",
     "TARGET": "aarch64-apple-darwin",
     "languages": ["python", "node", "java", "go", "dotnet", "php"],
-    "profiles": ["full"]
+    "profiles": []
   },
   {
     "OS": "macos",

--- a/.github/json_matrices/engine-matrix.json
+++ b/.github/json_matrices/engine-matrix.json
@@ -2,18 +2,22 @@
   {
     "type": "valkey",
     "version": "9.0",
-    "run": "always"
+    "run": "always",
+    "profiles": ["full"]
   },
   {
     "type": "valkey",
-    "version": "8.1"
+    "version": "8.1",
+    "profiles": ["full"]
   },
   {
     "type": "valkey",
-    "version": "8.0"
+    "version": "8.0",
+    "profiles": ["full"]
   },
   {
     "type": "valkey",
-    "version": "7.2"
+    "version": "7.2",
+    "profiles": ["full"]
   }
 ]

--- a/.github/json_matrices/load_matrices.py
+++ b/.github/json_matrices/load_matrices.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+def load_json(filename: str) -> list | dict:
+    return json.loads(Path(filename).read_text())
+
+PROFILES = load_json("profiles.json")
+
+def filter_by_profile(entries: list, profile: str) -> list:
+    return [e for e in entries if profile in e.get("profiles", [])]
+
+def main() -> None:
+    if len(sys.argv) != 2 or sys.argv[1] not in PROFILES:
+        print(f"Usage: {sys.argv[0]} <{'|'.join(PROFILES)}>", file=sys.stderr)
+        sys.exit(1)
+
+    profile = sys.argv[1]
+
+    build_matrix = filter_by_profile(load_json("build-matrix.json"), profile)
+    host = [h for h in build_matrix if "IMAGE" not in h]
+    container_host = [h for h in build_matrix if "IMAGE" in h]
+
+    engine = filter_by_profile(load_json("engine-matrix.json"), profile)
+    assert engine, "Given profile resulted in empty engine matrix."
+
+    lang_versions = load_json("supported-languages-versions.json")
+    php_entry = next(e for e in lang_versions if e["language"] == "php")
+    php = [e["version"] for e in filter_by_profile(php_entry["versioned"], profile)]
+    assert php, "Given profile resulted in empty php version matrix."
+
+    configs = {
+        "host-matrix": json.dumps(host),
+        "container-host-matrix": json.dumps(container_host),
+        "engine-matrix": json.dumps(engine),
+        "php-matrix": json.dumps(php),
+    }
+
+    print(f"Loaded matrices for profile '{profile}':")
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as f:
+            for key, value in configs.items():
+                print(f"{key}={value}", file=f)
+    else:
+        for key, value in configs.items():
+            print(f"{key}={value}")
+
+if __name__ == "__main__":
+    main()

--- a/.github/json_matrices/profiles.json
+++ b/.github/json_matrices/profiles.json
@@ -1,0 +1,5 @@
+{
+  "test": {},
+  "standard": {},
+  "full": {}
+}

--- a/.github/json_matrices/profiles.json
+++ b/.github/json_matrices/profiles.json
@@ -1,5 +1,3 @@
 {
-  "test": {},
-  "standard": {},
   "full": {}
 }

--- a/.github/json_matrices/supported-languages-versions.json
+++ b/.github/json_matrices/supported-languages-versions.json
@@ -2,6 +2,10 @@
   {
     "language": "php",
     "versions": ["8.2", "8.3"],
-    "always-run-versions": ["8.2", "8.3"]
+    "always-run-versions": ["8.2", "8.3"],
+    "versioned": [
+      { "version": "8.2", "profiles": ["full"] },
+      { "version": "8.3", "profiles": ["full"] }
+    ]
   }
 ]

--- a/.github/workflows/build-php-wrapper/action.yml
+++ b/.github/workflows/build-php-wrapper/action.yml
@@ -25,7 +25,7 @@ runs:
       with:
         php-version: ${{ inputs.php-version }}
         extensions: tokenizer, json, ctype, iconv, mbstring
-        tools: none
+        tools: composer
       env:
         runner: self-hosted
 
@@ -56,7 +56,7 @@ runs:
       if: ${{ inputs.os == 'macos' }}
       shell: bash
       run: |
-        brew install autoconf automake libtool pkg-config protobuf@3 openssl clang-format
+        brew install autoconf automake libtool pkg-config protobuf openssl clang-format
 
     - name: Install protobuf compiler (Ubuntu)
       if: ${{ inputs.os == 'ubuntu' }}
@@ -77,7 +77,7 @@ runs:
       if: ${{ inputs.os == 'macos' }}
       shell: bash
       run: |
-        echo 'export PATH="/opt/homebrew/opt/protobuf@3/bin:$PATH"' >> $GITHUB_ENV
+        echo 'export PATH="/opt/homebrew/opt/protobuf/bin:$PATH"' >> $GITHUB_ENV
         # Install protobuf-c
         brew install protobuf-c
 
@@ -111,6 +111,7 @@ runs:
         fi
 
     - name: Install zig
+      if: ${{ inputs.os != 'macos' }}
       uses: ./.github/workflows/install-zig
 
     - name: Setup sccache

--- a/.github/workflows/build-php-wrapper/action.yml
+++ b/.github/workflows/build-php-wrapper/action.yml
@@ -25,7 +25,7 @@ runs:
       with:
         php-version: ${{ inputs.php-version }}
         extensions: tokenizer, json, ctype, iconv, mbstring
-        tools: composer
+        tools: none
       env:
         runner: self-hosted
 
@@ -56,7 +56,7 @@ runs:
       if: ${{ inputs.os == 'macos' }}
       shell: bash
       run: |
-        brew install autoconf automake libtool pkg-config protobuf openssl clang-format
+        brew install autoconf automake libtool pkg-config protobuf@3 openssl clang-format
 
     - name: Install protobuf compiler (Ubuntu)
       if: ${{ inputs.os == 'ubuntu' }}
@@ -77,7 +77,7 @@ runs:
       if: ${{ inputs.os == 'macos' }}
       shell: bash
       run: |
-        echo 'export PATH="/opt/homebrew/opt/protobuf/bin:$PATH"' >> $GITHUB_ENV
+        echo 'export PATH="/opt/homebrew/opt/protobuf@3/bin:$PATH"' >> $GITHUB_ENV
         # Install protobuf-c
         brew install protobuf-c
 
@@ -111,7 +111,6 @@ runs:
         fi
 
     - name: Install zig
-      if: ${{ inputs.os != 'macos' }}
       uses: ./.github/workflows/install-zig
 
     - name: Setup sccache

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,13 +4,6 @@ on:
   schedule:
     - cron: "0 9 * * *" # 9:00 UTC Everyday
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,23 @@
+name: PHP Full Matrix Tests (Nightly)
+
+on:
+  schedule:
+    - cron: "0 9 * * *" # 9:00 UTC Everyday
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  full-matrix-tests:
+    uses: ./.github/workflows/test.yml
+    with:
+      profile: full
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         run: python3 load_matrices.py "$PROFILE"
 
   test-with-runners:
-    name: PHP ${{ matrix.php }}, server ${{ matrix.engine.version }}, ${{ matrix.host.TARGET }}
+    name: PHP ${{ matrix.php }}, ${{ matrix.engine.type }} ${{ matrix.engine.version }}, ${{ matrix.host.TARGET }}
     needs: load-matrix
     timeout-minutes: 35
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
     runs-on: ${{ matrix.host.RUNNER }}
     container:
       image: ${{ matrix.host.IMAGE }}
-      options: ${{ join(' -q ', matrix.host.CONTAINER_OPTIONS) }}
+      options: ${{ matrix.host.CONTAINER_OPTIONS }}
     steps:
       - name: Install git and dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,160 @@
+name: Reusable Test Workflow
+
+on:
+  workflow_call:
+    inputs:
+      profile:
+        required: true
+        type: string
+        description: "Test profile (test/standard/full)"
+  workflow_dispatch:
+    inputs:
+      profile:
+        required: true
+        type: string
+        description: "Test profile (test/standard/full)"
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  load-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      host-matrix: ${{ steps.load.outputs.host-matrix }}
+      container-host-matrix: ${{ steps.load.outputs.container-host-matrix }}
+      engine-matrix: ${{ steps.load.outputs.engine-matrix }}
+      php-matrix: ${{ steps.load.outputs.php-matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/json_matrices
+      - name: Load and filter matrices
+        id: load
+        working-directory: .github/json_matrices
+        env:
+          PROFILE: ${{ inputs.profile }}
+        run: python3 load_matrices.py "$PROFILE"
+
+  test-with-runners:
+    name: PHP ${{ matrix.php }}, server ${{ matrix.engine.version }}, ${{ matrix.host.TARGET }}
+    needs: load-matrix
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ${{ fromJson(needs.load-matrix.outputs.php-matrix) }}
+        engine: ${{ fromJson(needs.load-matrix.outputs.engine-matrix) }}
+        host: ${{ fromJson(needs.load-matrix.outputs.host-matrix) }}
+    runs-on: ${{ matrix.host.RUNNER }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Output matrix parameters
+        run: |
+          echo "Job running with the following matrix configuration:"
+          echo "${{ toJson(matrix) }}"
+      - name: Build PHP wrapper
+        uses: ./.github/workflows/build-php-wrapper
+        with:
+          os: ${{ matrix.host.OS }}
+          target: ${{ matrix.host.TARGET }}
+          php-version: ${{ matrix.php }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          engine-version: ${{ matrix.engine.version }}
+      - name: Generate test protobuf PHP classes
+        run: |
+          protoc --proto_path=./valkey-glide/glide-core/src/protobuf --php_out=./tests/ ./valkey-glide/glide-core/src/protobuf/connection_request.proto
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+      - name: Run PHP Extension Tests
+        uses: ./.github/workflows/run-php-tests
+        with:
+          extension-path: ${{ github.workspace }}/modules/valkey_glide.so
+          php-version: ${{ matrix.php }}
+      - name: Upload test reports
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-php-${{ matrix.php }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.OS }}-${{ matrix.host.ARCH }}
+          path: |
+            utils/clusters/**
+            tests/**/*.diff
+            tests/**/*.exp
+            tests/**/*.log
+            tests/**/*.out
+
+  test-with-containers:
+    name: PHP ${{ matrix.php }}, server ${{ matrix.engine.version }}, ${{ matrix.host.IMAGE }}
+    needs: load-matrix
+    if: false
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ${{ fromJson(needs.load-matrix.outputs.php-matrix) }}
+        engine: ${{ fromJson(needs.load-matrix.outputs.engine-matrix) }}
+        host: ${{ fromJson(needs.load-matrix.outputs.container-host-matrix) }}
+    runs-on: ${{ matrix.host.RUNNER }}
+    container:
+      image: ${{ matrix.host.IMAGE }}
+      options: ${{ join(' -q ', matrix.host.CONTAINER_OPTIONS) }}
+    steps:
+      - name: Install git and dependencies
+        run: |
+          yum update
+          yum install -y git tar php php-devel gcc make autoconf automake libtool pkgconfig openssl openssl-devel unzip
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          echo IMAGE=${{ matrix.host.IMAGE }} | sed -r 's/:/-/g' >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/cache@v4
+        with:
+          path: |
+            valkey-glide/ffi/target
+            valkey-glide/glide-core/src/generated
+            include/
+          key: ${{ matrix.host.IMAGE }}-php-${{ matrix.php }}
+          restore-keys: ${{ matrix.host.IMAGE }}-php
+      - name: Build PHP wrapper
+        uses: ./.github/workflows/build-php-wrapper
+        with:
+          os: ${{ matrix.host.OS }}
+          target: ${{ matrix.host.TARGET }}
+          php-version: ${{ matrix.php }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          engine-version: ${{ matrix.engine.version }}
+      - name: Start Valkey servers
+        working-directory: tests
+        run: |
+          export PATH="/usr/local/bin:$PATH"
+          chmod +x start_valkey_with_replicas.sh create-valkey-cluster.sh
+          ./start_valkey_with_replicas.sh
+          sleep 3
+          ./create-valkey-cluster.sh
+      - name: Run PHP extension tests
+        run: php -n -d extension=$(pwd)/modules/valkey_glide.so tests/TestValkeyGlide.php
+      - name: Stop Valkey servers
+        if: always()
+        run: |
+          pkill valkey-server 2>/dev/null || true
+          rm -rf $HOME/valkey-cluster || true
+          rm -rf tests/valkey_data || true
+      - name: Upload test reports
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-php-${{ matrix.php }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ env.IMAGE }}-${{ matrix.host.ARCH }}
+          path: |
+            utils/clusters/**
+            tests/**/*.diff
+            tests/**/*.exp
+            tests/**/*.log
+            tests/**/*.out

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,16 @@ on:
       profile:
         required: true
         type: string
-        description: "Test profile (test/standard/full)"
+        description: "Test profile: standard, full"
   workflow_dispatch:
     inputs:
       profile:
         required: true
-        type: string
-        description: "Test profile (test/standard/full)"
+        type: choice
+        options:
+          - standard
+          - full
+        description: "Test profile"
 
 permissions:
   contents: read
@@ -89,6 +92,7 @@ jobs:
             tests/**/*.log
             tests/**/*.out
 
+  # TODO: See #198 for details.
   test-with-containers:
     name: PHP ${{ matrix.php }}, server ${{ matrix.engine.version }}, ${{ matrix.host.IMAGE }}
     needs: load-matrix
@@ -107,7 +111,7 @@ jobs:
     steps:
       - name: Install git and dependencies
         run: |
-          yum update
+          yum update -y
           yum install -y git tar php php-devel gcc make autoconf automake libtool pkgconfig openssl openssl-devel unzip
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           echo IMAGE=${{ matrix.host.IMAGE }} | sed -r 's/:/-/g' >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Reusable Test Workflow
+name: GLIDE PHP Tests
 
 on:
   workflow_call:
@@ -13,7 +13,6 @@ on:
         required: true
         type: choice
         options:
-          - standard
           - full
         description: "Test profile"
 


### PR DESCRIPTION
### Summary

This PR adds support for profile based testing to CI, similar to how C# client is handling it. This is done through `test.yml` a reusable test workflow.

It also adds a `nightly.yml` FMT runs covering Valkey 7 to 9 on Ubuntu hosts.

Note that while `test.yml` is intended to be our backbone test workflow runner, several issues have been discovered below.

### Issue link

Closes #193 

### Follow up issues

- Add Amazon Linux Container tests: https://github.com/valkey-io/valkey-glide-php/issues/198
- Add Redis 6.2, 7.0 tests: https://github.com/valkey-io/valkey-glide-php/issues/197
- Found MacOS segfault failure in tests:  #200
- Reduce log size: #202

### Features / Behaviour Changes

The nightly FMT run has been added as the "full" profile, covering the following configurations.

|                           | Valkey 9.0 | Valkey 8.1 | Valkey 8.0 | Valkey 7.2 |
| ------------------------- | :--------: | :--------: | :--------: | :--------: |
| **Ubuntu x64, PHP 8.2**   |     ✅     |     ✅     |     ✅     |     ✅     |
| **Ubuntu x64, PHP 8.3**   |     ✅     |     ✅     |     ✅     |     ✅     |
| **Ubuntu arm64, PHP 8.2** |     ✅     |     ✅     |     ✅     |     ✅     |
| **Ubuntu arm64, PHP 8.3** |     ✅     |     ✅     |     ✅     |     ✅     |

### Implementation

- added `test.yml` as the profile based test worklflow
- added `nightly.yml` as our nightly FMT.
- Updated our existing json configurations with profile property.
- Removed dead configurations like `PACKAGE_MANAGER` and `CD_RUNNER` from json matrices. 
- Added `load_matrices.py` to load in configurations for workflow.
- Updated action `build-php-wrapper` to support macos. 

### Limitations

- This PR does not update our existing CI/CD
- The `full` profile omits MacOS. See https://github.com/valkey-io/valkey-glide-php/issues/200
- It does not add AMZ Linux container tests. 

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [ ] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [ ] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added "test", "standard", and "full" profiles across build and engine matrices; expanded Redis/engine coverage and PHP-version profile mappings. Enabled a scheduled nightly run using the test profile.

* **New Features**
  * Added a reusable, profile-driven test workflow and a CLI to load, filter, and emit test matrices/configs.

* **Chores**
  * Updated macOS protobuf handling and improved engine/Redis installation and caching behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/valkey-io/valkey-glide-php/pull/192)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->