### PR TITLE
PHP: Test pie failure by removing recursive submodule setting

### DIFF
--- a/.github/workflows/test-pie.yml
+++ b/.github/workflows/test-pie.yml
@@ -58,8 +58,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Output Matrix Parameters for this job
         run: |

--- a/.github/workflows/test-pie.yml
+++ b/.github/workflows/test-pie.yml
@@ -344,3 +344,43 @@ jobs:
           if [ -f server.pid ]; then
             kill $(cat server.pid) || true
           fi
+
+  test-pie-install-from-packagist:
+    name: PIE Install from Packagist (v${{ matrix.version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1.0.0"]
+        php: ["8.2"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup PHP Extension Build Environment
+        uses: ./.github/workflows/setup-php-extension
+        with:
+          php-version: ${{ matrix.php }}
+          install-composer-deps: "false"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          engine-version: "9.0"
+
+      - name: Install from Packagist
+        run: |
+          echo "=== Installing valkey-glide-php v${{ matrix.version }} from Packagist ==="
+          sudo -E env "PATH=$PATH" "CARGO_BUILD_JOBS=$(nproc)" \
+            pie install valkey-io/valkey-glide-php:${{ matrix.version }} --force --no-interaction -vvv 2>&1 | tee pie_install.log
+          PIE_EXIT_CODE=${PIPESTATUS[0]}
+
+          if [ $PIE_EXIT_CODE -ne 0 ]; then
+            echo "ERROR: PIE install failed with exit code $PIE_EXIT_CODE"
+            exit 1
+          fi
+
+          echo "=== Verifying extension loads ==="
+          php -d extension=valkey_glide -r "
+            if (!class_exists('ValkeyGlide')) { echo 'FAIL: ValkeyGlide class not found'; exit(1); }
+            echo 'SUCCESS: Extension loaded from Packagist install' . PHP_EOL;
+          "

--- a/.github/workflows/test-pie.yml
+++ b/.github/workflows/test-pie.yml
@@ -346,7 +346,7 @@ jobs:
           fi
 
   test-pie-install-from-packagist:
-    name: PIE Install from Packagist (v${{ steps.get-version.outputs.version || 'unknown' }})
+    name: PIE Install from Packagist
     runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:

--- a/.github/workflows/test-pie.yml
+++ b/.github/workflows/test-pie.yml
@@ -58,6 +58,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Output Matrix Parameters for this job
         run: |
@@ -122,74 +124,6 @@ jobs:
           cd web && python3 -m http.server 8000 &
           echo $! > ../server.pid
           sleep 3
-
-      - name: Setup sccache for cross-user Rust caching
-        run: |
-          echo "=== Setting up sccache for cross-user Rust compilation caching ==="
-
-          # Install sccache
-          curl -L https://github.com/mozilla/sccache/releases/download/v0.7.4/sccache-v0.7.4-x86_64-unknown-linux-musl.tar.gz | tar xz
-          sudo mv sccache-v0.7.4-x86_64-unknown-linux-musl/sccache /usr/local/bin/
-          sudo chmod +x /usr/local/bin/sccache
-
-          # Set up sccache environment for all users
-          echo 'export RUSTC_WRAPPER=sccache' | sudo tee /etc/profile.d/sccache.sh
-          echo 'export SCCACHE_DIR=/opt/sccache' | sudo tee -a /etc/profile.d/sccache.sh
-          sudo chmod +x /etc/profile.d/sccache.sh
-
-          # Create sccache directory accessible to all users
-          sudo mkdir -p /opt/sccache
-          sudo chmod 777 /opt/sccache
-
-          # Set environment for current session
-          export RUSTC_WRAPPER=sccache
-          export SCCACHE_DIR=/opt/sccache
-
-          echo "sccache setup complete"
-
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
-        with:
-          workspaces: |
-            valkey-glide/ffi
-            valkey-glide/glide-core
-          key: pie
-
-      - name: Setup Cargo cache for root user
-        run: |
-          echo "=== Setting up Cargo cache for root user ==="
-          # Copy Cargo cache to root's home directory so PIE can use it
-          sudo mkdir -p /root/.cargo
-          if [ -d "$HOME/.cargo/registry" ]; then
-            echo "Copying Cargo registry cache to root..."
-            sudo cp -r "$HOME/.cargo/registry" /root/.cargo/ || echo "Failed to copy registry cache"
-          fi
-          if [ -d "$HOME/.cargo/git" ]; then
-            echo "Copying Cargo git cache to root..."
-            sudo cp -r "$HOME/.cargo/git" /root/.cargo/ || echo "Failed to copy git cache"
-          fi
-
-          # Set up shared target directory for compiled dependencies
-          echo "=== Setting up shared compilation cache for PIE ==="
-
-          # Create a shared target directory that root can access
-          sudo mkdir -p /opt/cargo-target
-          sudo chmod 755 /opt/cargo-target
-
-          # Copy existing compiled dependencies (not our project code)
-          if [ -d "valkey-glide/ffi/target/release/deps" ]; then
-            echo "Copying compiled dependencies..."
-            sudo mkdir -p /opt/cargo-target/release
-            sudo cp -r valkey-glide/ffi/target/release/deps /opt/cargo-target/release/
-            sudo chmod -R 755 /opt/cargo-target/release/deps
-          fi
-
-          # Set CARGO_TARGET_DIR for all processes
-          echo 'export CARGO_TARGET_DIR=/opt/cargo-target' | sudo tee /etc/profile.d/cargo.sh
-          echo 'export CARGO_HOME=/root/.cargo' | sudo tee -a /etc/profile.d/cargo.sh
-          echo 'export PATH="/root/.cargo/bin:$PATH"' | sudo tee -a /etc/profile.d/cargo.sh
-          sudo chmod +x /etc/profile.d/cargo.sh
-
-          echo "Shared compilation cache setup complete"
 
       - name: Test PIE with manual repository
         run: |

--- a/.github/workflows/test-pie.yml
+++ b/.github/workflows/test-pie.yml
@@ -346,18 +346,24 @@ jobs:
           fi
 
   test-pie-install-from-packagist:
-    name: PIE Install from Packagist (v${{ matrix.version }})
+    name: PIE Install from Packagist (v${{ steps.get-version.outputs.version || 'unknown' }})
     runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
-        version: ["1.0.0"]
         php: ["8.2"]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Get release version from common.h
+        id: get-version
+        run: |
+          VERSION=$(grep -o '#define VALKEY_GLIDE_PHP_VERSION "[^"]*"' common.h | sed 's/.*"\([^"]*\)"/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Detected version: $VERSION"
 
       - name: Setup PHP Extension Build Environment
         uses: ./.github/workflows/setup-php-extension
@@ -369,9 +375,10 @@ jobs:
 
       - name: Install from Packagist
         run: |
-          echo "=== Installing valkey-glide-php v${{ matrix.version }} from Packagist ==="
+          VERSION="${{ steps.get-version.outputs.version }}"
+          echo "=== Installing valkey-glide-php v${VERSION} from Packagist ==="
           sudo -E env "PATH=$PATH" "CARGO_BUILD_JOBS=$(nproc)" \
-            pie install valkey-io/valkey-glide-php:${{ matrix.version }} --force --no-interaction -vvv 2>&1 | tee pie_install.log
+            pie install valkey-io/valkey-glide-php:${VERSION} --force --no-interaction -vvv 2>&1 | tee pie_install.log
           PIE_EXIT_CODE=${PIPESTATUS[0]}
 
           if [ $PIE_EXIT_CODE -ne 0 ]; then


### PR DESCRIPTION
### Summary

Removes sccache, rust-cache, and cargo cache sharing steps from the PIE install test to expose the submodule resolution bug.

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide-php/issues/224

### What this does

The PIE test had steps that pre-built Rust artifacts from the CI checkout's submodule (correct commit) and shared them with the root user running pie install. This masked the fact 
that PIE's own submodule resolution clones valkey-glide at main HEAD instead of the pinned release commit.

Removed steps:
- Setup sccache for cross-user Rust caching
- Swatinem/rust-cache
- Setup Cargo cache for root user

### Expected Result

This CI run should fail — proving that PIE builds against main of the Rust core instead of the commit pinned in the release tag. The failure will occur during the Rust FFI build due to
incompatible API changes on main.

### Next Steps

Once failure is confirmed, a follow-up PR will fix the submodule resolution in config.m4 and Makefile.frag using git ls-tree HEAD to extract the correct commit hash.
### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
