### PR TITLE
PHP: fix ort workflow to verify signatures

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,8 @@ Add a summary describing the changes
 
 ### Issue link
 
-This Pull Request is linked to issue (URL): [REPLACE ME]
+This Pull Request is linked to issue: [<Issue Title>](<Issue URL>)
+Closes <Issue #>
 
 ### Features / Behaviour Changes
 

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -357,33 +357,18 @@ jobs:
         ### Create PR, Note a potential race on the source branch ###
       - name: Create pull request
         if: ${{ env.FOUND_DIFF  == 'true' && github.event_name != 'pull_request' }}
-        run: |
-          export ORT_DIFF_BRANCH_NAME="ort-diff-for-$TARGET_BRANCH"
-          echo "Creating pull request from branch $ORT_DIFF_BRANCH_NAME to branch $TARGET_BRANCH"
-          git config --global user.email "valkey-glide@lists.valkey.io"
-          git config --global user.name "ort-bot"
-          git checkout -b ${ORT_DIFF_BRANCH_NAME}
-          git add $PHP_ATTRIBUTIONS
-          git commit -m "Updated attribution files" -s
-          git push --set-upstream origin ${ORT_DIFF_BRANCH_NAME} -f
-
-          # Check if PR already exists
-          existing_pr=$(gh pr list --base ${TARGET_BRANCH} --head ${ORT_DIFF_BRANCH_NAME} --json number --jq '.[0].number')
-
-          if [ -z "$existing_pr" ]; then
-            # Create a new PR if none exists
-            title="Updated attribution files for commit ${TARGET_COMMIT}"
-            gh pr create -B ${TARGET_BRANCH} -H ${ORT_DIFF_BRANCH_NAME} --title "${title}" --body "Created by Github action. ${{ env.LICENSES_LIST }}"
-            echo "Pull request created successfully."
-          else
-            # Update the existing PR
-            echo "Pull request #$existing_pr already exists. Updating branch."
-            gh pr edit $existing_pr --title "Updated attribution files for commit ${TARGET_COMMIT}" --body "Created by Github action. ${{ env.LICENSES_LIST }}"
-            echo "Pull request updated successfully."
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_VERSION: ${{ github.event.inputs.version }}
+        id: create-pr
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sign-commits: true
+          commit-message: "Updated attribution files\n\nSigned-off-by: ort-bot <valkey-glide@lists.valkey.io>"
+          branch: "ort-diff-for-${{ env.TARGET_BRANCH }}"
+          base: ${{ env.TARGET_BRANCH }}
+          title: "Updated attribution files for commit ${{ env.TARGET_COMMIT }}"
+          body: "Created by Github action. ${{ env.LICENSES_LIST }}"
+          add-paths: |
+            ${{ env.PHP_ATTRIBUTIONS }}
 
       ### Warn of outdated attributions for PR ###
       - name: Warn of outdated attributions due to the PR


### PR DESCRIPTION
### Summary

Fix the ORT workflow to produce verified (signed) commits by switching from manual git commit/git push to the peter-evans/create-pull-request action with sign-commits: true. This aligns with how the main valkey-glide repo handles ORT attribution PRs and resolves the "Commits must have verified signatures" merge block on the main branch.

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide-php/issues/256
Pull request with the issue: https://github.com/valkey-io/valkey-glide-php/pull/250

### Features / Behaviour Changes

- ORT workflow now produces cryptographically signed (verified) commits when creating attribution PRs
- Commits targeting main will no longer be blocked by the "Require verified signatures" branch protection rule
- PR creation/update behavior remains functionally identical

### Implementation

Replaced the manual shell-based git commit, push, and PR creation logic in .github/workflows/ort.yml with the peter-evans/create-pull-request@v7 action using sign-commits: true. This action uses the GitHub 
API to create commits, which GitHub automatically signs server-side.

This matches the approach used in the main [valkey-glide repo's ORT workflow](https://github.com/valkey-io/valkey-glide/blob/main/.github/workflows/ort.yml).

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [ ] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [ ] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.
