### PR TITLE
PHP: Update lib-name and lib version

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -232,12 +232,12 @@ jobs:
         run: |
           echo "=== Pre-building Rust components for make ==="
           cd valkey-glide/ffi
-          cargo build --release
+          GLIDE_NAME=GlidePHP GLIDE_VERSION=$(grep -o '#define VALKEY_GLIDE_PHP_VERSION "[^"]*"' ../../common.h | sed 's/.*"\([^"]*\)"/\1/') cargo build --release
           echo "Rust pre-build completed"
 
       - name: Build FFI library
         working-directory: valkey-glide/ffi
-        run: cargo build --release
+        run: GLIDE_NAME=GlidePHP GLIDE_VERSION=$(grep -o '#define VALKEY_GLIDE_PHP_VERSION "[^"]*"' ../../common.h | sed 's/.*"\([^"]*\)"/\1/') cargo build --release
 
       - name: Set up PHP
         uses: shivammathur/setup-php@728c6c6b8cf02c2e48117716a91ee48313958a19 # v2
@@ -440,14 +440,14 @@ jobs:
         run: |
           echo "=== Pre-building Rust components for make ==="
           cd valkey-glide/ffi
-          cargo build --release
+          GLIDE_NAME=GlidePHP GLIDE_VERSION=$(grep -o '#define VALKEY_GLIDE_PHP_VERSION "[^"]*"' ../../common.h | sed 's/.*"\([^"]*\)"/\1/') cargo build --release
           echo "Rust pre-build completed"
 
       - name: Build FFI library with debug symbols
         working-directory: valkey-glide/ffi
         run: |
           # Build with debug symbols for better Valgrind analysis
-          CFLAGS="-g -O0" cargo build --target x86_64-unknown-linux-gnu --release
+          GLIDE_NAME=GlidePHP GLIDE_VERSION=$(grep -o '#define VALKEY_GLIDE_PHP_VERSION "[^"]*"' ../../common.h | sed 's/.*"\([^"]*\)"/\1/') CFLAGS="-g -O0" cargo build --target x86_64-unknown-linux-gnu --release
 
       - name: Set up PHP
         uses: shivammathur/setup-php@728c6c6b8cf02c2e48117716a91ee48313958a19 # v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* PHP: Set CLIENT SETINFO lib-name=GlidePHP and lib-ver to extension version for proper client identification
 * PHP: Fix script injection vulnerability in create-version-pr action (CWE-829)
 * PHP: Add Sigstore-based artifact attestation for published PECL packages
 * PHP: Pin all third-party GitHub Actions to SHA commit hashes to mitigate supply chain attacks (CWE-829)

--- a/Makefile.frag
+++ b/Makefile.frag
@@ -68,6 +68,9 @@ logger_arginfo.h: logger.stub.php
 src/client_constructor_mock_arginfo.h: src/client_constructor_mock.stub.php
 	@php -f $(top_srcdir)/build/gen_stub.php src/client_constructor_mock.stub.php || echo "client_constructor_mock arginfo generation failed"
 
+GLIDE_NAME = GlidePHP
+GLIDE_VERSION ?= $(shell grep -o '\#define VALKEY_GLIDE_PHP_VERSION "[^"]*"' common.h | sed 's/.*"\([^"]*\)"/\1/')
+
 valkey-glide/ffi/target/release/libglide_ffi.a: ensure-submodules
 	@echo "=== BUILDING FFI LIBRARY ==="
 	@if [ ! -f valkey-glide/ffi/target/release/libglide_ffi.a ]; then \
@@ -77,7 +80,7 @@ valkey-glide/ffi/target/release/libglide_ffi.a: ensure-submodules
 			echo "Using sccache for Rust compilation"; \
 		fi && \
 		if [ -d valkey-glide/ffi ]; then \
-			cd valkey-glide/ffi && CARGO_BUILD_JOBS=$$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "4") cargo build --release && cd ../..; \
+			cd valkey-glide/ffi && GLIDE_NAME=$(GLIDE_NAME) GLIDE_VERSION=$(GLIDE_VERSION) CARGO_BUILD_JOBS=$$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "4") cargo build --release && cd ../..; \
 		fi; \
 	else \
 		echo "FFI library already exists, skipping cargo build"; \

--- a/config.m4
+++ b/config.m4
@@ -434,7 +434,8 @@ if test "$PHP_VALKEY_GLIDE" != "no"; then
         AC_MSG_RESULT([Debug: Using fallback CARGO_HOME=$CARGO_HOME_DIR])
       fi
       
