### PR TITLE
PHP: Implement getLastError() and clearLastError() for PHPRedis compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * PHP: Fix pie install from Packagist using PIE pre-packaged-source download method ([#233](https://github.com/valkey-io/valkey-glide-php/pull/233))
 * PHP: Fix pie install from Packagist by setting preferred-install to source for submodule resolution ([#232](https://github.com/valkey-io/valkey-glide-php/pull/232))
 * PHP: Fix pie install ([#229](https://github.com/valkey-io/valkey-glide-php/pull/229))
+* PHP: Implement getLastError()/clearLastError() for PHPRedis compatibility ([#221](https://github.com/valkey-io/valkey-glide-php/pull/221))
 * PHP: Set CLIENT SETINFO lib-name=GlidePHP and lib-ver to extension version for proper client identification
 * PHP: Add address resolver support for standalone and cluster clients, allowing custom host/port remapping at connection time ([#196](https://github.com/valkey-io/valkey-glide-php/pull/196))
 

--- a/common.h
+++ b/common.h
@@ -285,10 +285,16 @@ typedef struct {
 
     AddressResolverCallback resolver_cb; /* NULL if no address resolver */
 
+    /* Last command error message (PHPRedis getLastError/clearLastError), NULL if none */
+    zend_string* last_error;
+
     zend_object std; /* MUST be last - PHP allocates extra memory after this */
 } valkey_glide_object;
 
 void valkey_glide_clear_batch_state(valkey_glide_object* valkey_glide);
+void valkey_glide_set_last_error(valkey_glide_object* valkey_glide, const char* msg);
+void valkey_glide_clear_last_error(valkey_glide_object* valkey_glide);
+void valkey_glide_record_command_error(valkey_glide_object* valkey_glide, CommandResult* result);
 
 /* For convenience we store the salt as a printable hex string which requires 2
  * characters per byte + 1 for the NULL terminator */

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -5447,6 +5447,66 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->valkey_glide->del($key);
     }
 
+    public function testGetLastErrorAndClearLastError()
+    {
+        // Fresh client: no error recorded
+        $this->assertNull($this->valkey_glide->getLastError());
+
+        // A failing script records the server error message
+        $this->assertFalse($this->valkey_glide->eval('this is not valid lua {{{'));
+        $err = $this->valkey_glide->getLastError();
+        $this->assertIsString($err);
+
+        // A successful command does NOT clear the last error (PHPRedis semantics)
+        $this->assertTrue($this->valkey_glide->set('{lasterror}key', 'value'));
+        $this->assertEquals($err, $this->valkey_glide->getLastError());
+
+        // clearLastError() resets it and always returns true
+        $this->assertTrue($this->valkey_glide->clearLastError());
+        $this->assertNull($this->valkey_glide->getLastError());
+
+        // A command error via the core execution path is recorded too
+        $this->assertEquals(1, $this->valkey_glide->rPush('{lasterror}list', 'a'));
+        $this->assertFalse($this->valkey_glide->incr('{lasterror}list'));
+        $err = $this->valkey_glide->getLastError();
+        $this->assertIsString($err);
+        $this->assertStringContains('WRONGTYPE', $err);
+
+        // Command families with their own execution paths record errors too
+        $this->assertTrue($this->valkey_glide->set('{lasterror}str', 'v'));
+        foreach (
+            [
+                'zAdd'  => fn() => $this->valkey_glide->zAdd('{lasterror}str', 1.0, 'm'),
+                'rPush' => fn() => $this->valkey_glide->rPush('{lasterror}str', 'x'),
+                'hSet'  => fn() => $this->valkey_glide->hSet('{lasterror}str', 'f', 'v'),
+                'xAdd'  => fn() => $this->valkey_glide->xAdd('{lasterror}str', '*', ['f' => 'v']),
+                'geoadd' => fn() => $this->valkey_glide->geoadd('{lasterror}str', 13.36, 38.11, 'P'),
+                'sAdd'  => fn() => $this->valkey_glide->sAdd('{lasterror}str', 'x'),
+            ] as $cmd => $fn
+        ) {
+            $this->assertTrue($this->valkey_glide->clearLastError());
+            $this->assertFalse($fn());
+            $err = $this->valkey_glide->getLastError();
+            $this->assertIsString($err);
+            $this->assertStringContains('WRONGTYPE', $err);
+        }
+
+        // A new error overwrites the previous one
+        $this->assertFalse($this->valkey_glide->eval('return redis.call("NOSUCHCOMMAND")'));
+        $this->assertNotEquals($err, $this->valkey_glide->getLastError());
+
+        // NOSCRIPT errors keep their RESP code prefix (PHPRedis-compatible consumers
+        // like Symfony Lock RedisStore rely on it to reload missing scripts)
+        $this->valkey_glide->clearLastError();
+        $this->assertFalse($this->valkey_glide->evalsha(str_repeat('a', 40)));
+        $err = $this->valkey_glide->getLastError();
+        $this->assertIsString($err);
+        $this->assertPatternMatch('/^NOSCRIPT/', $err);
+
+        // Clean up
+        $this->assertTrue($this->valkey_glide->clearLastError());
+        $this->valkey_glide->del('{lasterror}key', '{lasterror}list', '{lasterror}str');
+    }
 
     public function testEvalSHA()
     {

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -660,11 +660,60 @@ zend_module_entry valkey_glide_module_entry = {STANDARD_MODULE_HEADER,
 ZEND_GET_MODULE(valkey_glide)
 #endif
 
+/* Store the last command error message on the object (PHPRedis getLastError semantics):
+ * a new error overwrites the previous one; successful commands do not clear it.
+ *
+ * glide-core (redis-rs) reformats server errors as
+ * "An error was signalled by the server: - <ErrorKind>: <detail>". PHPRedis-compatible
+ * consumers pattern-match the raw RESP error code instead (e.g. Symfony Lock RedisStore
+ * checks str_starts_with($err, 'NOSCRIPT') to reload missing scripts), so strip the
+ * glide prefix and restore the RESP code for the error kinds that lose it. */
+void valkey_glide_set_last_error(valkey_glide_object* valkey_glide, const char* msg) {
+    static const char server_prefix[] = "An error was signalled by the server: - ";
+    static const char noscript_kind[] = "NoScriptError: ";
+
+    if (!valkey_glide || !msg) {
+        return;
+    }
+    valkey_glide_clear_last_error(valkey_glide);
+
+    if (strncmp(msg, server_prefix, sizeof(server_prefix) - 1) == 0) {
+        msg += sizeof(server_prefix) - 1;
+        if (strncmp(msg, noscript_kind, sizeof(noscript_kind) - 1) == 0) {
+            msg += sizeof(noscript_kind) - 1;
+            valkey_glide->last_error = zend_strpprintf(0, "NOSCRIPT %s", msg);
+            return;
+        }
+    }
+    valkey_glide->last_error = zend_string_init(msg, strlen(msg), 0);
+}
+
+void valkey_glide_clear_last_error(valkey_glide_object* valkey_glide) {
+    if (valkey_glide && valkey_glide->last_error) {
+        zend_string_release(valkey_glide->last_error);
+        valkey_glide->last_error = NULL;
+    }
+}
+
+/* Record the error carried by a CommandResult, if any. Shared by all command
+ * execution paths that report failures by returning false. */
+void valkey_glide_record_command_error(valkey_glide_object* valkey_glide, CommandResult* result) {
+    if (valkey_glide && result && result->command_error) {
+        valkey_glide_set_last_error(valkey_glide,
+                                    result->command_error->command_error_message
+                                        ? result->command_error->command_error_message
+                                        : "Command execution failed");
+    }
+}
+
 void free_valkey_glide_object(zend_object* object) {
     valkey_glide_object* valkey_glide = VALKEY_GLIDE_PHP_GET_OBJECT(valkey_glide_object, object);
 
     /* Free buffered batch commands if object is destroyed mid-batch */
     valkey_glide_clear_batch_state(valkey_glide);
+
+    /* Free the last error message if set */
+    valkey_glide_clear_last_error(valkey_glide);
 
     /* Free the Valkey Glide client if it exists */
     if (valkey_glide->glide_client) {

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -434,6 +434,24 @@ class ValkeyGlide
     public function getOption(int $option): mixed;
 
     /**
+     * Get the last error message returned by the server, if any.
+     *
+     * The message is recorded when a command fails and returns false; it is
+     * overwritten by subsequent errors and is not cleared by successful
+     * commands. Use clearLastError() to reset it.
+     *
+     * @return string|null The last error message, or NULL if there is no error
+     */
+    public function getLastError(): ?string;
+
+    /**
+     * Clear the last error message, if any.
+     *
+     * @return bool Always true
+     */
+    public function clearLastError(): bool;
+
+    /**
      * Append data to a ValkeyGlide STRING key.
      *
      * @param string $key   The key in question

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -1277,6 +1277,14 @@ SETOPTION_METHOD_IMPL(ValkeyGlideCluster)
 GETOPTION_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
+/* {{{ proto string|null ValkeyGlideCluster::getLastError() */
+GETLASTERROR_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto bool ValkeyGlideCluster::clearLastError() */
+CLEARLASTERROR_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
 /* {{{ proto bool ValkeyGlideCluster::jsonSet(string key, string path, string value [, string
  * condition]) */
 JSON_SET_METHOD_IMPL(ValkeyGlideCluster)

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -299,6 +299,16 @@ class ValkeyGlideCluster
     public function getOption(int $option): mixed;
 
     /**
+     * @see ValkeyGlide::getLastError()
+     */
+    public function getLastError(): ?string;
+
+    /**
+     * @see ValkeyGlide::clearLastError()
+     */
+    public function clearLastError(): bool;
+
+    /**
      * @see ValkeyGlide::append()
      */
     public function append(string $key, mixed $value): ValkeyGlideCluster|bool|int;

--- a/valkey_glide_commands_3.c
+++ b/valkey_glide_commands_3.c
@@ -59,7 +59,7 @@ static int execute_function_list_command_with_args(zval*             object,
         result = execute_command(valkey_glide->glide_client, FunctionList, 0, NULL, NULL);
     }
 
-    return handle_function_command_result_or_return_false(result, return_value);
+    return handle_function_command_result_or_return_false(valkey_glide, result, return_value);
 }
 
 /* Helper functions to reduce code duplication */
@@ -771,11 +771,13 @@ static int process_script_operation(valkey_glide_object* valkey_glide,
                 unsigned long  args_len[1] = {mode_len};
                 CommandResult* result =
                     execute_command(valkey_glide->glide_client, ScriptFlush, 1, cmd_args, args_len);
-                return handle_function_command_result_or_return_false(result, return_value);
+                return handle_function_command_result_or_return_false(
+                    valkey_glide, result, return_value);
             } else {
                 CommandResult* result =
                     execute_command(valkey_glide->glide_client, ScriptFlush, 0, NULL, NULL);
-                return handle_function_command_result_or_return_false(result, return_value);
+                return handle_function_command_result_or_return_false(
+                    valkey_glide, result, return_value);
             }
         } else if (strcasecmp(operation, "LOAD") == 0) {
             if (args_count < 1 || Z_TYPE(z_args[0]) != IS_STRING) {
@@ -993,6 +995,7 @@ int execute_exec_command(zval* object, int argc, zval* return_value, zend_class_
     if (result) {
         if (result->command_error) {
             /* Command failed */
+            valkey_glide_record_command_error(valkey_glide, result);
             free_command_result(result);
             valkey_glide_clear_batch_state(valkey_glide);
             ZVAL_FALSE(return_value);

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -92,9 +92,11 @@ static inline void handle_command_result_or_throw(CommandResult* result,
 }
 
 // Helper that returns false on errors instead of throwing exceptions
-static inline int handle_function_command_result_or_return_false(CommandResult* result,
-                                                                 zval*          return_value) {
+static inline int handle_function_command_result_or_return_false(valkey_glide_object* valkey_glide,
+                                                                 CommandResult*       result,
+                                                                 zval* return_value) {
     if (!result || result->command_error || !result->response) {
+        valkey_glide_record_command_error(valkey_glide, result);
         ZVAL_FALSE(return_value);
         if (result) {
             free_command_result(result);
@@ -1558,6 +1560,31 @@ void execute_script_command(zval* object, int argc, zval* return_value, zend_cla
             default:                                                          \
                 RETURN_FALSE;                                                 \
         }                                                                     \
+    }
+
+/* Error introspection methods - matching PHPRedis getLastError/clearLastError API */
+#define GETLASTERROR_METHOD_IMPL(class_name)                                  \
+    PHP_METHOD(class_name, getLastError) {                                    \
+        ZEND_PARSE_PARAMETERS_NONE();                                         \
+                                                                              \
+        valkey_glide_object* valkey_glide =                                   \
+            VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, getThis()); \
+        if (!valkey_glide || !valkey_glide->last_error) {                     \
+            RETURN_NULL();                                                    \
+        }                                                                     \
+                                                                              \
+        RETURN_STR_COPY(valkey_glide->last_error);                            \
+    }
+
+#define CLEARLASTERROR_METHOD_IMPL(class_name)                                \
+    PHP_METHOD(class_name, clearLastError) {                                  \
+        ZEND_PARSE_PARAMETERS_NONE();                                         \
+                                                                              \
+        valkey_glide_object* valkey_glide =                                   \
+            VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, getThis()); \
+        valkey_glide_clear_last_error(valkey_glide);                          \
+                                                                              \
+        RETURN_TRUE;                                                          \
     }
 
 /* FFI Compression functions - Statistics struct already defined in glide_bindings.h */

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -149,6 +149,7 @@ int execute_core_command(valkey_glide_object* valkey_glide,
                                         ? result->command_error->command_error_message
                                         : "Command execution failed";
             VALKEY_LOG_ERROR_FMT("execute_core_command", "Command error: %s", error_msg);
+            valkey_glide_record_command_error(valkey_glide, result);
 
             efree(result_ptr);
             free_command_result(result);

--- a/valkey_glide_function_commands.c
+++ b/valkey_glide_function_commands.c
@@ -15,8 +15,11 @@
  * Helper function to handle CommandResult for boolean function commands
  * Returns 0 on error, otherwise returns the status from process_core_bool_result
  */
-static int handle_function_bool_result(CommandResult* result, zval* return_value) {
+static int handle_function_bool_result(valkey_glide_object* valkey_glide,
+                                       CommandResult*       result,
+                                       zval*                return_value) {
     if (!result || result->command_error || !result->response) {
+        valkey_glide_record_command_error(valkey_glide, result);
         ZVAL_FALSE(return_value);
         if (result) {
             free_command_result(result);
@@ -59,7 +62,7 @@ int execute_function_load_internal(valkey_glide_object* valkey_glide,
     efree(cmd_args);
     efree(args_len);
 
-    return handle_function_command_result_or_return_false(result, return_value);
+    return handle_function_command_result_or_return_false(valkey_glide, result, return_value);
 }
 
 int execute_function_load_command(zval*             object,
@@ -112,7 +115,7 @@ int execute_function_list_command(zval*             object,
         result = execute_command(valkey_glide->glide_client, FunctionList, 0, NULL, NULL);
     }
 
-    return handle_function_command_result_or_return_false(result, return_value);
+    return handle_function_command_result_or_return_false(valkey_glide, result, return_value);
 }
 
 int execute_function_flush_command(zval*             object,
@@ -129,7 +132,7 @@ int execute_function_flush_command(zval*             object,
     CommandResult* result =
         execute_command(valkey_glide->glide_client, FunctionFlush, 0, NULL, NULL);
 
-    return handle_function_bool_result(result, return_value);
+    return handle_function_bool_result(valkey_glide, result, return_value);
 }
 
 int execute_function_delete_command(zval*             object,
@@ -158,7 +161,7 @@ int execute_function_delete_command(zval*             object,
     CommandResult* result =
         execute_command(valkey_glide->glide_client, FunctionDelete, 1, cmd_args, args_len);
 
-    return handle_function_bool_result(result, return_value);
+    return handle_function_bool_result(valkey_glide, result, return_value);
 }
 
 int execute_function_dump_command(zval*             object,
@@ -174,7 +177,7 @@ int execute_function_dump_command(zval*             object,
 
     CommandResult* result =
         execute_command(valkey_glide->glide_client, FunctionDump, 0, NULL, NULL);
-    return handle_function_command_result_or_return_false(result, return_value);
+    return handle_function_command_result_or_return_false(valkey_glide, result, return_value);
 }
 
 int execute_function_restore_command(zval*             object,
@@ -203,7 +206,7 @@ int execute_function_restore_command(zval*             object,
     CommandResult* result =
         execute_command(valkey_glide->glide_client, FunctionRestore, 1, cmd_args, args_len);
 
-    return handle_function_bool_result(result, return_value);
+    return handle_function_bool_result(valkey_glide, result, return_value);
 }
 
 int execute_function_kill_command(zval*             object,
@@ -220,7 +223,7 @@ int execute_function_kill_command(zval*             object,
     CommandResult* result =
         execute_command(valkey_glide->glide_client, FunctionKill, 0, NULL, NULL);
 
-    return handle_function_bool_result(result, return_value);
+    return handle_function_bool_result(valkey_glide, result, return_value);
 }
 
 int execute_function_stats_command(zval*             object,
@@ -236,5 +239,5 @@ int execute_function_stats_command(zval*             object,
 
     CommandResult* result =
         execute_command(valkey_glide->glide_client, FunctionStats, 0, NULL, NULL);
-    return handle_function_command_result_or_return_false(result, return_value);
+    return handle_function_command_result_or_return_false(valkey_glide, result, return_value);
 }

--- a/valkey_glide_geo_common.c
+++ b/valkey_glide_geo_common.c
@@ -520,6 +520,7 @@ int execute_geo_generic_command(valkey_glide_object*   valkey_glide,
 
     /* Check if there was an error */
     if (result->command_error) {
+        valkey_glide_record_command_error(valkey_glide, result);
         free_command_result(result);
         return 0;
     }
@@ -997,6 +998,7 @@ int execute_geosearch_unified(
     efree(arg_lens);
 
     if (!result || result->command_error) {
+        valkey_glide_record_command_error(valkey_glide, result);
         if (result)
             free_command_result(result);
         return 0;

--- a/valkey_glide_hash_common.c
+++ b/valkey_glide_hash_common.c
@@ -147,6 +147,7 @@ int execute_h_generic_command(valkey_glide_object* valkey_glide,
         if (!result->command_error && result->response && process_result) {
             status = process_result(result->response, result_ptr, return_value);
         } else {
+            valkey_glide_record_command_error(valkey_glide, result);
             if (result_ptr) {
                 efree(args->fields);
                 efree(result_ptr);
@@ -276,6 +277,8 @@ int execute_h_simple_command(valkey_glide_object* valkey_glide,
     if (result && Z_TYPE_P(return_value) != IS_FALSE) {
         if (!result->command_error && result->response && processor) {
             status = processor(result->response, result_ptr, return_value);
+        } else {
+            valkey_glide_record_command_error(valkey_glide, result);
         }
         free_command_result(result);
     } else {

--- a/valkey_glide_list_common.c
+++ b/valkey_glide_list_common.c
@@ -279,6 +279,8 @@ int execute_list_generic_command(valkey_glide_object* valkey_glide,
     if (result) {
         if (!result->command_error && result->response && process_result) {
             status = process_result(result->response, result_ptr, return_value);
+        } else {
+            valkey_glide_record_command_error(valkey_glide, result);
         }
         free_command_result(result);
     }

--- a/valkey_glide_s_common.c
+++ b/valkey_glide_s_common.c
@@ -840,7 +840,8 @@ int execute_s_generic_command(valkey_glide_object* valkey_glide,
         /* Always run the processor: on the SCAN path it resets the scan iterator
          * and frees the emalloc'd scan_data, which would otherwise leak on error.
          * The processors handle a NULL response by returning a false/empty value. */
-        status = process_result(result->command_error ? NULL : result->response, scan_data, return_value);
+        status = process_result(
+            result->command_error ? NULL : result->response, scan_data, return_value);
     }
     free_command_result(result);
 

--- a/valkey_glide_s_common.c
+++ b/valkey_glide_s_common.c
@@ -834,7 +834,11 @@ int execute_s_generic_command(valkey_glide_object* valkey_glide,
     /* Execute the command synchronously */
     result = execute_command(valkey_glide->glide_client, cmd_type, arg_count, cmd_args, args_len);
     if (result) {
-        status = process_result(result->response, scan_data, return_value);
+        if (result->command_error) {
+            valkey_glide_record_command_error(valkey_glide, result);
+        } else {
+            status = process_result(result->response, scan_data, return_value);
+        }
     }
     free_command_result(result);
 

--- a/valkey_glide_s_common.c
+++ b/valkey_glide_s_common.c
@@ -836,9 +836,11 @@ int execute_s_generic_command(valkey_glide_object* valkey_glide,
     if (result) {
         if (result->command_error) {
             valkey_glide_record_command_error(valkey_glide, result);
-        } else {
-            status = process_result(result->response, scan_data, return_value);
         }
+        /* Always run the processor: on the SCAN path it resets the scan iterator
+         * and frees the emalloc'd scan_data, which would otherwise leak on error.
+         * The processors handle a NULL response by returning a false/empty value. */
+        status = process_result(result->command_error ? NULL : result->response, scan_data, return_value);
     }
     free_command_result(result);
 

--- a/valkey_glide_script_commands.c
+++ b/valkey_glide_script_commands.c
@@ -5,9 +5,10 @@
 #include "valkey_glide_core_common.h"
 
 // Helper macros for validating CommandResult in script commands
-#define VALIDATE_SCRIPT_RESULT_OR_RETURN_FALSE(result, return_value)       \
+#define VALIDATE_SCRIPT_RESULT_OR_RETURN_FALSE(valkey_glide, result)       \
     do {                                                                   \
         if (!(result) || (result)->command_error || !(result)->response) { \
+            valkey_glide_record_command_error(valkey_glide, result);       \
             if (result) {                                                  \
                 free_command_result(result);                               \
             }                                                              \
@@ -15,9 +16,10 @@
         }                                                                  \
     } while (0)
 
-#define VALIDATE_SCRIPT_RESULT_OR_RETURN_NULL(result, return_value)        \
+#define VALIDATE_SCRIPT_RESULT_OR_RETURN_NULL(valkey_glide, result)        \
     do {                                                                   \
         if (!(result) || (result)->command_error || !(result)->response) { \
+            valkey_glide_record_command_error(valkey_glide, result);       \
             if (result) {                                                  \
                 free_command_result(result);                               \
             }                                                              \
@@ -25,9 +27,10 @@
         }                                                                  \
     } while (0)
 
-#define VALIDATE_SCRIPT_RESULT_NO_RESPONSE_OR_RETURN_FALSE(result, return_value) \
+#define VALIDATE_SCRIPT_RESULT_NO_RESPONSE_OR_RETURN_FALSE(valkey_glide, result) \
     do {                                                                         \
         if (!(result) || (result)->command_error) {                              \
+            valkey_glide_record_command_error(valkey_glide, result);             \
             if (result) {                                                        \
                 free_command_result(result);                                     \
             }                                                                    \
@@ -38,8 +41,11 @@
 /**
  * Helper function to handle CommandResult for boolean script commands (void return)
  */
-static void handle_script_bool_result(CommandResult* result, zval* return_value) {
+static void handle_script_bool_result(valkey_glide_object* valkey_glide,
+                                      CommandResult*       result,
+                                      zval*                return_value) {
     if (!result || result->command_error || !result->response) {
+        valkey_glide_record_command_error(valkey_glide, result);
         ZVAL_FALSE(return_value);
         if (result) {
             free_command_result(result);
@@ -111,7 +117,7 @@ void execute_script_flush_command(zval* object, zval* return_value, bool is_clus
         return;
     }
     CommandResult* result = execute_command(valkey_glide->glide_client, ScriptFlush, 0, NULL, NULL);
-    handle_script_bool_result(result, return_value);
+    handle_script_bool_result(valkey_glide, result, return_value);
 }
 
 
@@ -182,7 +188,7 @@ static void execute_eval_style_command(const char* cmd_name,
     efree(cmd_args);
     efree(cmd_args_len);
 
-    VALIDATE_SCRIPT_RESULT_NO_RESPONSE_OR_RETURN_FALSE(result, return_value);
+    VALIDATE_SCRIPT_RESULT_NO_RESPONSE_OR_RETURN_FALSE(valkey_glide, result);
 
     command_response_to_zval(result->response, return_value, 0, false);
     free_command_result(result);
@@ -341,7 +347,7 @@ void execute_script_exists_command(zval* object, zval* sha1s, zval* return_value
     efree(cmd_args);
     efree(cmd_args_len);
 
-    VALIDATE_SCRIPT_RESULT_OR_RETURN_FALSE(result, return_value);
+    VALIDATE_SCRIPT_RESULT_OR_RETURN_FALSE(valkey_glide, result);
 
     command_response_to_zval(result->response, return_value, 0, false);
     free_command_result(result);
@@ -363,7 +369,7 @@ void execute_script_show_command(
     CommandResult* result =
         execute_command(valkey_glide->glide_client, ScriptShow, 1, cmd_args, cmd_args_len);
 
-    VALIDATE_SCRIPT_RESULT_OR_RETURN_NULL(result, return_value);
+    VALIDATE_SCRIPT_RESULT_OR_RETURN_NULL(valkey_glide, result);
 
     command_response_to_zval(result->response, return_value, 0, false);
     free_command_result(result);
@@ -380,7 +386,7 @@ void execute_script_kill_command(zval* object, zval* return_value, bool is_clust
 
     CommandResult* result = execute_command(valkey_glide->glide_client, ScriptKill, 0, NULL, NULL);
 
-    VALIDATE_SCRIPT_RESULT_NO_RESPONSE_OR_RETURN_FALSE(result, return_value);
+    VALIDATE_SCRIPT_RESULT_NO_RESPONSE_OR_RETURN_FALSE(valkey_glide, result);
 
     command_response_to_zval(result->response, return_value, 0, false);
     free_command_result(result);

--- a/valkey_glide_x_common.c
+++ b/valkey_glide_x_common.c
@@ -487,6 +487,7 @@ int execute_x_generic_command(valkey_glide_object* valkey_glide,
 
     /* Check if there was an error */
     if (result->command_error) {
+        valkey_glide_record_command_error(valkey_glide, result);
         free_command_result(result);
         return 0;
     }

--- a/valkey_glide_z.c
+++ b/valkey_glide_z.c
@@ -1721,6 +1721,7 @@ int execute_zmpop_command_internal(valkey_glide_object* valkey_glide,
 
         /* Check if there was an error */
         if (cmd_result->command_error) {
+            valkey_glide_record_command_error(valkey_glide, cmd_result);
             free_command_result(cmd_result);
             return 0;
         }

--- a/valkey_glide_z_common.c
+++ b/valkey_glide_z_common.c
@@ -611,6 +611,7 @@ int execute_z_generic_command(valkey_glide_object* valkey_glide,
 
     /* Check if there was an error */
     if (result->command_error) {
+        valkey_glide_record_command_error(valkey_glide, result);
         free_command_result(result);
         return 0;
     }

--- a/valkey_z_php_methods.c
+++ b/valkey_z_php_methods.c
@@ -858,6 +858,14 @@ SETOPTION_METHOD_IMPL(ValkeyGlide)
 GETOPTION_METHOD_IMPL(ValkeyGlide)
 /* }}} */
 
+/* {{{ proto string|null ValkeyGlide::getLastError() */
+GETLASTERROR_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto bool ValkeyGlide::clearLastError() */
+CLEARLASTERROR_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
 /* {{{ proto bool ValkeyGlide::jsonSet(string key, string path, string value [, string condition])
  */
 JSON_SET_METHOD_IMPL(ValkeyGlide)


### PR DESCRIPTION
### Summary

`ValkeyGlide` / `ValkeyGlideCluster` did not implement the PHPRedis error-introspection methods `getLastError()` / `clearLastError()`. PHPRedis-compatible libraries depend on them: Symfony Lock `RedisStore::evaluate()` calls `clearLastError()` unconditionally on **every** lock acquire, which fataled with `Call to undefined method ValkeyGlide::clearLastError()` (#218, reproduced live).

The extension's error model already returns `false` to the caller on command errors — but the server error message produced by glide-core was discarded at the execution error sites. This PR stores that already-produced message on the client object and exposes the two accessors. **No behavior change on success paths or on paths that throw `ValkeyGlideException`.**

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide-php/issues/218

### Features / Behaviour Changes

- New methods on both `ValkeyGlide` and `ValkeyGlideCluster`, with PHPRedis semantics:
  - `getLastError(): ?string` — last recorded command error, `NULL` if none
  - `clearLastError(): bool` — resets it, always returns `true`
  - errors overwrite the previous one; successful commands do **not** clear it; only `clearLastError()` resets
- Command errors that are converted into a `false` return now record the server error message on the object. Paths that throw `ValkeyGlideException` are unchanged (the exception already carries the message).

### Implementation

- `zend_string* last_error` field on `valkey_glide_object` (shared by both classes), released in `free_valkey_glide_object`
- One shared helper, `valkey_glide_record_command_error()`, called at every execution path that converts a command error into `false`: the core command framework (`execute_core_command`), the script/eval validation macros, batch `exec()`, and the z / geo / list / hash / stream / set / function family executors (these have their own execution paths that bypass the core framework and previously dropped the error silently)
- Methods implemented via `GETLASTERROR_METHOD_IMPL` / `CLEARLASTERROR_METHOD_IMPL` macros following the existing `GETOPTION_METHOD_IMPL` pattern; stubs updated for both classes (arginfo is regenerated at build time)

**Reviewer attention — NOSCRIPT normalization** (`valkey_glide_set_last_error`, valkey_glide.c): glide-core (redis-rs) reformats server errors as `An error was signalled by the server: - NoScriptError: No matching script.`, while PHPRedis consumers pattern-match the raw RESP code — Symfony Lock does `str_starts_with($err, 'NOSCRIPT')` to reload missing scripts, which is the standard evalSha-first flow. Without restoring the prefix, the fallback never triggers and every `RedisStore` acquire fails. The helper strips the glide prefix and restores the `NOSCRIPT` code for that error kind. This is string-based because the FFI `RequestErrorType` enum only exposes Unspecified/ExecAbort/Timeout/Disconnect — exposing the full error kind through the FFI would be the robust long-term fix (happy to open a follow-up issue on valkey-glide core); a regression test guards the current mapping.

### Limitations

- Only the `NOSCRIPT` RESP code is restored; other server errors keep glide-core's message format (e.g. `WRONGTYPE: ...` instead of the raw `WRONGTYPE ...`). `str_contains`/prefix checks still match for the common codes.
- `last_error` is not populated for connection/lifecycle errors that throw — by design, the exception carries the message.

### Testing

- New `testGetLastErrorAndClearLastError` in `tests/ValkeyGlideTest.php` (inherited by `ValkeyGlideClusterTest`; uses `{hashtag}` keys so it is cluster-safe): fresh-client NULL, error recording via eval and via the core path, persistence across successful commands, clear semantics, overwrite semantics, NOSCRIPT prefix regression, and a per-family loop (zAdd / rPush / hSet / xAdd / geoadd / sAdd against a wrong-type key)
- Full local suite (extension built from this branch): 206 passed / 3 failed / 12 skipped — identical profile to `main`: the 3 failures are the `localhost`-hardcoded connection tests (pass when the test server shares the network namespace) and the 12 skips are the Valkey 9 hash-field-expiration gates (all pass against `valkey:9`)
- End-to-end with Symfony Lock 7.4 + PHP 8.3 + Valkey 8 (the exact #218 reproduction): `acquire()` → `true`, `refresh()`, `release()`, contention (second acquire `false`, no fatal), and the NOSCRIPT script-reload path all work; 22/22 checks pass
- `clang-format-18` and `phpcs` clean

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
