### PR TITLE
fix(compatibility): track getLastError/clearLastError as missing PHPRedis methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * PHP: Fix pie install from Packagist using PIE pre-packaged-source download method ([#233](https://github.com/valkey-io/valkey-glide-php/pull/233))
 * PHP: Fix pie install ([#229](https://github.com/valkey-io/valkey-glide-php/pull/229))
+* PHP: Track getLastError/clearLastError as missing PHPRedis methods in the compatibility report instead of excluding them as connection management internals ([#220](https://github.com/valkey-io/valkey-glide-php/pull/220))
 * PHP: Set CLIENT SETINFO lib-name=GlidePHP and lib-ver to extension version for proper client identification
 * PHP: Add address resolver support for standalone and cluster clients, allowing custom host/port remapping at connection time ([#196](https://github.com/valkey-io/valkey-glide-php/pull/196))
 

--- a/compatibility_check.php
+++ b/compatibility_check.php
@@ -20,8 +20,8 @@
 // _prefix, _serialize, _unserialize, _pack, _unpack, _digest)
 // Excludes: deprecated aliases (open, popen, delete, sortAsc, sortAscAlpha, sortDesc, sortDescAlpha)
 // Excludes: connection management internals (getHost, getPort, getAuth, getDBNum,
-// getReadTimeout, getTimeout, getPersistentID, getMode, getLastError,
-// clearLastError, isConnected, getTransferredBytes, clearTransferredBytes)
+// getReadTimeout, getTimeout, getPersistentID, getMode, isConnected,
+// getTransferredBytes, clearTransferredBytes)
 // ============================================================================
 
 $phpredis_commands = [
@@ -88,6 +88,10 @@ $phpredis_commands = [
 
     // Connection
     'auth', 'client', 'close', 'echo', 'ping', 'rawcommand', 'setOption', 'getOption',
+
+    // Error introspection (required by PHPRedis-compatible libraries, e.g. Symfony
+    // Lock RedisStore calls clearLastError()/getLastError() on every evaluate())
+    'getLastError', 'clearLastError',
 
     // Bit commands
     'bitcount', 'bitop', 'bitpos',
@@ -368,6 +372,8 @@ $phpredis_cluster_commands = [
     // Cluster-specific
     'cluster', 'command', 'role', 'acl', 'bgsave', 'bgrewriteaof', 'waitaof',
     'setoption', 'getoption',
+    // Error introspection (RedisCluster exposes the same getLastError/clearLastError API)
+    'getLastError', 'clearLastError',
     // Redis 8+ / KeyDB
     'delex', 'delifeq', 'msetex', 'expiremember', 'expirememberat',
     'getWithMeta', 'hgetWithMeta',


### PR DESCRIPTION
### Summary

`getLastError()` / `clearLastError()` are currently listed in the `Excludes:` comment of `compatibility_check.php` as "connection management internals" and are absent from both command lists — so the gap is invisible to the compatibility report and to the umbrella tracking issue #215.

They are regular PHPRedis **error-introspection** methods, present on both `Redis` and `RedisCluster`:

- [`Redis::getLastError(): ?string`](https://github.com/phpredis/phpredis/blob/develop/redis.stub.php) / `Redis::clearLastError(): bool`
- `RedisCluster::getLastError()` / `RedisCluster::clearLastError()`

PHPRedis-compatible libraries depend on them: Symfony Lock `RedisStore::evaluate()` calls `clearLastError()` **unconditionally on every lock acquire**, which currently fatals with the aliased classes (#218).

This PR reclassifies them so the report tracks them as "Not Implemented" for both `ValkeyGlide` and `ValkeyGlideCluster`.

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide-php/issues/218

### Features / Behaviour Changes

Report-only change — no extension/runtime behavior is affected:

- standalone: Not Implemented 28 → 30 (total analyzed 258 → 260)
- cluster: Not Implemented 19 → 21 (total analyzed 228 → 230)
- all other categories (Compatible / Not Compatible / Excluded) unchanged

### Implementation

- Removed `getLastError`, `clearLastError` from the "connection management internals" `Excludes:` comment
- Added them to `$phpredis_commands` and `$phpredis_cluster_commands` under a new "Error introspection" group
- CHANGELOG entry added

### Limitations

This PR only makes the gap visible. The actual implementation of `getLastError()`/`clearLastError()` is tracked in #218 (I'm working on a follow-up PR for it).

### Testing

- `php -l` clean
- Ran the report before/after with the extension loaded (1.1.0): only the two methods move into "NOT IMPLEMENTED" for both classes, all other categories identical, sum still 100%
- Verified via reflection that both methods are absent from `ValkeyGlide` and `ValkeyGlideCluster` (`method_exists()` → `false` × 4)
- E2E reproduction of the dependency claim (PHP 8.3.31, symfony/lock 7.4.9, Valkey 8):

```text
--- calling lock->acquire() (enters RedisStore::evaluate) ---
THROWN: Error: Call to undefined method ValkeyGlide::clearLastError()
at vendor/symfony/lock/Store/RedisStore.php:236
```

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated. — N/A: `compatibility_check.php` is a standalone reporting tool with no test harness; validated by running the report before/after (see Testing)
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