-      cd valkey-glide/ffi && CARGO_HOME="$CARGO_HOME_DIR" PATH="$CARGO_DIR:$PATH" CARGO_BUILD_JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "4") ../../cargo build --release && CARGO_HOME="$CARGO_HOME_DIR" PATH="$CARGO_DIR:$PATH" ../../cbindgen --output ../../include/glide_bindings.h && cd ../.. || AC_MSG_ERROR([Rust build or header generation failed])
+      GLIDE_PHP_VERSION=$(grep -o '#define VALKEY_GLIDE_PHP_VERSION "[^"]*"' common.h | sed 's/.*"\([^"]*\)"/\1/' 2>/dev/null || echo "unknown")
+      cd valkey-glide/ffi && GLIDE_NAME=GlidePHP GLIDE_VERSION="$GLIDE_PHP_VERSION" CARGO_HOME="$CARGO_HOME_DIR" PATH="$CARGO_DIR:$PATH" CARGO_BUILD_JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "4") ../../cargo build --release && CARGO_HOME="$CARGO_HOME_DIR" PATH="$CARGO_DIR:$PATH" ../../cbindgen --output ../../include/glide_bindings.h && cd ../.. || AC_MSG_ERROR([Rust build or header generation failed])
       
       dnl Add include guards to the generated header immediately
       if test -f "include/glide_bindings.h"; then

--- a/tests/ValkeyGlideBatchTest.php
+++ b/tests/ValkeyGlideBatchTest.php
@@ -336,7 +336,7 @@ class ValkeyGlideBatchTest extends ValkeyGlideBaseTest
         $this->assertIsArray($results[0]); // INFO result (array of server info)
         $this->assertIsInt($results[1]); // CLIENT ID result (integer)
         // CLIENT GETNAME might return null if no name is set
-        $this->assertEquals('valkey-glide-php', $results[2]); // CLIENT SETNAME result
+        $this->assertFalse($results[2]); // No default client name set
         // Verify server info contains expected keys
         $this->assertArrayHasKey('server_name', $results[0]);
         $this->assertGT(0, $results[1]); // Client ID should be positive

--- a/tests/ValkeyGlideClusterBatchTest.php
+++ b/tests/ValkeyGlideClusterBatchTest.php
@@ -76,7 +76,7 @@ class ValkeyGlideClusterBatchTest extends ValkeyGlideBatchTest
         $this->assertCount(3, $results);
         $this->assertIsInt($results[0]); // CLIENT ID result (integer)
         // CLIENT GETNAME might return null if no name is set
-        $this->assertEquals('valkey-glide-php', $results[1]); // CLIENT SETNAME result
+        $this->assertFalse($results[1]); // No default client name set
 
         $this->assertGT(0, $results[0]); // Client ID should be positive
     }

--- a/tests/ValkeyGlideClusterFeaturesTest.php
+++ b/tests/ValkeyGlideClusterFeaturesTest.php
@@ -30,6 +30,25 @@ class ValkeyGlideClusterFeaturesTest extends ValkeyGlideClusterBaseTest
         $valkey_glide->close();
     }
 
+    public function testClientLibNameAndVersion()
+    {
+        // Verify that CLIENT INFO reports the correct lib-name and lib-ver
+        $info_str = $this->valkey_glide->rawcommand(
+            ['type' => 'primarySlotKey', 'key' => 'test'],
+            "CLIENT", "INFO"
+        );
+        $this->assertIsString($info_str);
+        $this->assertTrue(
+            str_contains($info_str, "lib-name=GlidePHP"),
+            "Expected lib-name=GlidePHP in CLIENT INFO, got: $info_str"
+        );
+        $expected_version = phpversion('valkey_glide');
+        $this->assertTrue(
+            str_contains($info_str, "lib-ver=" . $expected_version),
+            "Expected lib-ver=$expected_version in CLIENT INFO, got: $info_str"
+        );
+    }
+
     // ==============================================
     // ADDRESSES PARAMETER TESTS
     // ==============================================

--- a/tests/ValkeyGlideClusterFeaturesTest.php
+++ b/tests/ValkeyGlideClusterFeaturesTest.php
@@ -35,7 +35,8 @@ class ValkeyGlideClusterFeaturesTest extends ValkeyGlideClusterBaseTest
         // Verify that CLIENT INFO reports the correct lib-name and lib-ver
         $info_str = $this->valkey_glide->rawcommand(
             ['type' => 'primarySlotKey', 'key' => 'test'],
-            "CLIENT", "INFO"
+            "CLIENT",
+            "INFO"
         );
         $this->assertIsString($info_str);
         $this->assertTrue(

--- a/tests/ValkeyGlideClusterFeaturesTest.php
+++ b/tests/ValkeyGlideClusterFeaturesTest.php
@@ -39,15 +39,9 @@ class ValkeyGlideClusterFeaturesTest extends ValkeyGlideClusterBaseTest
             "INFO"
         );
         $this->assertIsString($info_str);
