### PR TITLE
feat(php): implement BGSAVE, BGSAVE SCHEDULE, and BGSAVE CANCEL commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Changes
 
-
 * PHP: Add `BGSAVE`, `BGSAVE SCHEDULE`, and `BGSAVE CANCEL` commands for standalone and cluster clients ([#236](https://github.com/valkey-io/valkey-glide-php/issues/236))
 * PHP: Fix pie install from Packagist using PIE pre-packaged-source download method ([#233](https://github.com/valkey-io/valkey-glide-php/pull/233))
 * PHP: Fix pie install from Packagist by setting preferred-install to source for submodule resolution ([#232](https://github.com/valkey-io/valkey-glide-php/pull/232))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* PHP: Add `BGSAVE`, `BGSAVE SCHEDULE`, and `BGSAVE CANCEL` commands for standalone and cluster clients ([#236](https://github.com/valkey-io/valkey-glide-php/issues/236))
 * PHP: Fix pie install from Packagist by setting preferred-install to source for submodule resolution ([#232](https://github.com/valkey-io/valkey-glide-php/pull/232))
 * PHP: Fix pie install ([#229](https://github.com/valkey-io/valkey-glide-php/pull/229))
 * PHP: Set CLIENT SETINFO lib-name=GlidePHP and lib-ver to extension version for proper client identification

--- a/tests/ValkeyGlideBaseTest.php
+++ b/tests/ValkeyGlideBaseTest.php
@@ -323,4 +323,23 @@ abstract class ValkeyGlideBaseTest extends TestSuite
             $this->markTestSkipped('DNS tests are disabled. Set VALKEY_GLIDE_DNS_TESTS_ENABLED=1 to enable.');
         }
     }
+
+    /**
+     * Waits until the given condition callback returns true, polling every 100ms.
+     *
+     * @param callable $condition  A callback that returns true when the condition is met.
+     * @param int      $timeoutSeconds  Maximum time to wait in seconds.
+     * @param string   $message  Failure message if timeout is reached.
+     */
+    protected function waitFor(callable $condition, int $timeoutSeconds = 10, string $message = 'waitFor timed out'): void
+    {
+        $start = time();
+        while (time() - $start < $timeoutSeconds) {
+            if ($condition()) {
+                return;
+            }
+            usleep(100000); // 100ms
+        }
+        $this->fail($message);
+    }
 }

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -418,6 +418,30 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         ];
     }
 
+    /**
+     * Override for cluster - info() requires a route parameter.
+     */
+    protected function waitForSaveNotInProgress()
+    {
+        $route  = 'randomNode';
+        $maxWait = 10; // seconds
+        $start   = time();
+        while (time() - $start < $maxWait) {
+            $info = $this->valkey_glide->info($route, 'persistence');
+            if (is_array($info)) {
+                if (
+                    (!isset($info['rdb_bgsave_in_progress']) || $info['rdb_bgsave_in_progress'] != '1') &&
+                    (!isset($info['aof_rewrite_in_progress']) || $info['aof_rewrite_in_progress'] != '1')
+                ) {
+                    return;
+                }
+            } else {
+                return;
+            }
+            usleep(100000); // 100ms
+        }
+    }
+
     public function testBgSave()
     {
         // Wait for any in-progress save to complete

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -430,7 +430,10 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         // Test with allPrimaries route - returns array of node => bool
         $result = $this->valkey_glide->bgSave('allPrimaries');
         $this->assertIsArray($result);
-        foreach ($result as $nodeResult) {
+        $this->assertGT(0, count($result));
+        foreach ($result as $nodeAddress => $nodeResult) {
+            $this->assertIsString($nodeAddress);
+            $this->assertStringContains(':', $nodeAddress);
             $this->assertTrue($nodeResult);
         }
 
@@ -448,7 +451,10 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         // Test with allPrimaries route - returns array of node => bool
         $result = $this->valkey_glide->bgSave('allPrimaries', 'SCHEDULE');
         $this->assertIsArray($result);
-        foreach ($result as $nodeResult) {
+        $this->assertGT(0, count($result));
+        foreach ($result as $nodeAddress => $nodeResult) {
+            $this->assertIsString($nodeAddress);
+            $this->assertStringContains(':', $nodeAddress);
             $this->assertTrue($nodeResult);
         }
 
@@ -471,7 +477,10 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         // Test with allPrimaries route - returns array of node => bool
         $result = $this->valkey_glide->bgSave('allPrimaries', 'CANCEL');
         $this->assertIsArray($result);
-        foreach ($result as $nodeResult) {
+        $this->assertGT(0, count($result));
+        foreach ($result as $nodeAddress => $nodeResult) {
+            $this->assertIsString($nodeAddress);
+            $this->assertStringContains(':', $nodeAddress);
             $this->assertFalse($nodeResult);
         }
 

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -424,20 +424,10 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitFor(function () {
             $info = $this->valkey_glide->info('allPrimaries', 'persistence');
-            if (!is_array($info)) {
-                return true;
-            }
             foreach ($info as $nodeInfo) {
-                if (is_array($nodeInfo)) {
-                    if (($nodeInfo['rdb_bgsave_in_progress'] ?? '0') == '1'
-                        || ($nodeInfo['aof_rewrite_in_progress'] ?? '0') == '1') {
-                        return false;
-                    }
-                } elseif (is_string($nodeInfo)) {
-                    if (strpos($nodeInfo, 'rdb_bgsave_in_progress:1') !== false
-                        || strpos($nodeInfo, 'aof_rewrite_in_progress:1') !== false) {
-                        return false;
-                    }
+                if ($nodeInfo['rdb_bgsave_in_progress'] == '1'
+                    || $nodeInfo['aof_rewrite_in_progress'] == '1') {
+                    return false;
                 }
             }
             return true;

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -422,40 +422,26 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
      */
     protected function waitForSaveNotInProgress()
     {
-        $route   = 'allPrimaries';
-        $maxWait = 10; // seconds
-        $start   = time();
-        while (time() - $start < $maxWait) {
-            $info = $this->valkey_glide->info($route, 'persistence');
-            if (is_array($info)) {
-                $saveInProgress = false;
-                foreach ($info as $nodeInfo) {
-                    if (is_array($nodeInfo)) {
-                        if (
-                            (isset($nodeInfo['rdb_bgsave_in_progress']) && $nodeInfo['rdb_bgsave_in_progress'] == '1') ||
-                            (isset($nodeInfo['aof_rewrite_in_progress']) && $nodeInfo['aof_rewrite_in_progress'] == '1')
-                        ) {
-                            $saveInProgress = true;
-                            break;
-                        }
-                    } elseif (is_string($nodeInfo)) {
-                        if (
-                            strpos($nodeInfo, 'rdb_bgsave_in_progress:1') !== false ||
-                            strpos($nodeInfo, 'aof_rewrite_in_progress:1') !== false
-                        ) {
-                            $saveInProgress = true;
-                            break;
-                        }
+        $this->waitFor(function () {
+            $info = $this->valkey_glide->info('allPrimaries', 'persistence');
+            if (!is_array($info)) {
+                return true;
+            }
+            foreach ($info as $nodeInfo) {
+                if (is_array($nodeInfo)) {
+                    if (($nodeInfo['rdb_bgsave_in_progress'] ?? '0') == '1'
+                        || ($nodeInfo['aof_rewrite_in_progress'] ?? '0') == '1') {
+                        return false;
+                    }
+                } elseif (is_string($nodeInfo)) {
+                    if (strpos($nodeInfo, 'rdb_bgsave_in_progress:1') !== false
+                        || strpos($nodeInfo, 'aof_rewrite_in_progress:1') !== false) {
+                        return false;
                     }
                 }
-                if (!$saveInProgress) {
-                    return;
-                }
-            } else {
-                return;
             }
-            usleep(100000); // 100ms
-        }
+            return true;
+        }, 10, 'Timed out waiting for background save to complete on cluster');
     }
 
     public function testBgSave()

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -406,6 +406,18 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         }
     }
 
+    /**
+     * Valid BGSAVE response strings for cluster (includes "OK" from aggregated multi-node response).
+     */
+    protected function bgsaveResponses(): array
+    {
+        return [
+            'Background saving started',
+            'Background saving scheduled',
+            'OK',
+        ];
+    }
+
     public function testBgSave()
     {
         // Wait for any in-progress save to complete
@@ -413,10 +425,10 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         $route = 'allPrimaries';
 
-        // BGSAVE with route - returns a non-empty status string
+        // BGSAVE with route - returns a valid status string
         $result = $this->valkey_glide->bgSave($route);
         $this->assertIsString($result);
-        $this->assertNotEquals('', $result);
+        $this->assertContains($result, $this->bgsaveResponses());
 
         // Wait for the bgsave to complete before next test
         $this->waitForSaveNotInProgress();
@@ -432,7 +444,7 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         // BGSAVE SCHEDULE with route
         $result = $this->valkey_glide->bgSave($route, 'SCHEDULE');
         $this->assertIsString($result);
-        $this->assertNotEquals('', $result);
+        $this->assertContains($result, $this->bgsaveResponses());
 
         // Wait for the scheduled bgsave to complete
         $this->waitForSaveNotInProgress();

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -465,10 +465,9 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         $route = 'allPrimaries';
 
-        // BGSAVE with route - returns a valid status string
+        // BGSAVE with route - returns true on success (PHPRedis compatible)
         $result = $this->valkey_glide->bgSave($route);
-        $this->assertIsString($result);
-        $this->assertContains($result, $this->bgsaveResponses());
+        $this->assertTrue($result);
 
         // Wait for the bgsave to complete before next test
         $this->waitForSaveNotInProgress();
@@ -481,10 +480,9 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         $route = 'allPrimaries';
 
-        // BGSAVE SCHEDULE with route
+        // BGSAVE SCHEDULE with route - returns true on success
         $result = $this->valkey_glide->bgSave($route, 'SCHEDULE');
-        $this->assertIsString($result);
-        $this->assertContains($result, $this->bgsaveResponses());
+        $this->assertTrue($result);
 
         // Wait for the scheduled bgsave to complete
         $this->waitForSaveNotInProgress();
@@ -503,7 +501,7 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         // Wait for any in-progress save to complete
         $this->waitForSaveNotInProgress();
 
-        // When no save is in progress, BGSAVE CANCEL should return an error (false)
+        // When no save is in progress, BGSAVE CANCEL should return false
         $result = $this->valkey_glide->bgSave($route, 'CANCEL');
         $this->assertFalse($result);
     }

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -448,37 +448,26 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
     public function testBgSave()
     {
-        // Wait for any in-progress save to complete
         $this->waitForSaveNotInProgress();
 
         $route = 'allPrimaries';
 
-        // BGSAVE with route - returns true on success (PHPRedis compatible)
         $result = $this->valkey_glide->bgSave($route);
         $this->assertTrue($result);
-
-        // Wait for the bgsave to complete before next test
-        $this->waitForSaveNotInProgress();
     }
 
     public function testBgSaveSchedule()
     {
-        // Wait for any in-progress save to complete
         $this->waitForSaveNotInProgress();
 
         $route = 'allPrimaries';
 
-        // BGSAVE SCHEDULE with route - returns true on success
         $result = $this->valkey_glide->bgSave($route, 'SCHEDULE');
         $this->assertTrue($result);
-
-        // Wait for the scheduled bgsave to complete
-        $this->waitForSaveNotInProgress();
     }
 
     public function testBgSaveCancel()
     {
-        // BGSAVE CANCEL requires Valkey 8.1+
         if (!$this->minVersionCheck('8.1.0')) {
             $this->markTestSkipped('BGSAVE CANCEL requires Valkey 8.1.0+');
             return;
@@ -486,10 +475,8 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         $route = 'allPrimaries';
 
-        // Wait for any in-progress save to complete
         $this->waitForSaveNotInProgress();
 
-        // When no save is in progress, BGSAVE CANCEL should return false
         $result = $this->valkey_glide->bgSave($route, 'CANCEL');
         $this->assertFalse($result);
     }

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -418,20 +418,32 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     }
 
     /**
+     * Override for cluster - info() requires a route parameter and checks all primaries.
+     */
+    protected function isSaveInProgress(): bool
+    {
+        $info = $this->valkey_glide->info('allPrimaries', 'persistence');
+        foreach ($info as $nodeInfo) {
+            if (
+                $nodeInfo['rdb_bgsave_in_progress'] == '1'
+                || $nodeInfo['aof_rewrite_in_progress'] == '1'
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Override for cluster - info() requires a route parameter.
      */
     protected function waitForSaveNotInProgress()
     {
-        $this->waitFor(function () {
-            $info = $this->valkey_glide->info('allPrimaries', 'persistence');
-            foreach ($info as $nodeInfo) {
-                if ($nodeInfo['rdb_bgsave_in_progress'] == '1'
-                    || $nodeInfo['aof_rewrite_in_progress'] == '1') {
-                    return false;
-                }
-            }
-            return true;
-        }, 10, 'Timed out waiting for background save to complete on cluster');
+        $this->waitFor(
+            fn() => !$this->isSaveInProgress(),
+            10,
+            'Timed out waiting for background save to complete on cluster'
+        );
     }
 
     public function testBgSave()

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -423,18 +423,6 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         return false;
     }
 
-    /**
-     * Override for cluster - info() requires a route parameter.
-     */
-    protected function waitForSaveNotInProgress()
-    {
-        $this->waitFor(
-            fn() => !$this->isSaveInProgress(),
-            10,
-            'Timed out waiting for background save to complete on cluster'
-        );
-    }
-
     public function testBgSave()
     {
         $this->waitForSaveNotInProgress();

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -474,7 +474,14 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         $this->waitForSaveNotInProgress();
 
-        // When no save is in progress, CANCEL returns false (error response)
+        // When no save is in progress, CANCEL returns false (not an array) even for
+        // multi-node routes. This is because the glide-core's response aggregation
+        // checks all node responses for errors before building the Map result. When
+        // ALL nodes return a ServerError (no save in progress), the core collapses
+        // them into a single command_error rather than returning a per-node Map.
+        // This matches PHPRedis semantics where bgSave() returns false on failure.
+        // A successful CANCEL (when a save IS in progress) would return an array
+        // for multi-node routes since at least one node returns a success response.
         $result = $this->valkey_glide->bgSave('allPrimaries', 'CANCEL');
         $this->assertFalse($result);
 
@@ -523,6 +530,7 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         if ($this->minVersionCheck('8.1.0')) {
             $this->waitForSaveNotInProgress();
 
+            // CANCEL with no save in progress returns false (see testBgSaveCancel comment)
             $result = $this->valkey_glide->bgSave('allPrimaries', 'CANCEL');
             $this->assertFalse($result);
 

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -407,14 +407,13 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     }
 
     /**
-     * Valid BGSAVE response strings for cluster (includes "OK" from aggregated multi-node response).
+     * Valid BGSAVE response strings for cluster.
      */
     protected function bgsaveResponses(): array
     {
         return [
             'Background saving started',
             'Background saving scheduled',
-            'OK',
         ];
     }
 
@@ -423,16 +422,33 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
      */
     protected function waitForSaveNotInProgress()
     {
-        $route  = 'randomNode';
+        $route   = 'allPrimaries';
         $maxWait = 10; // seconds
         $start   = time();
         while (time() - $start < $maxWait) {
             $info = $this->valkey_glide->info($route, 'persistence');
             if (is_array($info)) {
-                if (
-                    (!isset($info['rdb_bgsave_in_progress']) || $info['rdb_bgsave_in_progress'] != '1') &&
-                    (!isset($info['aof_rewrite_in_progress']) || $info['aof_rewrite_in_progress'] != '1')
-                ) {
+                $saveInProgress = false;
+                foreach ($info as $nodeInfo) {
+                    if (is_array($nodeInfo)) {
+                        if (
+                            (isset($nodeInfo['rdb_bgsave_in_progress']) && $nodeInfo['rdb_bgsave_in_progress'] == '1') ||
+                            (isset($nodeInfo['aof_rewrite_in_progress']) && $nodeInfo['aof_rewrite_in_progress'] == '1')
+                        ) {
+                            $saveInProgress = true;
+                            break;
+                        }
+                    } elseif (is_string($nodeInfo)) {
+                        if (
+                            strpos($nodeInfo, 'rdb_bgsave_in_progress:1') !== false ||
+                            strpos($nodeInfo, 'aof_rewrite_in_progress:1') !== false
+                        ) {
+                            $saveInProgress = true;
+                            break;
+                        }
+                    }
+                }
+                if (!$saveInProgress) {
                     return;
                 }
             } else {

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -474,17 +474,10 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         $this->waitForSaveNotInProgress();
 
-        // Test with allPrimaries route - returns array of node => bool
+        // When no save is in progress, CANCEL returns false (error response)
         $result = $this->valkey_glide->bgSave('allPrimaries', 'CANCEL');
-        $this->assertIsArray($result);
-        $this->assertGT(0, count($result));
-        foreach ($result as $nodeAddress => $nodeResult) {
-            $this->assertIsString($nodeAddress);
-            $this->assertStringContains(':', $nodeAddress);
-            $this->assertFalse($nodeResult);
-        }
+        $this->assertFalse($result);
 
-        // Test with randomNode route - returns scalar bool
         $result = $this->valkey_glide->bgSave('randomNode', 'CANCEL');
         $this->assertFalse($result);
     }
@@ -530,14 +523,9 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         if ($this->minVersionCheck('8.1.0')) {
             $this->waitForSaveNotInProgress();
 
-            // Test CANCEL with allPrimaries route - returns array of node => bool
             $result = $this->valkey_glide->bgSave('allPrimaries', 'CANCEL');
-            $this->assertIsArray($result);
-            foreach ($result as $nodeResult) {
-                $this->assertFalse($nodeResult);
-            }
+            $this->assertFalse($result);
 
-            // Test CANCEL with randomNode route - returns scalar bool
             $result = $this->valkey_glide->bgSave('randomNode', 'CANCEL');
             $this->assertFalse($result);
         }
@@ -578,10 +566,7 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
             $this->valkey_glide->pipeline();
             $this->valkey_glide->bgSave('allPrimaries', 'CANCEL');
             $result = $this->valkey_glide->exec();
-            $this->assertIsArray($result[0]);
-            foreach ($result[0] as $nodeResult) {
-                $this->assertFalse($nodeResult);
-            }
+            $this->assertFalse($result[0]);
         }
     }
 

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -523,14 +523,14 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->valkey_glide->pipeline();
         $this->valkey_glide->bgSave('allPrimaries');
         $result = $this->valkey_glide->exec();
-        $this->assertTrue($result[0]);
+        $this->assertContains($result[0], $this->bgsaveResponses());
 
         $this->waitForSaveNotInProgress();
 
         $this->valkey_glide->pipeline();
         $this->valkey_glide->bgSave('allPrimaries', 'SCHEDULE');
         $result = $this->valkey_glide->exec();
-        $this->assertTrue($result[0]);
+        $this->assertContains($result[0], $this->bgsaveResponses());
 
         if ($this->minVersionCheck('8.1.0')) {
             $this->waitForSaveNotInProgress();

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -511,6 +511,37 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
     }
 
+    public function testBgSaveBatch()
+    {
+        if (!$this->havePipeline()) {
+            $this->markTestSkipped('Pipeline not supported');
+            return;
+        }
+
+        $this->waitForSaveNotInProgress();
+
+        $this->valkey_glide->pipeline();
+        $this->valkey_glide->bgSave('allPrimaries');
+        $result = $this->valkey_glide->exec();
+        $this->assertTrue($result[0]);
+
+        $this->waitForSaveNotInProgress();
+
+        $this->valkey_glide->pipeline();
+        $this->valkey_glide->bgSave('allPrimaries', 'SCHEDULE');
+        $result = $this->valkey_glide->exec();
+        $this->assertTrue($result[0]);
+
+        if ($this->minVersionCheck('8.1.0')) {
+            $this->waitForSaveNotInProgress();
+
+            $this->valkey_glide->pipeline();
+            $this->valkey_glide->bgSave('allPrimaries', 'CANCEL');
+            $result = $this->valkey_glide->exec();
+            $this->assertFalse($result[0]);
+        }
+    }
+
     public function testInfo()
     {
         $fields = [

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -427,13 +427,16 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
-        // Test with allPrimaries route
+        // Test with allPrimaries route - returns array of node => bool
         $result = $this->valkey_glide->bgSave('allPrimaries');
-        $this->assertTrue($result);
+        $this->assertIsArray($result);
+        foreach ($result as $nodeResult) {
+            $this->assertTrue($nodeResult);
+        }
 
         $this->waitForSaveNotInProgress();
 
-        // Test with randomNode route
+        // Test with randomNode route - returns scalar bool
         $result = $this->valkey_glide->bgSave('randomNode');
         $this->assertTrue($result);
     }
@@ -442,13 +445,16 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
-        // Test with allPrimaries route
+        // Test with allPrimaries route - returns array of node => bool
         $result = $this->valkey_glide->bgSave('allPrimaries', 'SCHEDULE');
-        $this->assertTrue($result);
+        $this->assertIsArray($result);
+        foreach ($result as $nodeResult) {
+            $this->assertTrue($nodeResult);
+        }
 
         $this->waitForSaveNotInProgress();
 
-        // Test with randomNode route
+        // Test with randomNode route - returns scalar bool
         $result = $this->valkey_glide->bgSave('randomNode', 'SCHEDULE');
         $this->assertTrue($result);
     }
@@ -462,11 +468,14 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         $this->waitForSaveNotInProgress();
 
-        // Test with allPrimaries route
+        // Test with allPrimaries route - returns array of node => bool
         $result = $this->valkey_glide->bgSave('allPrimaries', 'CANCEL');
-        $this->assertFalse($result);
+        $this->assertIsArray($result);
+        foreach ($result as $nodeResult) {
+            $this->assertFalse($nodeResult);
+        }
 
-        // Test with randomNode route
+        // Test with randomNode route - returns scalar bool
         $result = $this->valkey_glide->bgSave('randomNode', 'CANCEL');
         $this->assertFalse($result);
     }
@@ -477,28 +486,34 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
 
-        // Test with allPrimaries route
+        // Test with allPrimaries route - returns array of node => string
         $result = $this->valkey_glide->bgSave('allPrimaries');
-        $this->assertIsString($result);
-        $this->assertContains($result, $this->bgsaveResponses());
+        $this->assertIsArray($result);
+        foreach ($result as $nodeResult) {
+            $this->assertIsString($nodeResult);
+            $this->assertContains($nodeResult, $this->bgsaveResponses());
+        }
 
         $this->waitForSaveNotInProgress();
 
-        // Test with randomNode route
+        // Test with randomNode route - returns scalar string
         $result = $this->valkey_glide->bgSave('randomNode');
         $this->assertIsString($result);
         $this->assertContains($result, $this->bgsaveResponses());
 
         $this->waitForSaveNotInProgress();
 
-        // Test SCHEDULE with allPrimaries route
+        // Test SCHEDULE with allPrimaries route - returns array of node => string
         $result = $this->valkey_glide->bgSave('allPrimaries', 'SCHEDULE');
-        $this->assertIsString($result);
-        $this->assertContains($result, $this->bgsaveResponses());
+        $this->assertIsArray($result);
+        foreach ($result as $nodeResult) {
+            $this->assertIsString($nodeResult);
+            $this->assertContains($nodeResult, $this->bgsaveResponses());
+        }
 
         $this->waitForSaveNotInProgress();
 
-        // Test SCHEDULE with randomNode route
+        // Test SCHEDULE with randomNode route - returns scalar string
         $result = $this->valkey_glide->bgSave('randomNode', 'SCHEDULE');
         $this->assertIsString($result);
         $this->assertContains($result, $this->bgsaveResponses());
@@ -506,11 +521,14 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         if ($this->minVersionCheck('8.1.0')) {
             $this->waitForSaveNotInProgress();
 
-            // Test CANCEL with allPrimaries route
+            // Test CANCEL with allPrimaries route - returns array of node => bool
             $result = $this->valkey_glide->bgSave('allPrimaries', 'CANCEL');
-            $this->assertFalse($result);
+            $this->assertIsArray($result);
+            foreach ($result as $nodeResult) {
+                $this->assertFalse($nodeResult);
+            }
 
-            // Test CANCEL with randomNode route
+            // Test CANCEL with randomNode route - returns scalar bool
             $result = $this->valkey_glide->bgSave('randomNode', 'CANCEL');
             $this->assertFalse($result);
         }
@@ -530,14 +548,20 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->valkey_glide->pipeline();
         $this->valkey_glide->bgSave('allPrimaries');
         $result = $this->valkey_glide->exec();
-        $this->assertTrue($result[0]);
+        $this->assertIsArray($result[0]);
+        foreach ($result[0] as $nodeResult) {
+            $this->assertTrue($nodeResult);
+        }
 
         $this->waitForSaveNotInProgress();
 
         $this->valkey_glide->pipeline();
         $this->valkey_glide->bgSave('allPrimaries', 'SCHEDULE');
         $result = $this->valkey_glide->exec();
-        $this->assertTrue($result[0]);
+        $this->assertIsArray($result[0]);
+        foreach ($result[0] as $nodeResult) {
+            $this->assertTrue($nodeResult);
+        }
 
         if ($this->minVersionCheck('8.1.0')) {
             $this->waitForSaveNotInProgress();
@@ -545,7 +569,10 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
             $this->valkey_glide->pipeline();
             $this->valkey_glide->bgSave('allPrimaries', 'CANCEL');
             $result = $this->valkey_glide->exec();
-            $this->assertFalse($result[0]);
+            $this->assertIsArray($result[0]);
+            foreach ($result[0] as $nodeResult) {
+                $this->assertFalse($nodeResult);
+            }
         }
     }
 

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -407,17 +407,6 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     }
 
     /**
-     * Valid BGSAVE response strings for cluster.
-     */
-    protected function bgsaveResponses(): array
-    {
-        return [
-            'Background saving started',
-            'Background saving scheduled',
-        ];
-    }
-
-    /**
      * Override for cluster - info() requires a route parameter and checks all primaries.
      */
     protected function isSaveInProgress(): bool
@@ -450,9 +439,14 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
-        $route = 'allPrimaries';
+        // Test with allPrimaries route
+        $result = $this->valkey_glide->bgSave('allPrimaries');
+        $this->assertTrue($result);
 
-        $result = $this->valkey_glide->bgSave($route);
+        $this->waitForSaveNotInProgress();
+
+        // Test with randomNode route
+        $result = $this->valkey_glide->bgSave('randomNode');
         $this->assertTrue($result);
     }
 
@@ -460,9 +454,14 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
-        $route = 'allPrimaries';
+        // Test with allPrimaries route
+        $result = $this->valkey_glide->bgSave('allPrimaries', 'SCHEDULE');
+        $this->assertTrue($result);
 
-        $result = $this->valkey_glide->bgSave($route, 'SCHEDULE');
+        $this->waitForSaveNotInProgress();
+
+        // Test with randomNode route
+        $result = $this->valkey_glide->bgSave('randomNode', 'SCHEDULE');
         $this->assertTrue($result);
     }
 
@@ -473,12 +472,43 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
             return;
         }
 
-        $route = 'allPrimaries';
+        $this->waitForSaveNotInProgress();
+
+        // Test with allPrimaries route
+        $result = $this->valkey_glide->bgSave('allPrimaries', 'CANCEL');
+        $this->assertFalse($result);
+
+        // Test with randomNode route
+        $result = $this->valkey_glide->bgSave('randomNode', 'CANCEL');
+        $this->assertFalse($result);
+    }
+
+    public function testBgSaveWithReplyLiteral()
+    {
+        $this->waitForSaveNotInProgress();
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+
+        // Test with allPrimaries route
+        $result = $this->valkey_glide->bgSave('allPrimaries');
+        $this->assertIsString($result);
+        $this->assertContains($result, $this->bgsaveResponses());
 
         $this->waitForSaveNotInProgress();
 
-        $result = $this->valkey_glide->bgSave($route, 'CANCEL');
-        $this->assertFalse($result);
+        // Test with randomNode route
+        $result = $this->valkey_glide->bgSave('randomNode');
+        $this->assertIsString($result);
+        $this->assertContains($result, $this->bgsaveResponses());
+
+        $this->waitForSaveNotInProgress();
+
+        // Test SCHEDULE with allPrimaries route
+        $result = $this->valkey_glide->bgSave('allPrimaries', 'SCHEDULE');
+        $this->assertIsString($result);
+        $this->assertContains($result, $this->bgsaveResponses());
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
     }
 
     public function testInfo()

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -508,6 +508,18 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->assertIsString($result);
         $this->assertContains($result, $this->bgsaveResponses());
 
+        if ($this->minVersionCheck('8.1.0')) {
+            $this->waitForSaveNotInProgress();
+
+            // Test CANCEL with allPrimaries route
+            $result = $this->valkey_glide->bgSave('allPrimaries', 'CANCEL');
+            $this->assertFalse($result);
+
+            // Test CANCEL with randomNode route
+            $result = $this->valkey_glide->bgSave('randomNode', 'CANCEL');
+            $this->assertFalse($result);
+        }
+
         $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
     }
 

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -406,6 +406,56 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         }
     }
 
+    public function testBgSave()
+    {
+        // Wait for any in-progress save to complete
+        $this->waitForSaveNotInProgress();
+
+        $route = 'allPrimaries';
+
+        // BGSAVE with route - returns a non-empty status string
+        $result = $this->valkey_glide->bgSave($route);
+        $this->assertIsString($result);
+        $this->assertNotEquals('', $result);
+
+        // Wait for the bgsave to complete before next test
+        $this->waitForSaveNotInProgress();
+    }
+
+    public function testBgSaveSchedule()
+    {
+        // Wait for any in-progress save to complete
+        $this->waitForSaveNotInProgress();
+
+        $route = 'allPrimaries';
+
+        // BGSAVE SCHEDULE with route
+        $result = $this->valkey_glide->bgSave($route, 'SCHEDULE');
+        $this->assertIsString($result);
+        $this->assertNotEquals('', $result);
+
+        // Wait for the scheduled bgsave to complete
+        $this->waitForSaveNotInProgress();
+    }
+
+    public function testBgSaveCancel()
+    {
+        // BGSAVE CANCEL requires Valkey 8.1+
+        if (!$this->minVersionCheck('8.1.0')) {
+            $this->markTestSkipped('BGSAVE CANCEL requires Valkey 8.1.0+');
+            return;
+        }
+
+        $route = 'allPrimaries';
+
+        // Wait for any in-progress save to complete
+        $this->waitForSaveNotInProgress();
+
+        // When no save is in progress, BGSAVE CANCEL should return an error (false)
+        $result = $this->valkey_glide->bgSave($route, 'CANCEL');
+        $this->assertFalse($result);
+    }
+
     public function testInfo()
     {
         $fields = [

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -496,6 +496,13 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->assertIsString($result);
         $this->assertContains($result, $this->bgsaveResponses());
 
+        $this->waitForSaveNotInProgress();
+
+        // Test SCHEDULE with randomNode route
+        $result = $this->valkey_glide->bgSave('randomNode', 'SCHEDULE');
+        $this->assertIsString($result);
+        $this->assertContains($result, $this->bgsaveResponses());
+
         if ($this->minVersionCheck('8.1.0')) {
             $this->waitForSaveNotInProgress();
 
@@ -523,14 +530,14 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->valkey_glide->pipeline();
         $this->valkey_glide->bgSave('allPrimaries');
         $result = $this->valkey_glide->exec();
-        $this->assertContains($result[0], $this->bgsaveResponses());
+        $this->assertTrue($result[0]);
 
         $this->waitForSaveNotInProgress();
 
         $this->valkey_glide->pipeline();
         $this->valkey_glide->bgSave('allPrimaries', 'SCHEDULE');
         $result = $this->valkey_glide->exec();
-        $this->assertContains($result[0], $this->bgsaveResponses());
+        $this->assertTrue($result[0]);
 
         if ($this->minVersionCheck('8.1.0')) {
             $this->waitForSaveNotInProgress();

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2652,14 +2652,14 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->valkey_glide->pipeline();
         $this->valkey_glide->bgSave();
         $result = $this->valkey_glide->exec();
-        $this->assertTrue($result[0]);
+        $this->assertContains($result[0], $this->bgsaveResponses());
 
         $this->waitForSaveNotInProgress();
 
         $this->valkey_glide->pipeline();
         $this->valkey_glide->bgSave('SCHEDULE');
         $result = $this->valkey_glide->exec();
-        $this->assertTrue($result[0]);
+        $this->assertContains($result[0], $this->bgsaveResponses());
 
         if ($this->minVersionCheck('8.1.0')) {
             $this->waitForSaveNotInProgress();

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2590,10 +2590,9 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         // Wait for any in-progress save to complete
         $this->waitForSaveNotInProgress();
 
-        // BGSAVE with no mode - returns a non-empty status string
+        // BGSAVE with no mode - returns true on success (PHPRedis compatible)
         $result = $this->valkey_glide->bgSave();
-        $this->assertIsString($result);
-        $this->assertContains($result, $this->bgsaveResponses());
+        $this->assertTrue($result);
 
         // Wait for the bgsave to complete before next test
         $this->waitForSaveNotInProgress();
@@ -2604,10 +2603,9 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         // Wait for any in-progress save to complete
         $this->waitForSaveNotInProgress();
 
-        // BGSAVE SCHEDULE - returns a non-empty status string
+        // BGSAVE SCHEDULE - returns true on success
         $result = $this->valkey_glide->bgSave('SCHEDULE');
-        $this->assertIsString($result);
-        $this->assertContains($result, $this->bgsaveResponses());
+        $this->assertTrue($result);
 
         // Wait for the scheduled bgsave to complete
         $this->waitForSaveNotInProgress();
@@ -2624,13 +2622,13 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         // Wait for any in-progress save to complete
         $this->waitForSaveNotInProgress();
 
-        // When no save is in progress, BGSAVE CANCEL should return an error (false)
+        // When no save is in progress, BGSAVE CANCEL should return false
         $result = $this->valkey_glide->bgSave('CANCEL');
         $this->assertFalse($result);
     }
 
     /**
-     * Valid BGSAVE response strings.
+     * Valid BGSAVE response strings (used when OPT_REPLY_LITERAL is enabled).
      */
     protected function bgsaveResponses(): array
     {

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2587,42 +2587,29 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
 
     public function testBgSave()
     {
-        // Wait for any in-progress save to complete
         $this->waitForSaveNotInProgress();
 
-        // BGSAVE with no mode - returns true on success (PHPRedis compatible)
         $result = $this->valkey_glide->bgSave();
         $this->assertTrue($result);
-
-        // Wait for the bgsave to complete before next test
-        $this->waitForSaveNotInProgress();
     }
 
     public function testBgSaveSchedule()
     {
-        // Wait for any in-progress save to complete
         $this->waitForSaveNotInProgress();
 
-        // BGSAVE SCHEDULE - returns true on success
         $result = $this->valkey_glide->bgSave('SCHEDULE');
         $this->assertTrue($result);
-
-        // Wait for the scheduled bgsave to complete
-        $this->waitForSaveNotInProgress();
     }
 
     public function testBgSaveCancel()
     {
-        // BGSAVE CANCEL requires Valkey 8.1+
         if (!$this->minVersionCheck('8.1.0')) {
             $this->markTestSkipped('BGSAVE CANCEL requires Valkey 8.1.0+');
             return;
         }
 
-        // Wait for any in-progress save to complete
         $this->waitForSaveNotInProgress();
 
-        // When no save is in progress, BGSAVE CANCEL should return false
         $result = $this->valkey_glide->bgSave('CANCEL');
         $this->assertFalse($result);
     }

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2639,9 +2639,13 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         while (time() - $start < $maxWait) {
             $info = $this->valkey_glide->info('persistence');
             if (is_array($info)) {
-                $info = implode("\n", $info);
-            }
-            if (strpos($info, 'rdb_bgsave_in_progress:1') === false) {
+                if (
+                    (!isset($info['rdb_bgsave_in_progress']) || $info['rdb_bgsave_in_progress'] != '1') &&
+                    (!isset($info['aof_rewrite_in_progress']) || $info['aof_rewrite_in_progress'] != '1')
+                ) {
+                    return;
+                }
+            } else {
                 return;
             }
             usleep(100000); // 100ms

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2639,15 +2639,25 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
     }
 
     /**
+     * Returns true if a background save (RDB or AOF) is currently in progress.
+     */
+    protected function isSaveInProgress(): bool
+    {
+        $info = $this->valkey_glide->info('persistence');
+        return $info['rdb_bgsave_in_progress'] == '1'
+            || $info['aof_rewrite_in_progress'] == '1';
+    }
+
+    /**
      * Helper method to wait for any background save operations to complete.
      */
     protected function waitForSaveNotInProgress()
     {
-        $this->waitFor(function () {
-            $info = $this->valkey_glide->info('persistence');
-            return $info['rdb_bgsave_in_progress'] != '1'
-                && $info['aof_rewrite_in_progress'] != '1';
-        }, 10, 'Timed out waiting for background save to complete');
+        $this->waitFor(
+            fn() => !$this->isSaveInProgress(),
+            10,
+            'Timed out waiting for background save to complete'
+        );
     }
 
     public function testTTL()

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2585,6 +2585,69 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->assertEquals(0, $this->valkey_glide->dbSize());
     }
 
+    public function testBgSave()
+    {
+        // Wait for any in-progress save to complete
+        $this->waitForSaveNotInProgress();
+
+        // BGSAVE with no mode - returns a non-empty status string
+        $result = $this->valkey_glide->bgSave();
+        $this->assertIsString($result);
+        $this->assertNotEquals('', $result);
+
+        // Wait for the bgsave to complete before next test
+        $this->waitForSaveNotInProgress();
+    }
+
+    public function testBgSaveSchedule()
+    {
+        // Wait for any in-progress save to complete
+        $this->waitForSaveNotInProgress();
+
+        // BGSAVE SCHEDULE - returns a non-empty status string
+        $result = $this->valkey_glide->bgSave('SCHEDULE');
+        $this->assertIsString($result);
+        $this->assertNotEquals('', $result);
+
+        // Wait for the scheduled bgsave to complete
+        $this->waitForSaveNotInProgress();
+    }
+
+    public function testBgSaveCancel()
+    {
+        // BGSAVE CANCEL requires Valkey 8.1+
+        if (!$this->minVersionCheck('8.1.0')) {
+            $this->markTestSkipped('BGSAVE CANCEL requires Valkey 8.1.0+');
+            return;
+        }
+
+        // Wait for any in-progress save to complete
+        $this->waitForSaveNotInProgress();
+
+        // When no save is in progress, BGSAVE CANCEL should return an error (false)
+        $result = $this->valkey_glide->bgSave('CANCEL');
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Helper method to wait for any background save operations to complete.
+     */
+    protected function waitForSaveNotInProgress()
+    {
+        $maxWait = 10; // seconds
+        $start   = time();
+        while (time() - $start < $maxWait) {
+            $info = $this->valkey_glide->info('persistence');
+            if (is_array($info)) {
+                $info = implode("\n", $info);
+            }
+            if (strpos($info, 'rdb_bgsave_in_progress:1') === false) {
+                return;
+            }
+            usleep(100000); // 100ms
+        }
+    }
+
     public function testTTL()
     {
         $this->valkey_glide->set('x', 'y');

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2640,6 +2640,37 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
     }
 
+    public function testBgSaveBatch()
+    {
+        if (!$this->havePipeline()) {
+            $this->markTestSkipped('Pipeline not supported');
+            return;
+        }
+
+        $this->waitForSaveNotInProgress();
+
+        $this->valkey_glide->pipeline();
+        $this->valkey_glide->bgSave();
+        $result = $this->valkey_glide->exec();
+        $this->assertTrue($result[0]);
+
+        $this->waitForSaveNotInProgress();
+
+        $this->valkey_glide->pipeline();
+        $this->valkey_glide->bgSave('SCHEDULE');
+        $result = $this->valkey_glide->exec();
+        $this->assertTrue($result[0]);
+
+        if ($this->minVersionCheck('8.1.0')) {
+            $this->waitForSaveNotInProgress();
+
+            $this->valkey_glide->pipeline();
+            $this->valkey_glide->bgSave('CANCEL');
+            $result = $this->valkey_glide->exec();
+            $this->assertFalse($result[0]);
+        }
+    }
+
     /**
      * Valid BGSAVE response strings (used when OPT_REPLY_LITERAL is enabled).
      */

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2593,7 +2593,7 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         // BGSAVE with no mode - returns a non-empty status string
         $result = $this->valkey_glide->bgSave();
         $this->assertIsString($result);
-        $this->assertNotEquals('', $result);
+        $this->assertContains($result, $this->bgsaveResponses());
 
         // Wait for the bgsave to complete before next test
         $this->waitForSaveNotInProgress();
@@ -2607,7 +2607,7 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         // BGSAVE SCHEDULE - returns a non-empty status string
         $result = $this->valkey_glide->bgSave('SCHEDULE');
         $this->assertIsString($result);
-        $this->assertNotEquals('', $result);
+        $this->assertContains($result, $this->bgsaveResponses());
 
         // Wait for the scheduled bgsave to complete
         $this->waitForSaveNotInProgress();
@@ -2627,6 +2627,17 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         // When no save is in progress, BGSAVE CANCEL should return an error (false)
         $result = $this->valkey_glide->bgSave('CANCEL');
         $this->assertFalse($result);
+    }
+
+    /**
+     * Valid BGSAVE response strings.
+     */
+    protected function bgsaveResponses(): array
+    {
+        return [
+            'Background saving started',
+            'Background saving scheduled',
+        ];
     }
 
     /**

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2643,22 +2643,14 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
      */
     protected function waitForSaveNotInProgress()
     {
-        $maxWait = 10; // seconds
-        $start   = time();
-        while (time() - $start < $maxWait) {
+        $this->waitFor(function () {
             $info = $this->valkey_glide->info('persistence');
-            if (is_array($info)) {
-                if (
-                    (!isset($info['rdb_bgsave_in_progress']) || $info['rdb_bgsave_in_progress'] != '1') &&
-                    (!isset($info['aof_rewrite_in_progress']) || $info['aof_rewrite_in_progress'] != '1')
-                ) {
-                    return;
-                }
-            } else {
-                return;
+            if (!is_array($info)) {
+                return true;
             }
-            usleep(100000); // 100ms
-        }
+            return ($info['rdb_bgsave_in_progress'] ?? '0') != '1'
+                && ($info['aof_rewrite_in_progress'] ?? '0') != '1';
+        }, 10, 'Timed out waiting for background save to complete');
     }
 
     public function testTTL()

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2630,6 +2630,13 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->assertIsString($result);
         $this->assertContains($result, $this->bgsaveResponses());
 
+        if ($this->minVersionCheck('8.1.0')) {
+            $this->waitForSaveNotInProgress();
+
+            $result = $this->valkey_glide->bgSave('CANCEL');
+            $this->assertFalse($result);
+        }
+
         $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
     }
 

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2652,14 +2652,14 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->valkey_glide->pipeline();
         $this->valkey_glide->bgSave();
         $result = $this->valkey_glide->exec();
-        $this->assertContains($result[0], $this->bgsaveResponses());
+        $this->assertTrue($result[0]);
 
         $this->waitForSaveNotInProgress();
 
         $this->valkey_glide->pipeline();
         $this->valkey_glide->bgSave('SCHEDULE');
         $result = $this->valkey_glide->exec();
-        $this->assertContains($result[0], $this->bgsaveResponses());
+        $this->assertTrue($result[0]);
 
         if ($this->minVersionCheck('8.1.0')) {
             $this->waitForSaveNotInProgress();

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2614,6 +2614,25 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->assertFalse($result);
     }
 
+    public function testBgSaveWithReplyLiteral()
+    {
+        $this->waitForSaveNotInProgress();
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+
+        $result = $this->valkey_glide->bgSave();
+        $this->assertIsString($result);
+        $this->assertContains($result, $this->bgsaveResponses());
+
+        $this->waitForSaveNotInProgress();
+
+        $result = $this->valkey_glide->bgSave('SCHEDULE');
+        $this->assertIsString($result);
+        $this->assertContains($result, $this->bgsaveResponses());
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+    }
+
     /**
      * Valid BGSAVE response strings (used when OPT_REPLY_LITERAL is enabled).
      */

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2645,11 +2645,8 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
     {
         $this->waitFor(function () {
             $info = $this->valkey_glide->info('persistence');
-            if (!is_array($info)) {
-                return true;
-            }
-            return ($info['rdb_bgsave_in_progress'] ?? '0') != '1'
-                && ($info['aof_rewrite_in_progress'] ?? '0') != '1';
+            return $info['rdb_bgsave_in_progress'] != '1'
+                && $info['aof_rewrite_in_progress'] != '1';
         }, 10, 'Timed out waiting for background save to complete');
     }
 

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -1162,11 +1162,12 @@ class ValkeyGlide
      *
      * @param  string|null  $mode  Optional mode: null for default, "SCHEDULE" to schedule,
      *                             or "CANCEL" to abort (requires Valkey 8.1+).
-     * @return ValkeyGlide|string  A non-empty status string on success.
+     * @return ValkeyGlide|bool|string  Returns true on success, false on failure.
+     *                                  With OPT_REPLY_LITERAL enabled, returns the status string instead.
      *
      * @see https://valkey.io/commands/bgsave
      */
-    public function bgSave(?string $mode = null): ValkeyGlide|string|false;
+    public function bgSave(?string $mode = null): ValkeyGlide|bool|string;
 
     /**
      * Functions is an API for managing code to be executed on the server.

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -1154,6 +1154,21 @@ class ValkeyGlide
     public function flushDB(?bool $sync = null): ValkeyGlide|bool;
 
     /**
+     * Asynchronously saves the dataset to disk in the background.
+     *
+     * When called without a mode argument, initiates a background save immediately.
+     * When called with "SCHEDULE", schedules a background save to run when possible.
+     * When called with "CANCEL", aborts all in-progress and scheduled background saves (Valkey 8.1+).
+     *
+     * @param  string|null  $mode  Optional mode: null for default, "SCHEDULE" to schedule,
+     *                             or "CANCEL" to abort (requires Valkey 8.1+).
+     * @return ValkeyGlide|string  A non-empty status string on success.
+     *
+     * @see https://valkey.io/commands/bgsave
+     */
+    public function bgSave(?string $mode = null): ValkeyGlide|string|false;
+
+    /**
      * Functions is an API for managing code to be executed on the server.
      *
      * @param string $operation         The subcommand you intend to execute.  Valid options are as follows

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -977,6 +977,11 @@ FLUSHDB_METHOD_IMPL(ValkeyGlideCluster)
 FLUSHALL_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
+/* {{{ proto ValkeyGlideCluster::bgSave(mixed route, [string mode])
+ *     Asynchronously saves the dataset to disk in the background. */
+BGSAVE_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
 /* {{{ proto ValkeyGlideCluster::dbsize(string key)
  *     proto ValkeyGlideCluster::dbsize(array host_port) */
 DBSIZE_METHOD_IMPL(ValkeyGlideCluster)

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -559,6 +559,35 @@ class ValkeyGlideCluster
     public function flushDB(mixed $route, bool $async = false): ValkeyGlideCluster|bool;
 
     /**
+     * Asynchronously saves the dataset to disk in the background.
+     *
+     * When called without a mode argument, initiates a background save immediately.
+     * When called with "SCHEDULE", schedules a background save to run when possible.
+     * When called with "CANCEL", aborts all in-progress and scheduled background saves (Valkey 8.1+).
+     *
+     * For multi-node routes (allPrimaries, allNodes), returns an associative array mapping
+     * node addresses to individual results. For single-node routes (randomNode, slot-based,
+     * or address-based), returns a scalar value.
+     *
+     * @param mixed        $route  The routing configuration that determines which node(s) to send the
+     *                             command to. Can be:
+     *                             - string "randomNode" to route to a random node
+     *                             - string "allPrimaries" to route to all primary nodes
+     *                             - string "allNodes" to route to all nodes (primaries and replicas)
+     *                             - string containing a key name for slot-based routing
+     *                             - array ['type' => 'primarySlotKey', 'key' => 'keyName'] for slot key routing
+     *                             - array ['type' => 'routeByAddress', 'host' => 'hostname', 'port' => port]
+     *                               for specific node routing
+     * @param string|null  $mode   Optional mode: null for default, "SCHEDULE" to schedule,
+     *                             or "CANCEL" to abort (requires Valkey 8.1+).
+     *
+     * @return ValkeyGlideCluster|array|bool|string
+     *         - Multi-node route: array<string, bool> (or array<string, string> with OPT_REPLY_LITERAL)
+     *         - Single-node route: bool (true on success, false on failure)
+     *         - Single-node route with OPT_REPLY_LITERAL: string (status message)
+     *         - In batch/pipeline mode: ValkeyGlideCluster ($this for chaining)
+     *
+     * @see https://valkey.io/commands/bgsave
      * @see ValkeyGlide::bgSave
      */
     public function bgSave(mixed $route, ?string $mode = null): ValkeyGlideCluster|array|bool|string;

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -560,6 +560,9 @@ class ValkeyGlideCluster
 
     /**
      * @see ValkeyGlide::bgSave
+     *
+     * For multi-node routes, returns an associative array mapping node addresses to results.
+     * For single-node routes, returns a scalar (bool or string).
      */
     public function bgSave(mixed $route, ?string $mode = null): ValkeyGlideCluster|array|bool|string;
 

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -559,6 +559,11 @@ class ValkeyGlideCluster
     public function flushDB(mixed $route, bool $async = false): ValkeyGlideCluster|bool;
 
     /**
+     * @see ValkeyGlide::bgSave
+     */
+    public function bgSave(mixed $route, ?string $mode = null): ValkeyGlideCluster|string|false;
+
+    /**
      * @see ValkeyGlide::geoadd
      */
     public function geoadd(string $key, float $lng, float $lat, string $member, mixed ...$other_triples_and_options): ValkeyGlideCluster|int|false;

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -559,35 +559,6 @@ class ValkeyGlideCluster
     public function flushDB(mixed $route, bool $async = false): ValkeyGlideCluster|bool;
 
     /**
-     * Asynchronously saves the dataset to disk in the background.
-     *
-     * When called without a mode argument, initiates a background save immediately.
-     * When called with "SCHEDULE", schedules a background save to run when possible.
-     * When called with "CANCEL", aborts all in-progress and scheduled background saves (Valkey 8.1+).
-     *
-     * For multi-node routes (allPrimaries, allNodes), returns an associative array mapping
-     * node addresses to individual results. For single-node routes (randomNode, slot-based,
-     * or address-based), returns a scalar value.
-     *
-     * @param mixed        $route  The routing configuration that determines which node(s) to send the
-     *                             command to. Can be:
-     *                             - string "randomNode" to route to a random node
-     *                             - string "allPrimaries" to route to all primary nodes
-     *                             - string "allNodes" to route to all nodes (primaries and replicas)
-     *                             - string containing a key name for slot-based routing
-     *                             - array ['type' => 'primarySlotKey', 'key' => 'keyName'] for slot key routing
-     *                             - array ['type' => 'routeByAddress', 'host' => 'hostname', 'port' => port]
-     *                               for specific node routing
-     * @param string|null  $mode   Optional mode: null for default, "SCHEDULE" to schedule,
-     *                             or "CANCEL" to abort (requires Valkey 8.1+).
-     *
-     * @return ValkeyGlideCluster|array|bool|string
-     *         - Multi-node route: array<string, bool> (or array<string, string> with OPT_REPLY_LITERAL)
-     *         - Single-node route: bool (true on success, false on failure)
-     *         - Single-node route with OPT_REPLY_LITERAL: string (status message)
-     *         - In batch/pipeline mode: ValkeyGlideCluster ($this for chaining)
-     *
-     * @see https://valkey.io/commands/bgsave
      * @see ValkeyGlide::bgSave
      */
     public function bgSave(mixed $route, ?string $mode = null): ValkeyGlideCluster|array|bool|string;

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -561,7 +561,7 @@ class ValkeyGlideCluster
     /**
      * @see ValkeyGlide::bgSave
      */
-    public function bgSave(mixed $route, ?string $mode = null): ValkeyGlideCluster|bool|string;
+    public function bgSave(mixed $route, ?string $mode = null): ValkeyGlideCluster|array|bool|string;
 
     /**
      * @see ValkeyGlide::geoadd

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -561,7 +561,7 @@ class ValkeyGlideCluster
     /**
      * @see ValkeyGlide::bgSave
      */
-    public function bgSave(mixed $route, ?string $mode = null): ValkeyGlideCluster|string|false;
+    public function bgSave(mixed $route, ?string $mode = null): ValkeyGlideCluster|bool|string;
 
     /**
      * @see ValkeyGlide::geoadd

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -316,20 +316,20 @@ int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_clas
         core_args.arg_count                     = 1;
     }
 
+    /* Select processor based on OPT_REPLY_LITERAL:
+     * - With OPT_REPLY_LITERAL: return raw string (process_core_string_result)
+     * - Without OPT_REPLY_LITERAL: return bool (process_core_bgsave_bool_result)
+     * This ensures correct types in both normal and batch/pipeline mode. */
+    z_result_processor_t processor = valkey_glide->opt_reply_literal
+                                         ? process_core_string_result
+                                         : process_core_bgsave_bool_result;
+
     /* Execute using unified core framework */
-    if (execute_core_command(
-            valkey_glide, &core_args, NULL, process_core_string_result, return_value)) {
+    if (execute_core_command(valkey_glide, &core_args, NULL, processor, return_value)) {
         if (valkey_glide->is_in_batch_mode) {
             /* In batch mode, return $this for method chaining */
             ZVAL_COPY(return_value, object);
             return 1;
-        }
-
-        /* PHPRedis compatibility: bgSave returns bool by default,
-         * string only when OPT_REPLY_LITERAL is enabled */
-        if (!valkey_glide->opt_reply_literal && Z_TYPE_P(return_value) == IS_STRING) {
-            zval_dtor(return_value);
-            ZVAL_TRUE(return_value);
         }
 
         return 1;

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -321,7 +321,7 @@ int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_clas
      * - Without OPT_REPLY_LITERAL: return bool (process_core_bgsave_bool_result)
      * This ensures correct types in both normal and batch/pipeline mode. */
     z_result_processor_t processor = valkey_glide->opt_reply_literal
-                                         ? process_core_string_result
+                                         ? process_core_bgsave_string_result
                                          : process_core_bgsave_bool_result;
 
     /* Execute using unified core framework */

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -258,6 +258,79 @@ int execute_flushall_command(zval* object, int argc, zval* return_value, zend_cl
     }
 }
 
+/* Execute a BGSAVE command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
+int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    zval*                args       = NULL;
+    int                  args_count = 0;
+    zend_bool            is_cluster = (ce == get_valkey_glide_cluster_ce());
+    char*                mode       = NULL;
+    size_t               mode_len   = 0;
+
+    /* Get ValkeyGlide object */
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    /* Setup core command arguments */
+    core_command_args_t core_args = {0};
+    core_args.glide_client        = valkey_glide->glide_client;
+    core_args.cmd_type            = BgSave;
+    core_args.is_cluster          = is_cluster;
+
+    if (is_cluster) {
+        /* Parse parameters for cluster - first parameter is route, optional second is mode */
+        if (zend_parse_method_parameters(argc, object, "O*", &object, ce, &args, &args_count) ==
+            FAILURE) {
+            return 0;
+        }
+
+        if (args_count == 0) {
+            /* Need at least the route parameter */
+            return 0;
+        }
+
+        /* Set up routing */
+        core_args.has_route   = 1;
+        core_args.route_param = &args[0];
+
+        /* Get optional mode parameter */
+        if (args_count > 1 && Z_TYPE(args[1]) == IS_STRING) {
+            mode     = Z_STRVAL(args[1]);
+            mode_len = Z_STRLEN(args[1]);
+        }
+    } else {
+        /* Non-cluster case - parse optional mode parameter */
+        if (zend_parse_method_parameters(argc, object, "O|s!", &object, ce, &mode, &mode_len) ==
+            FAILURE) {
+            return 0;
+        }
+    }
+
+    /* Add mode option if provided (SCHEDULE or CANCEL) */
+    if (mode && mode_len > 0) {
+        core_args.args[0].type                  = CORE_ARG_TYPE_STRING;
+        core_args.args[0].data.string_arg.value = mode;
+        core_args.args[0].data.string_arg.len   = mode_len;
+        core_args.arg_count                     = 1;
+    }
+
+    /* Execute using unified core framework */
+    if (execute_core_command(
+            valkey_glide, &core_args, NULL, process_core_string_result, return_value)) {
+        if (valkey_glide->is_in_batch_mode) {
+            /* In batch mode, return $this for method chaining */
+            ZVAL_COPY(return_value, object);
+            return 1;
+        }
+
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
 /* Execute a TIME command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
 int execute_time_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
     valkey_glide_object* valkey_glide;

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -325,6 +325,13 @@ int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_clas
             return 1;
         }
 
+        /* PHPRedis compatibility: bgSave returns bool by default,
+         * string only when OPT_REPLY_LITERAL is enabled */
+        if (!valkey_glide->opt_reply_literal && Z_TYPE_P(return_value) == IS_STRING) {
+            zval_dtor(return_value);
+            ZVAL_TRUE(return_value);
+        }
+
         return 1;
     } else {
         return 0;

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -317,7 +317,7 @@ int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_clas
     }
 
     /* Select processor based on OPT_REPLY_LITERAL:
-     * - With OPT_REPLY_LITERAL: return raw string (process_core_string_result)
+     * - With OPT_REPLY_LITERAL: return raw string (process_core_bgsave_string_result)
      * - Without OPT_REPLY_LITERAL: return bool (process_core_bgsave_bool_result)
      * This ensures correct types in both normal and batch/pipeline mode. */
     z_result_processor_t processor = valkey_glide->opt_reply_literal
@@ -325,17 +325,14 @@ int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_clas
                                          : process_core_bgsave_bool_result;
 
     /* Execute using unified core framework */
-    if (execute_core_command(valkey_glide, &core_args, NULL, processor, return_value)) {
-        if (valkey_glide->is_in_batch_mode) {
-            /* In batch mode, return $this for method chaining */
-            ZVAL_COPY(return_value, object);
-            return 1;
-        }
-
-        return 1;
-    } else {
+    if (!execute_core_command(valkey_glide, &core_args, NULL, processor, return_value)) {
         return 0;
     }
+    if (valkey_glide->is_in_batch_mode) {
+        /* In batch mode, return $this for method chaining */
+        ZVAL_COPY(return_value, object);
+    }
+    return 1;
 }
 
 /* Execute a TIME command using the Valkey Glide client - UNIFIED IMPLEMENTATION */

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -203,6 +203,7 @@ int execute_watch_command(zval* object, int argc, zval* return_value, zend_class
 int execute_unwatch_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_flushdb_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_flushall_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_time_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_scan_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_cluster_scan_command(const void* glide_client,
@@ -683,6 +684,20 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
                                          ? get_valkey_glide_cluster_ce()            \
                                          : get_valkey_glide_ce())) {                \
             APPLY_REPLY_LITERAL(return_value);                                      \
+            return;                                                                 \
+        }                                                                           \
+        zval_dtor(return_value);                                                    \
+        RETURN_FALSE;                                                               \
+    }
+
+#define BGSAVE_METHOD_IMPL(class_name)                                             \
+    PHP_METHOD(class_name, bgSave) {                                               \
+        if (execute_bgsave_command(getThis(),                                      \
+                                    ZEND_NUM_ARGS(),                                \
+                                    return_value,                                   \
+                                    strcmp(#class_name, "ValkeyGlideCluster") == 0  \
+                                        ? get_valkey_glide_cluster_ce()             \
+                                        : get_valkey_glide_ce())) {                 \
             return;                                                                 \
         }                                                                           \
         zval_dtor(return_value);                                                    \

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -690,18 +690,18 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
         RETURN_FALSE;                                                               \
     }
 
-#define BGSAVE_METHOD_IMPL(class_name)                                             \
-    PHP_METHOD(class_name, bgSave) {                                               \
-        if (execute_bgsave_command(getThis(),                                      \
-                                    ZEND_NUM_ARGS(),                                \
-                                    return_value,                                   \
-                                    strcmp(#class_name, "ValkeyGlideCluster") == 0  \
-                                        ? get_valkey_glide_cluster_ce()             \
-                                        : get_valkey_glide_ce())) {                 \
-            return;                                                                 \
-        }                                                                           \
-        zval_dtor(return_value);                                                    \
-        RETURN_FALSE;                                                               \
+#define BGSAVE_METHOD_IMPL(class_name)                                            \
+    PHP_METHOD(class_name, bgSave) {                                              \
+        if (execute_bgsave_command(getThis(),                                     \
+                                   ZEND_NUM_ARGS(),                               \
+                                   return_value,                                  \
+                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
+                                       ? get_valkey_glide_cluster_ce()            \
+                                       : get_valkey_glide_ce())) {                \
+            return;                                                               \
+        }                                                                         \
+        zval_dtor(return_value);                                                  \
+        RETURN_FALSE;                                                             \
     }
 
 #define TIME_METHOD_IMPL(class_name)                                            \

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -1591,6 +1591,9 @@ int process_core_string_result(CommandResponse* response, void* output, zval* re
         }
 
         return 1;
+    } else if (response->response_type == Ok) {
+        ZVAL_STRING(return_value, "OK");
+        return 1;
     } else if (response->response_type == Null) {
         ZVAL_FALSE(return_value);
         return 1;
@@ -1683,37 +1686,6 @@ static int process_bgsave_single_node_bool(CommandResponse* response,
 }
 
 /**
- * Single-node BGSAVE string processor (OPT_REPLY_LITERAL mode).
- * Returns the status string, or false for Null responses.
- */
-static int process_bgsave_single_node_string(CommandResponse* response,
-                                             void*            output,
-                                             zval*            return_value) {
-    if (!response) {
-        ZVAL_NULL(return_value);
-        return 0;
-    }
-
-    if (response->response_type == String) {
-        if (response->string_value_len > 0) {
-            ZVAL_STRINGL(return_value, response->string_value, response->string_value_len);
-        } else {
-            ZVAL_EMPTY_STRING(return_value);
-        }
-        return 1;
-    } else if (response->response_type == Ok) {
-        ZVAL_STRING(return_value, "OK");
-        return 1;
-    } else if (response->response_type == Null) {
-        ZVAL_FALSE(return_value);
-        return 1;
-    }
-
-    ZVAL_NULL(return_value);
-    return 0;
-}
-
-/**
  * BGSAVE boolean result processor.
  * For single-node: returns true on success (String/Ok), false otherwise.
  * For multi-node routes: returns an associative array of node => bool.
@@ -1729,8 +1701,7 @@ int process_core_bgsave_bool_result(CommandResponse* response, void* output, zva
  * For multi-node routes: returns an associative array of node => string.
  */
 int process_core_bgsave_string_result(CommandResponse* response, void* output, zval* return_value) {
-    return process_core_cluster_result(
-        response, output, return_value, process_bgsave_single_node_string);
+    return process_core_cluster_result(response, output, return_value, process_core_string_result);
 }
 
 

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -1637,6 +1637,33 @@ int process_core_bool_result(CommandResponse* response, void* output, zval* retu
     return 1;
 }
 
+/**
+ * Batch-compatible wrapper for BGSAVE boolean results.
+ * Converts String/Ok responses to true, Null to false.
+ */
+int process_core_bgsave_bool_result(CommandResponse* response, void* output, zval* return_value) {
+    if (!response) {
+        ZVAL_FALSE(return_value);
+        return 0;
+    }
+
+    if (response->response_type == String || response->response_type == Ok) {
+        ZVAL_TRUE(return_value);
+        return 1;
+    } else if (response->response_type == Map && response->array_value &&
+               response->array_value_len > 0) {
+        /* Multi-node response (cluster routing) - process first node's value recursively */
+        CommandResponse* element     = &response->array_value[0];
+        CommandResponse* first_value = element->map_value;
+        if (first_value) {
+            return process_core_bgsave_bool_result(first_value, output, return_value);
+        }
+    }
+
+    ZVAL_FALSE(return_value);
+    return 1;
+}
+
 
 /* ====================================================================
  * SPECIALIZED COMMAND HELPERS

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -1594,11 +1594,13 @@ int process_core_string_result(CommandResponse* response, void* output, zval* re
     } else if (response->response_type == Ok) {
         ZVAL_STRING(return_value, "OK");
         return 1;
-    } else if (response->response_type == Map && response->map_value &&
+    } else if (response->response_type == Map && response->array_value &&
                response->array_value_len > 0) {
         /* Multi-node response (cluster routing) - return first string value */
-        CommandResponse* first_value = &response->map_value[0];
-        if (first_value->response_type == String && first_value->string_value_len > 0) {
+        CommandResponse* element     = &response->array_value[0];
+        CommandResponse* first_value = element->map_value;
+        if (first_value && first_value->response_type == String &&
+            first_value->string_value_len > 0) {
             result = emalloc(first_value->string_value_len + 1);
             if (!result) {
                 ZVAL_NULL(return_value);
@@ -1609,7 +1611,7 @@ int process_core_string_result(CommandResponse* response, void* output, zval* re
             ZVAL_STRINGL(return_value, result, first_value->string_value_len);
             efree(result);
             return 1;
-        } else if (first_value->response_type == Ok) {
+        } else if (first_value && first_value->response_type == Ok) {
             ZVAL_STRING(return_value, "OK");
             return 1;
         }

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -1591,19 +1591,6 @@ int process_core_string_result(CommandResponse* response, void* output, zval* re
         }
 
         return 1;
-    } else if (response->response_type == Ok) {
-        ZVAL_STRING(return_value, "OK");
-        return 1;
-    } else if (response->response_type == Map && response->array_value &&
-               response->array_value_len > 0) {
-        /* Multi-node response (cluster routing) - process first node's value recursively */
-        CommandResponse* element     = &response->array_value[0];
-        CommandResponse* first_value = element->map_value;
-        if (first_value) {
-            return process_core_string_result(first_value, output, return_value);
-        }
-        ZVAL_NULL(return_value);
-        return 0;
     } else if (response->response_type == Null) {
         ZVAL_FALSE(return_value);
         return 1;
@@ -1658,10 +1645,13 @@ int process_core_bgsave_bool_result(CommandResponse* response, void* output, zva
         for (long i = 0; i < response->array_value_len; i++) {
             CommandResponse* element = &response->array_value[i];
             CommandResponse* value   = element->map_value;
-            if (element->string_value && value) {
+            if (element->map_key && element->map_key->string_value && value) {
                 zval node_result;
                 process_core_bgsave_bool_result(value, output, &node_result);
-                add_assoc_zval(return_value, element->string_value, &node_result);
+                add_assoc_zval_ex(return_value,
+                                  element->map_key->string_value,
+                                  element->map_key->string_value_len,
+                                  &node_result);
             }
         }
         return 1;
@@ -1698,10 +1688,13 @@ int process_core_bgsave_string_result(CommandResponse* response, void* output, z
         for (long i = 0; i < response->array_value_len; i++) {
             CommandResponse* element = &response->array_value[i];
             CommandResponse* value   = element->map_value;
-            if (element->string_value && value) {
+            if (element->map_key && element->map_key->string_value && value) {
                 zval node_result;
                 process_core_bgsave_string_result(value, output, &node_result);
-                add_assoc_zval(return_value, element->string_value, &node_result);
+                add_assoc_zval_ex(return_value,
+                                  element->map_key->string_value,
+                                  element->map_key->string_value_len,
+                                  &node_result);
             }
         }
         return 1;

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -1591,6 +1591,9 @@ int process_core_string_result(CommandResponse* response, void* output, zval* re
         }
 
         return 1;
+    } else if (response->response_type == Ok) {
+        ZVAL_STRING(return_value, "OK");
+        return 1;
     } else if (response->response_type == Null) {
         ZVAL_FALSE(return_value);
         return 1;

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -1596,18 +1596,14 @@ int process_core_string_result(CommandResponse* response, void* output, zval* re
         return 1;
     } else if (response->response_type == Map && response->array_value &&
                response->array_value_len > 0) {
-        /* Multi-node response (cluster routing) - return associative array of node responses */
-        array_init(return_value);
-        for (long i = 0; i < response->array_value_len; i++) {
-            CommandResponse* element = &response->array_value[i];
-            CommandResponse* value   = element->map_value;
-            if (element->string_value && value) {
-                zval node_result;
-                process_core_string_result(value, output, &node_result);
-                add_assoc_zval(return_value, element->string_value, &node_result);
-            }
+        /* Multi-node response (cluster routing) - process first node's value recursively */
+        CommandResponse* element     = &response->array_value[0];
+        CommandResponse* first_value = element->map_value;
+        if (first_value) {
+            return process_core_string_result(first_value, output, return_value);
         }
-        return 1;
+        ZVAL_NULL(return_value);
+        return 0;
     } else if (response->response_type == Null) {
         ZVAL_FALSE(return_value);
         return 1;
@@ -1673,6 +1669,49 @@ int process_core_bgsave_bool_result(CommandResponse* response, void* output, zva
 
     ZVAL_FALSE(return_value);
     return 1;
+}
+
+/**
+ * Batch-compatible wrapper for BGSAVE string results (OPT_REPLY_LITERAL mode).
+ * Returns string for single-node, associative array for multi-node routes.
+ */
+int process_core_bgsave_string_result(CommandResponse* response, void* output, zval* return_value) {
+    if (!response) {
+        ZVAL_NULL(return_value);
+        return 0;
+    }
+
+    if (response->response_type == String) {
+        if (response->string_value_len > 0) {
+            ZVAL_STRINGL(return_value, response->string_value, response->string_value_len);
+        } else {
+            ZVAL_EMPTY_STRING(return_value);
+        }
+        return 1;
+    } else if (response->response_type == Ok) {
+        ZVAL_STRING(return_value, "OK");
+        return 1;
+    } else if (response->response_type == Map && response->array_value &&
+               response->array_value_len > 0) {
+        /* Multi-node response - return associative array of node => string */
+        array_init(return_value);
+        for (long i = 0; i < response->array_value_len; i++) {
+            CommandResponse* element = &response->array_value[i];
+            CommandResponse* value   = element->map_value;
+            if (element->string_value && value) {
+                zval node_result;
+                process_core_bgsave_string_result(value, output, &node_result);
+                add_assoc_zval(return_value, element->string_value, &node_result);
+            }
+        }
+        return 1;
+    } else if (response->response_type == Null) {
+        ZVAL_FALSE(return_value);
+        return 1;
+    }
+
+    ZVAL_NULL(return_value);
+    return 0;
 }
 
 

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -1596,14 +1596,18 @@ int process_core_string_result(CommandResponse* response, void* output, zval* re
         return 1;
     } else if (response->response_type == Map && response->array_value &&
                response->array_value_len > 0) {
-        /* Multi-node response (cluster routing) - process first node's value recursively */
-        CommandResponse* element     = &response->array_value[0];
-        CommandResponse* first_value = element->map_value;
-        if (first_value) {
-            return process_core_string_result(first_value, output, return_value);
+        /* Multi-node response (cluster routing) - return associative array of node responses */
+        array_init(return_value);
+        for (long i = 0; i < response->array_value_len; i++) {
+            CommandResponse* element = &response->array_value[i];
+            CommandResponse* value   = element->map_value;
+            if (element->string_value && value) {
+                zval node_result;
+                process_core_string_result(value, output, &node_result);
+                add_assoc_zval(return_value, element->string_value, &node_result);
+            }
         }
-        ZVAL_NULL(return_value);
-        return 0;
+        return 1;
     } else if (response->response_type == Null) {
         ZVAL_FALSE(return_value);
         return 1;
@@ -1640,6 +1644,7 @@ int process_core_bool_result(CommandResponse* response, void* output, zval* retu
 /**
  * Batch-compatible wrapper for BGSAVE boolean results.
  * Converts String/Ok responses to true, Null to false.
+ * For multi-node routes, returns an associative array of node => bool.
  */
 int process_core_bgsave_bool_result(CommandResponse* response, void* output, zval* return_value) {
     if (!response) {
@@ -1652,12 +1657,18 @@ int process_core_bgsave_bool_result(CommandResponse* response, void* output, zva
         return 1;
     } else if (response->response_type == Map && response->array_value &&
                response->array_value_len > 0) {
-        /* Multi-node response (cluster routing) - process first node's value recursively */
-        CommandResponse* element     = &response->array_value[0];
-        CommandResponse* first_value = element->map_value;
-        if (first_value) {
-            return process_core_bgsave_bool_result(first_value, output, return_value);
+        /* Multi-node response (cluster routing) - return associative array of node results */
+        array_init(return_value);
+        for (long i = 0; i < response->array_value_len; i++) {
+            CommandResponse* element = &response->array_value[i];
+            CommandResponse* value   = element->map_value;
+            if (element->string_value && value) {
+                zval node_result;
+                process_core_bgsave_bool_result(value, output, &node_result);
+                add_assoc_zval(return_value, element->string_value, &node_result);
+            }
         }
+        return 1;
     }
 
     ZVAL_FALSE(return_value);

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -313,6 +313,7 @@ int prepare_core_args(core_command_args_t* args,
         case Wait:
         case FlushDB:
         case FlushAll:
+        case BgSave:
         case Select:
         case SwapDb:
             return prepare_message_args(

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -1594,6 +1594,27 @@ int process_core_string_result(CommandResponse* response, void* output, zval* re
     } else if (response->response_type == Ok) {
         ZVAL_STRING(return_value, "OK");
         return 1;
+    } else if (response->response_type == Map && response->map_value &&
+               response->array_value_len > 0) {
+        /* Multi-node response (cluster routing) - return first string value */
+        CommandResponse* first_value = &response->map_value[0];
+        if (first_value->response_type == String && first_value->string_value_len > 0) {
+            result = emalloc(first_value->string_value_len + 1);
+            if (!result) {
+                ZVAL_NULL(return_value);
+                return 0;
+            }
+            memcpy(result, first_value->string_value, first_value->string_value_len);
+            result[first_value->string_value_len] = '\0';
+            ZVAL_STRINGL(return_value, result, first_value->string_value_len);
+            efree(result);
+            return 1;
+        } else if (first_value->response_type == Ok) {
+            ZVAL_STRING(return_value, "OK");
+            return 1;
+        }
+        ZVAL_NULL(return_value);
+        return 0;
     } else if (response->response_type == Null) {
         ZVAL_FALSE(return_value);
         return 1;

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -1625,29 +1625,30 @@ int process_core_bool_result(CommandResponse* response, void* output, zval* retu
 }
 
 /**
- * Batch-compatible wrapper for BGSAVE boolean results.
- * Converts String/Ok responses to true, Null to false.
- * For multi-node routes, returns an associative array of node => bool.
+ * Generic cluster result processor.
+ * For single-node responses, delegates to the provided single_node_processor.
+ * For multi-node (Map) responses, builds an associative array of node => result
+ * by applying single_node_processor to each node's value.
  */
-int process_core_bgsave_bool_result(CommandResponse* response, void* output, zval* return_value) {
+int process_core_cluster_result(CommandResponse*      response,
+                                void*                 output,
+                                zval*                 return_value,
+                                z_result_processor_t  single_node_processor) {
     if (!response) {
         ZVAL_FALSE(return_value);
         return 0;
     }
 
-    if (response->response_type == String || response->response_type == Ok) {
-        ZVAL_TRUE(return_value);
-        return 1;
-    } else if (response->response_type == Map && response->array_value &&
-               response->array_value_len > 0) {
-        /* Multi-node response (cluster routing) - return associative array of node results */
+    if (response->response_type == Map && response->array_value &&
+        response->array_value_len > 0) {
+        /* Multi-node response - return associative array of node => result */
         array_init(return_value);
         for (long i = 0; i < response->array_value_len; i++) {
             CommandResponse* element = &response->array_value[i];
             CommandResponse* value   = element->map_value;
             if (element->map_key && element->map_key->string_value && value) {
                 zval node_result;
-                process_core_bgsave_bool_result(value, output, &node_result);
+                single_node_processor(value, output, &node_result);
                 add_assoc_zval_ex(return_value,
                                   element->map_key->string_value,
                                   element->map_key->string_value_len,
@@ -1657,15 +1658,38 @@ int process_core_bgsave_bool_result(CommandResponse* response, void* output, zva
         return 1;
     }
 
+    /* Single-node response - delegate directly */
+    return single_node_processor(response, output, return_value);
+}
+
+/**
+ * Single-node BGSAVE bool processor.
+ * Converts String/Ok responses to true, anything else to false.
+ */
+static int process_bgsave_single_node_bool(CommandResponse* response,
+                                           void*            output,
+                                           zval*            return_value) {
+    if (!response) {
+        ZVAL_FALSE(return_value);
+        return 0;
+    }
+
+    if (response->response_type == String || response->response_type == Ok) {
+        ZVAL_TRUE(return_value);
+        return 1;
+    }
+
     ZVAL_FALSE(return_value);
     return 1;
 }
 
 /**
- * Batch-compatible wrapper for BGSAVE string results (OPT_REPLY_LITERAL mode).
- * Returns string for single-node, associative array for multi-node routes.
+ * Single-node BGSAVE string processor (OPT_REPLY_LITERAL mode).
+ * Returns the status string, or false for Null responses.
  */
-int process_core_bgsave_string_result(CommandResponse* response, void* output, zval* return_value) {
+static int process_bgsave_single_node_string(CommandResponse* response,
+                                             void*            output,
+                                             zval*            return_value) {
     if (!response) {
         ZVAL_NULL(return_value);
         return 0;
@@ -1681,23 +1705,6 @@ int process_core_bgsave_string_result(CommandResponse* response, void* output, z
     } else if (response->response_type == Ok) {
         ZVAL_STRING(return_value, "OK");
         return 1;
-    } else if (response->response_type == Map && response->array_value &&
-               response->array_value_len > 0) {
-        /* Multi-node response - return associative array of node => string */
-        array_init(return_value);
-        for (long i = 0; i < response->array_value_len; i++) {
-            CommandResponse* element = &response->array_value[i];
-            CommandResponse* value   = element->map_value;
-            if (element->map_key && element->map_key->string_value && value) {
-                zval node_result;
-                process_core_bgsave_string_result(value, output, &node_result);
-                add_assoc_zval_ex(return_value,
-                                  element->map_key->string_value,
-                                  element->map_key->string_value_len,
-                                  &node_result);
-            }
-        }
-        return 1;
     } else if (response->response_type == Null) {
         ZVAL_FALSE(return_value);
         return 1;
@@ -1705,6 +1712,26 @@ int process_core_bgsave_string_result(CommandResponse* response, void* output, z
 
     ZVAL_NULL(return_value);
     return 0;
+}
+
+/**
+ * BGSAVE boolean result processor.
+ * For single-node: returns true on success (String/Ok), false otherwise.
+ * For multi-node routes: returns an associative array of node => bool.
+ */
+int process_core_bgsave_bool_result(CommandResponse* response, void* output, zval* return_value) {
+    return process_core_cluster_result(response, output, return_value,
+                                       process_bgsave_single_node_bool);
+}
+
+/**
+ * BGSAVE string result processor (OPT_REPLY_LITERAL mode).
+ * For single-node: returns the status string.
+ * For multi-node routes: returns an associative array of node => string.
+ */
+int process_core_bgsave_string_result(CommandResponse* response, void* output, zval* return_value) {
+    return process_core_cluster_result(response, output, return_value,
+                                       process_bgsave_single_node_string);
 }
 
 

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -1596,24 +1596,11 @@ int process_core_string_result(CommandResponse* response, void* output, zval* re
         return 1;
     } else if (response->response_type == Map && response->array_value &&
                response->array_value_len > 0) {
-        /* Multi-node response (cluster routing) - return first string value */
+        /* Multi-node response (cluster routing) - process first node's value recursively */
         CommandResponse* element     = &response->array_value[0];
         CommandResponse* first_value = element->map_value;
-        if (first_value && first_value->response_type == String &&
-            first_value->string_value_len > 0) {
-            result = emalloc(first_value->string_value_len + 1);
-            if (!result) {
-                ZVAL_NULL(return_value);
-                return 0;
-            }
-            memcpy(result, first_value->string_value, first_value->string_value_len);
-            result[first_value->string_value_len] = '\0';
-            ZVAL_STRINGL(return_value, result, first_value->string_value_len);
-            efree(result);
-            return 1;
-        } else if (first_value && first_value->response_type == Ok) {
-            ZVAL_STRING(return_value, "OK");
-            return 1;
+        if (first_value) {
+            return process_core_string_result(first_value, output, return_value);
         }
         ZVAL_NULL(return_value);
         return 0;

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -1630,17 +1630,16 @@ int process_core_bool_result(CommandResponse* response, void* output, zval* retu
  * For multi-node (Map) responses, builds an associative array of node => result
  * by applying single_node_processor to each node's value.
  */
-int process_core_cluster_result(CommandResponse*      response,
-                                void*                 output,
-                                zval*                 return_value,
-                                z_result_processor_t  single_node_processor) {
+int process_core_cluster_result(CommandResponse*     response,
+                                void*                output,
+                                zval*                return_value,
+                                z_result_processor_t single_node_processor) {
     if (!response) {
         ZVAL_FALSE(return_value);
         return 0;
     }
 
-    if (response->response_type == Map && response->array_value &&
-        response->array_value_len > 0) {
+    if (response->response_type == Map && response->array_value && response->array_value_len > 0) {
         /* Multi-node response - return associative array of node => result */
         array_init(return_value);
         for (long i = 0; i < response->array_value_len; i++) {
@@ -1720,8 +1719,8 @@ static int process_bgsave_single_node_string(CommandResponse* response,
  * For multi-node routes: returns an associative array of node => bool.
  */
 int process_core_bgsave_bool_result(CommandResponse* response, void* output, zval* return_value) {
-    return process_core_cluster_result(response, output, return_value,
-                                       process_bgsave_single_node_bool);
+    return process_core_cluster_result(
+        response, output, return_value, process_bgsave_single_node_bool);
 }
 
 /**
@@ -1730,8 +1729,8 @@ int process_core_bgsave_bool_result(CommandResponse* response, void* output, zva
  * For multi-node routes: returns an associative array of node => string.
  */
 int process_core_bgsave_string_result(CommandResponse* response, void* output, zval* return_value) {
-    return process_core_cluster_result(response, output, return_value,
-                                       process_bgsave_single_node_string);
+    return process_core_cluster_result(
+        response, output, return_value, process_bgsave_single_node_string);
 }
 
 

--- a/valkey_glide_core_common.h
+++ b/valkey_glide_core_common.h
@@ -207,6 +207,7 @@ int process_core_string_result(CommandResponse* response, void* output, zval* re
 /* Boolean result processor */
 int process_core_bool_result(CommandResponse* response, void* output, zval* return_value);
 int process_core_bgsave_bool_result(CommandResponse* response, void* output, zval* return_value);
+int process_core_bgsave_string_result(CommandResponse* response, void* output, zval* return_value);
 
 /* Array result processor */
 int process_core_array_result(CommandResponse* response, void* output, zval* return_value);

--- a/valkey_glide_core_common.h
+++ b/valkey_glide_core_common.h
@@ -206,6 +206,7 @@ int process_core_string_result(CommandResponse* response, void* output, zval* re
 
 /* Boolean result processor */
 int process_core_bool_result(CommandResponse* response, void* output, zval* return_value);
+int process_core_bgsave_bool_result(CommandResponse* response, void* output, zval* return_value);
 
 /* Array result processor */
 int process_core_array_result(CommandResponse* response, void* output, zval* return_value);

--- a/valkey_glide_core_common.h
+++ b/valkey_glide_core_common.h
@@ -207,11 +207,12 @@ int process_core_string_result(CommandResponse* response, void* output, zval* re
 /* Boolean result processor */
 int process_core_bool_result(CommandResponse* response, void* output, zval* return_value);
 
-/* Generic cluster result processor - applies single_node_processor per node for multi-node routes */
-int process_core_cluster_result(CommandResponse*      response,
-                                void*                 output,
-                                zval*                 return_value,
-                                z_result_processor_t  single_node_processor);
+/* Generic cluster result processor - applies single_node_processor per node for multi-node routes
+ */
+int process_core_cluster_result(CommandResponse*     response,
+                                void*                output,
+                                zval*                return_value,
+                                z_result_processor_t single_node_processor);
 
 /* BGSAVE result processors (use process_core_cluster_result internally) */
 int process_core_bgsave_bool_result(CommandResponse* response, void* output, zval* return_value);

--- a/valkey_glide_core_common.h
+++ b/valkey_glide_core_common.h
@@ -206,6 +206,14 @@ int process_core_string_result(CommandResponse* response, void* output, zval* re
 
 /* Boolean result processor */
 int process_core_bool_result(CommandResponse* response, void* output, zval* return_value);
+
+/* Generic cluster result processor - applies single_node_processor per node for multi-node routes */
+int process_core_cluster_result(CommandResponse*      response,
+                                void*                 output,
+                                zval*                 return_value,
+                                z_result_processor_t  single_node_processor);
+
+/* BGSAVE result processors (use process_core_cluster_result internally) */
 int process_core_bgsave_bool_result(CommandResponse* response, void* output, zval* return_value);
 int process_core_bgsave_string_result(CommandResponse* response, void* output, zval* return_value);
 

--- a/valkey_z_php_methods.c
+++ b/valkey_z_php_methods.c
@@ -814,6 +814,10 @@ FLUSHDB_METHOD_IMPL(ValkeyGlide)
 FLUSHALL_METHOD_IMPL(ValkeyGlide)
 /* }}} */
 
+/* {{{ proto string ValkeyGlide::bgSave([string mode]) */
+BGSAVE_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
 /* {{{ proto array ValkeyGlide::time() */
 TIME_METHOD_IMPL(ValkeyGlide)
 /* }}} */


### PR DESCRIPTION
### Summary

Implement BGSAVE, BGSAVE SCHEDULE, and BGSAVE CANCEL commands for both standalone and cluster clients, matching PHPRedis API and the implementation in other GLIDE clients (Go, Python,
Node, C#).

### Issue link

This Pull Request is linked to issue (URL): #236
Related issues and pull requests:
- [2.5] Implement New Missing Commands valkey-io/valkey-glide#6010
- feat: Add BGSAVE commands valkey-io/valkey-glide-csharp#436

### Features / Behaviour Changes

- Add ValkeyGlide::bgSave(?string $mode = null): bool|string for standalone client
- Add ValkeyGlideCluster::bgSave(mixed $route, ?string $mode = null): bool|string for cluster client
- **PHPRedis compatible**: Returns true on success, false on failure by default
- With OPT_REPLY_LITERAL enabled, returns the actual status string (e.g., "Background saving started")
- Supports three modes:
  - null (default): Initiates a background save immediately
  - "SCHEDULE": Schedules a background save
  - "CANCEL": Aborts in-progress/scheduled saves (Valkey 8.1+)

### Implementation

- execute_bgsave_command() added in valkey_glide_commands.c
- BGSAVE_METHOD_IMPL macro added in valkey_glide_commands_common.h
- Macro invoked for ValkeyGlide in valkey_z_php_methods.c
- Macro invoked for ValkeyGlideCluster in valkey_glide_cluster.c
- BgSave case added to prepare_message_args switch in valkey_glide_core_common.c
- Added Map response type handling in process_core_string_result for cluster multi-node responses
- Stub definitions added to valkey_glide.stub.php and valkey_glide_cluster.stub.php

### Testing

- 3 standalone tests: testBgSave, testBgSaveSchedule, testBgSaveCancel
- 3 cluster tests with route parameter
- BGSAVE CANCEL tests version-gated to Valkey 8.1+
- waitForSaveNotInProgress() helper prevents test conflicts from concurrent saves
- Verified OPT_REPLY_LITERAL returns actual string response

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