-        $this->assertTrue(
-            str_contains($info_str, "lib-name=GlidePHP"),
-            "Expected lib-name=GlidePHP in CLIENT INFO, got: $info_str"
-        );
+        $this->assertTrue(str_contains($info_str, "lib-name=GlidePHP"));
         $expected_version = phpversion('valkey_glide');
-        $this->assertTrue(
-            str_contains($info_str, "lib-ver=" . $expected_version),
-            "Expected lib-ver=$expected_version in CLIENT INFO, got: $info_str"
-        );
+        $this->assertTrue(str_contains($info_str, "lib-ver=" . $expected_version));
     }
 
     // ==============================================

--- a/tests/ValkeyGlideFeaturesTest.php
+++ b/tests/ValkeyGlideFeaturesTest.php
@@ -42,15 +42,9 @@ class ValkeyGlideFeaturesTest extends ValkeyGlideBaseTest
         // Verify that CLIENT INFO reports the correct lib-name and lib-ver
         $info_str = $this->valkey_glide->rawcommand("CLIENT", "INFO");
         $this->assertIsString($info_str);
-        $this->assertTrue(
-            str_contains($info_str, "lib-name=GlidePHP"),
-            "Expected lib-name=GlidePHP in CLIENT INFO, got: $info_str"
-        );
+        $this->assertTrue(str_contains($info_str, "lib-name=GlidePHP"));
         $expected_version = phpversion('valkey_glide');
-        $this->assertTrue(
-            str_contains($info_str, "lib-ver=" . $expected_version),
-            "Expected lib-ver=$expected_version in CLIENT INFO, got: $info_str"
-        );
+        $this->assertTrue(str_contains($info_str, "lib-ver=" . $expected_version));
     }
 
     public function testConstructorWithSingleAddress()

--- a/tests/ValkeyGlideFeaturesTest.php
+++ b/tests/ValkeyGlideFeaturesTest.php
@@ -37,6 +37,22 @@ class ValkeyGlideFeaturesTest extends ValkeyGlideBaseTest
         }
     }
 
+    public function testClientLibNameAndVersion()
+    {
+        // Verify that CLIENT INFO reports the correct lib-name and lib-ver
+        $info_str = $this->valkey_glide->rawcommand("CLIENT", "INFO");
+        $this->assertIsString($info_str);
+        $this->assertTrue(
+            str_contains($info_str, "lib-name=GlidePHP"),
+            "Expected lib-name=GlidePHP in CLIENT INFO, got: $info_str"
+        );
+        $expected_version = phpversion('valkey_glide');
+        $this->assertTrue(
+            str_contains($info_str, "lib-ver=" . $expected_version),
+            "Expected lib-ver=$expected_version in CLIENT INFO, got: $info_str"
+        );
+    }
+
     public function testConstructorWithSingleAddress()
     {
         // Test constructor with single address in proper array format

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -185,7 +185,7 @@ uint8_t* create_connection_request(size_t*                                   len
     }
 
     /* Set client name */
-    conn_req.client_name = config->client_name ? config->client_name : "valkey-glide-php";
+    conn_req.client_name = config->client_name ? config->client_name : NULL;
 
     /* Set client AZ */
     if (config->client_az) {


### PR DESCRIPTION
### Summary

The PHP client was reporting itself as GlideFFI with version 0.1.0 in CLIENT INFO output, which are the default values from the shared FFI layer. This PR sets proper client identification so the server sees lib-name=GlidePHP and lib-ver=1.0.0 (matching the extension version).  Also removes the default client_name to align with other GLIDE clients.

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide-php/issues/211
Closes https://github.com/valkey-io/valkey-glide-php/issues/211

### Features / Behaviour Changes

- Makefile.frag: Pass GLIDE_NAME=GlidePHP and GLIDE_VERSION to cargo build when building the FFI library.
- config.m4: Same env vars added to the PECL/PIE build path used in CI.
- tests/ValkeyGlideFeaturesTest.php: Add testClientLibNameAndVersion.
- tests/ValkeyGlideClusterFeaturesTest.php: Same test for cluster client.
- valkey_glide_core_commands.c: Remove default client_name ("valkey-glide-php").

### How it works

The Rust layer uses compile-time env vars GLIDE_NAME and GLIDE_VERSION (via option_env!() / env!()) to populate the CLIENT SETINFO commands sent during connection setup. By passing these at build time, the PHP client now properly identifies itself to the server.

### Testing

- Standalone test passes locally (testClientLibNameAndVersion — PASSED)

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
