### PR TITLE
PHP: Implement bgwriteaof command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,69 +4,69 @@
 
 ### Changes
 
-* PHP: Add `BGREWRITEAOF` command for standalone and cluster clients ([#271](https://github.com/valkey-io/valkey-glide-php/pull/271))
-* PHP: Add `BGSAVE`, `BGSAVE SCHEDULE`, and `BGSAVE CANCEL` commands for standalone and cluster clients ([#236](https://github.com/valkey-io/valkey-glide-php/issues/236))
-* PHP: Fix pie install from Packagist using PIE pre-packaged-source download method ([#233](https://github.com/valkey-io/valkey-glide-php/pull/233))
-* PHP: Fix pie install from Packagist by setting preferred-install to source for submodule resolution ([#232](https://github.com/valkey-io/valkey-glide-php/pull/232))
-* PHP: Fix pie install ([#229](https://github.com/valkey-io/valkey-glide-php/pull/229))
-* PHP: Track getLastError/clearLastError as missing PHPRedis methods in the compatibility report instead of excluding them as connection management internals ([#220](https://github.com/valkey-io/valkey-glide-php/pull/220))
-* PHP: Implement getLastError()/clearLastError() for PHPRedis compatibility ([#221](https://github.com/valkey-io/valkey-glide-php/pull/221))
-* PHP: Set CLIENT SETINFO lib-name=GlidePHP and lib-ver to extension version for proper client identification
-* PHP: Add address resolver support for standalone and cluster clients, allowing custom host/port remapping at connection time ([#196](https://github.com/valkey-io/valkey-glide-php/pull/196))
+* Add `BGREWRITEAOF` command for standalone and cluster clients ([#271](https://github.com/valkey-io/valkey-glide-php/pull/271))
+* Add `BGSAVE`, `BGSAVE SCHEDULE`, and `BGSAVE CANCEL` commands for standalone and cluster clients ([#236](https://github.com/valkey-io/valkey-glide-php/issues/236))
+* Fix pie install from Packagist using PIE pre-packaged-source download method ([#233](https://github.com/valkey-io/valkey-glide-php/pull/233))
+* Fix pie install from Packagist by setting preferred-install to source for submodule resolution ([#232](https://github.com/valkey-io/valkey-glide-php/pull/232))
+* Fix pie install ([#229](https://github.com/valkey-io/valkey-glide-php/pull/229))
+* Track getLastError/clearLastError as missing PHPRedis methods in the compatibility report instead of excluding them as connection management internals ([#220](https://github.com/valkey-io/valkey-glide-php/pull/220))
+* Implement getLastError()/clearLastError() for PHPRedis compatibility ([#221](https://github.com/valkey-io/valkey-glide-php/pull/221))
+* Set CLIENT SETINFO lib-name=GlidePHP and lib-ver to extension version for proper client identification
+* Add address resolver support for standalone and cluster clients, allowing custom host/port remapping at connection time ([#196](https://github.com/valkey-io/valkey-glide-php/pull/196))
 
 ## 1.1.0
 
 ### Changes (1.1.0)
 
-* PHP: Fix script injection vulnerability in create-version-pr action (CWE-829) ([#206](https://github.com/valkey-io/valkey-glide-php/pull/206))
-* PHP: Add Sigstore-based artifact attestation for published PECL packages ([#189](https://github.com/valkey-io/valkey-glide-php/pull/189))
-* PHP: Pin all third-party GitHub Actions to SHA commit hashes to mitigate supply chain attacks (CWE-829) ([#188](https://github.com/valkey-io/valkey-glide-php/pull/188))
-* PHP: Remove repo-level SECURITY.md to use org-level security policy consistently across all valkey-io repositories ([#187](https://github.com/valkey-io/valkey-glide-php/pull/187))
-* PHP: Implement client-side caching with TTL-based expiration ([#180](https://github.com/valkey-io/valkey-glide-php/pull/180))
-* PHP: Fix memory leaks and resource management issues ([#174](https://github.com/valkey-io/valkey-glide-php/pull/174))
-* PHP: Add transparent compression support for string values ([#186](https://github.com/valkey-io/valkey-glide-php/pull/186))
-* PHP: Add Modules Testing CI ([#173](https://github.com/valkey-io/valkey-glide-php/pull/173))
-* PHP: Add FT.* (Vector Search) commands: ftCreate, ftDropIndex, ftList, ftSearch, ftAggregate, ftInfo, ftAliasAdd, ftAliasDel, ftAliasUpdate, ftAliasList for standalone and cluster clients ([#171](https://github.com/valkey-io/valkey-glide-php/pull/171))
-* PHP: Add JSON commands ([#185](https://github.com/valkey-io/valkey-glide-php/pull/185))
-* PHP: Add JSON.SET and JSON.GET commands for standalone and cluster clients ([#184](https://github.com/valkey-io/valkey-glide-php/pull/184))
-* PHP: Refactor IAM authentication tests ([#151](https://github.com/valkey-io/valkey-glide-php/pull/151))
-* PHP: Add DNS, TLS, and IP address tests ([#157](https://github.com/valkey-io/valkey-glide-php/pull/157))
-* PHP: Update approved license for aws-lc-sys:0.39.0 ([#176](https://github.com/valkey-io/valkey-glide-php/pull/176))
-* PHP: Update PECL installation readme ([#160](https://github.com/valkey-io/valkey-glide-php/pull/160))
-* PHP: Update valkey-glide submodule to latest main ([#154](https://github.com/valkey-io/valkey-glide-php/pull/154))
-* PHP: Implement transparent compression feature ([#150](https://github.com/valkey-io/valkey-glide-php/pull/150))
-* PHP: Add OPT_REPLY_LITERAL option for PHPRedis compatibility ([#120](https://github.com/valkey-io/valkey-glide-php/pull/120))
-* PHP: Add soak tests ([#130](https://github.com/valkey-io/valkey-glide-php/pull/130))
+* Fix script injection vulnerability in create-version-pr action (CWE-829) ([#206](https://github.com/valkey-io/valkey-glide-php/pull/206))
+* Add Sigstore-based artifact attestation for published PECL packages ([#189](https://github.com/valkey-io/valkey-glide-php/pull/189))
+* Pin all third-party GitHub Actions to SHA commit hashes to mitigate supply chain attacks (CWE-829) ([#188](https://github.com/valkey-io/valkey-glide-php/pull/188))
+* Remove repo-level SECURITY.md to use org-level security policy consistently across all valkey-io repositories ([#187](https://github.com/valkey-io/valkey-glide-php/pull/187))
+* Implement client-side caching with TTL-based expiration ([#180](https://github.com/valkey-io/valkey-glide-php/pull/180))
+* Fix memory leaks and resource management issues ([#174](https://github.com/valkey-io/valkey-glide-php/pull/174))
+* Add transparent compression support for string values ([#186](https://github.com/valkey-io/valkey-glide-php/pull/186))
+* Add Modules Testing CI ([#173](https://github.com/valkey-io/valkey-glide-php/pull/173))
+* Add FT.* (Vector Search) commands: ftCreate, ftDropIndex, ftList, ftSearch, ftAggregate, ftInfo, ftAliasAdd, ftAliasDel, ftAliasUpdate, ftAliasList for standalone and cluster clients ([#171](https://github.com/valkey-io/valkey-glide-php/pull/171))
+* Add JSON commands ([#185](https://github.com/valkey-io/valkey-glide-php/pull/185))
+* Add JSON.SET and JSON.GET commands for standalone and cluster clients ([#184](https://github.com/valkey-io/valkey-glide-php/pull/184))
+* Refactor IAM authentication tests ([#151](https://github.com/valkey-io/valkey-glide-php/pull/151))
+* Add DNS, TLS, and IP address tests ([#157](https://github.com/valkey-io/valkey-glide-php/pull/157))
+* Update approved license for aws-lc-sys:0.39.0 ([#176](https://github.com/valkey-io/valkey-glide-php/pull/176))
+* Update PECL installation readme ([#160](https://github.com/valkey-io/valkey-glide-php/pull/160))
+* Update valkey-glide submodule to latest main ([#154](https://github.com/valkey-io/valkey-glide-php/pull/154))
+* Implement transparent compression feature ([#150](https://github.com/valkey-io/valkey-glide-php/pull/150))
+* Add OPT_REPLY_LITERAL option for PHPRedis compatibility ([#120](https://github.com/valkey-io/valkey-glide-php/pull/120))
+* Add soak tests ([#130](https://github.com/valkey-io/valkey-glide-php/pull/130))
 
 ## 1.0.0
 
 ### Changes (1.0.0)
 
-* PHP: Fix mac development instructions ([#96](https://github.com/valkey-io/valkey-glide-php/pull/96))
-* PHP: chore: bump valkey-glide submodule for root_certs support ([#99](https://github.com/valkey-io/valkey-glide-php/pull/99))
-* PHP: ci: Add release automation workflows and version management ([#94](https://github.com/valkey-io/valkey-glide-php/pull/94))
-* PHP: (dev): Update and improve linting infrastructure ([#104](https://github.com/valkey-io/valkey-glide-php/pull/104))
-* PHP: (ci): test-modules job queuing indefinitely ([#106](https://github.com/valkey-io/valkey-glide-php/pull/106))
-* PHP: (feat): Add TLS support for secure connections ([#100](https://github.com/valkey-io/valkey-glide-php/pull/100))
-* PHP: feat: add markdown linting support for developers ([#110](https://github.com/valkey-io/valkey-glide-php/pull/110))
-* PHP: perf(php): optimize struct member ordering to reduce padding ([#111](https://github.com/valkey-io/valkey-glide-php/pull/111))
-* PHP: Add script and function commands ([#97](https://github.com/valkey-io/valkey-glide-php/pull/97))
-* PHP: Pub/Sub Implementation ([#121](https://github.com/valkey-io/valkey-glide-php/pull/121))
-* PHP: Remove ValkeyGlideClusterException ([#127](https://github.com/valkey-io/valkey-glide-php/pull/127))
-* PHP: Add aliases to PHPRedis-compatible class names ([#126](https://github.com/valkey-io/valkey-glide-php/pull/126))
-* PHP: Add connect method for ValkeyGlide client ([#131](https://github.com/valkey-io/valkey-glide-php/pull/131))
-* PHP: Add benchmarks ([#124](https://github.com/valkey-io/valkey-glide-php/pull/124))
-* PHP: Fix validation check for rc builds on PECL Package ([#135](https://github.com/valkey-io/valkey-glide-php/pull/135))
+* Fix mac development instructions ([#96](https://github.com/valkey-io/valkey-glide-php/pull/96))
+* chore: bump valkey-glide submodule for root_certs support ([#99](https://github.com/valkey-io/valkey-glide-php/pull/99))
+* ci: Add release automation workflows and version management ([#94](https://github.com/valkey-io/valkey-glide-php/pull/94))
+* (dev): Update and improve linting infrastructure ([#104](https://github.com/valkey-io/valkey-glide-php/pull/104))
+* (ci): test-modules job queuing indefinitely ([#106](https://github.com/valkey-io/valkey-glide-php/pull/106))
+* (feat): Add TLS support for secure connections ([#100](https://github.com/valkey-io/valkey-glide-php/pull/100))
+* feat: add markdown linting support for developers ([#110](https://github.com/valkey-io/valkey-glide-php/pull/110))
+* perf(php): optimize struct member ordering to reduce padding ([#111](https://github.com/valkey-io/valkey-glide-php/pull/111))
+* Add script and function commands ([#97](https://github.com/valkey-io/valkey-glide-php/pull/97))
+* Pub/Sub Implementation ([#121](https://github.com/valkey-io/valkey-glide-php/pull/121))
+* Remove ValkeyGlideClusterException ([#127](https://github.com/valkey-io/valkey-glide-php/pull/127))
+* Add aliases to PHPRedis-compatible class names ([#126](https://github.com/valkey-io/valkey-glide-php/pull/126))
+* Add connect method for ValkeyGlide client ([#131](https://github.com/valkey-io/valkey-glide-php/pull/131))
+* Add benchmarks ([#124](https://github.com/valkey-io/valkey-glide-php/pull/124))
+* Fix validation check for rc builds on PECL Package ([#135](https://github.com/valkey-io/valkey-glide-php/pull/135))
 
 ## 0.10.0
 
 ### Changes (0.10.0)
 
-* PHP: Add OPT_REPLY_LITERAL option for PHPRedis compatibility - allows commands returning OK to return the string "OK" instead of boolean true via setOption()/getOption() API
-* PHP: Implement TLS support for PHP client ([#2983](https://github.com/valkey-io/valkey-glide/pull/2983))
-* PHP: Add refresh topology configuration
-* PHP: Add Multi-Database Support for Cluster Mode Valkey 9.0 - Added `database_id` parameter to `ValkeyGlideCluster` constructor and support for SELECT, COPY, and MOVE commands in cluster mode. The COPY command can now specify a `database_id` parameter for cross-database operations. This feature requires Valkey 9.0+ with `cluster-databases > 1` configuration.
+* Add OPT_REPLY_LITERAL option for PHPRedis compatibility - allows commands returning OK to return the string "OK" instead of boolean true via setOption()/getOption() API
+* Implement TLS support for PHP client ([#2983](https://github.com/valkey-io/valkey-glide/pull/2983))
+* Add refresh topology configuration
+* Add Multi-Database Support for Cluster Mode Valkey 9.0 - Added `database_id` parameter to `ValkeyGlideCluster` constructor and support for SELECT, COPY, and MOVE commands in cluster mode. The COPY command can now specify a `database_id` parameter for cross-database operations. This feature requires Valkey 9.0+ with `cluster-databases > 1` configuration.
 
 ### Documentation
 
-* PHP: Updated README with multi-database cluster examples and inline documentation for database selection requirements and best practices
+* Updated README with multi-database cluster examples and inline documentation for database selection requirements and best practices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* PHP: Add `BGREWRITEAOF` command for standalone and cluster clients ([#271](https://github.com/valkey-io/valkey-glide-php/pull/271))
 * PHP: Add `BGSAVE`, `BGSAVE SCHEDULE`, and `BGSAVE CANCEL` commands for standalone and cluster clients ([#236](https://github.com/valkey-io/valkey-glide-php/issues/236))
 * PHP: Fix pie install from Packagist using PIE pre-packaged-source download method ([#233](https://github.com/valkey-io/valkey-glide-php/pull/233))
 * PHP: Fix pie install from Packagist by setting preferred-install to source for submodule resolution ([#232](https://github.com/valkey-io/valkey-glide-php/pull/232))

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -626,6 +626,24 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
     }
 
+    public function testBgRewriteAofBatch()
+    {
+        if (!$this->havePipeline()) {
+            $this->markTestSkipped('Pipeline not supported');
+            return;
+        }
+
+        $this->waitForSaveNotInProgress();
+
+        $this->valkey_glide->pipeline();
+        $this->valkey_glide->bgRewriteAof('allPrimaries');
+        $result = $this->valkey_glide->exec();
+        $this->assertIsArray($result[0]);
+        foreach ($result[0] as $nodeResult) {
+            $this->assertTrue($nodeResult);
+        }
+    }
+
     public function testInfo()
     {
         $fields = [

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -582,15 +582,14 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
-        // Test with allPrimaries route - returns array of node => string
+        // Test with allPrimaries route - returns array of node => bool
         $result = $this->valkey_glide->bgRewriteAof('allPrimaries');
         $this->assertIsArray($result);
         $this->assertGT(0, count($result));
         foreach ($result as $nodeAddress => $nodeResult) {
             $this->assertIsString($nodeAddress);
             $this->assertStringContains(':', $nodeAddress);
-            $this->assertIsString($nodeResult);
-            $this->assertContains($nodeResult, $this->bgRewriteAofResponses());
+            $this->assertTrue($nodeResult);
         }
     }
 
@@ -598,10 +597,33 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
+        // Test with randomNode route - returns scalar bool
+        $result = $this->valkey_glide->bgRewriteAof('randomNode');
+        $this->assertTrue($result);
+    }
+
+    public function testBgRewriteAofWithReplyLiteral()
+    {
+        $this->waitForSaveNotInProgress();
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+
+        // Test with allPrimaries route - returns array of node => string
+        $result = $this->valkey_glide->bgRewriteAof('allPrimaries');
+        $this->assertIsArray($result);
+        foreach ($result as $nodeResult) {
+            $this->assertIsString($nodeResult);
+            $this->assertContains($nodeResult, $this->bgRewriteAofResponses());
+        }
+
+        $this->waitForSaveNotInProgress();
+
         // Test with randomNode route - returns scalar string
         $result = $this->valkey_glide->bgRewriteAof('randomNode');
         $this->assertIsString($result);
         $this->assertContains($result, $this->bgRewriteAofResponses());
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
     }
 
     public function testInfo()

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -578,6 +578,32 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         }
     }
 
+    public function testBgRewriteAof()
+    {
+        $this->waitForSaveNotInProgress();
+
+        // Test with allPrimaries route - returns array of node => string
+        $result = $this->valkey_glide->bgRewriteAof('allPrimaries');
+        $this->assertIsArray($result);
+        $this->assertGT(0, count($result));
+        foreach ($result as $nodeAddress => $nodeResult) {
+            $this->assertIsString($nodeAddress);
+            $this->assertStringContains(':', $nodeAddress);
+            $this->assertIsString($nodeResult);
+            $this->assertContains($nodeResult, $this->bgRewriteAofResponses());
+        }
+    }
+
+    public function testBgRewriteAofWithRoute()
+    {
+        $this->waitForSaveNotInProgress();
+
+        // Test with randomNode route - returns scalar string
+        $result = $this->valkey_glide->bgRewriteAof('randomNode');
+        $this->assertIsString($result);
+        $this->assertContains($result, $this->bgRewriteAofResponses());
+    }
+
     public function testInfo()
     {
         $fields = [

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2671,6 +2671,15 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         }
     }
 
+    public function testBgRewriteAof()
+    {
+        $this->waitForSaveNotInProgress();
+
+        $result = $this->valkey_glide->bgRewriteAof();
+        $this->assertIsString($result);
+        $this->assertContains($result, $this->bgRewriteAofResponses());
+    }
+
     /**
      * Valid BGSAVE response strings (used when OPT_REPLY_LITERAL is enabled).
      */
@@ -2679,6 +2688,17 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         return [
             'Background saving started',
             'Background saving scheduled',
+        ];
+    }
+
+    /**
+     * Valid BGREWRITEAOF response strings.
+     */
+    protected function bgRewriteAofResponses(): array
+    {
+        return [
+            'Background append only file rewriting started',
+            'Background append only file rewriting scheduled',
         ];
     }
 

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2676,8 +2676,20 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->waitForSaveNotInProgress();
 
         $result = $this->valkey_glide->bgRewriteAof();
+        $this->assertTrue($result);
+    }
+
+    public function testBgRewriteAofWithReplyLiteral()
+    {
+        $this->waitForSaveNotInProgress();
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+
+        $result = $this->valkey_glide->bgRewriteAof();
         $this->assertIsString($result);
         $this->assertContains($result, $this->bgRewriteAofResponses());
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
     }
 
     /**

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2692,6 +2692,21 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
     }
 
+    public function testBgRewriteAofBatch()
+    {
+        if (!$this->havePipeline()) {
+            $this->markTestSkipped('Pipeline not supported');
+            return;
+        }
+
+        $this->waitForSaveNotInProgress();
+
+        $this->valkey_glide->pipeline();
+        $this->valkey_glide->bgRewriteAof();
+        $result = $this->valkey_glide->exec();
+        $this->assertTrue($result[0]);
+    }
+
     /**
      * Valid BGSAVE response strings (used when OPT_REPLY_LITERAL is enabled).
      */

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -1188,6 +1188,20 @@ class ValkeyGlide
     public function bgSave(?string $mode = null): ValkeyGlide|bool|string;
 
     /**
+     * Initiates a background rewrite of the append-only file (AOF).
+     *
+     * The server will fork a child process to rewrite the AOF in the background.
+     * The response indicates whether the rewrite was started or scheduled.
+     *
+     * @return ValkeyGlide|string  Returns a status string such as
+     *                             "Background append only file rewriting started" or
+     *                             "Background append only file rewriting scheduled".
+     *
+     * @see https://valkey.io/commands/bgrewriteaof
+     */
+    public function bgRewriteAof(): ValkeyGlide|string;
+
+    /**
      * Functions is an API for managing code to be executed on the server.
      *
      * @param string $operation         The subcommand you intend to execute.  Valid options are as follows

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -1193,13 +1193,12 @@ class ValkeyGlide
      * The server will fork a child process to rewrite the AOF in the background.
      * The response indicates whether the rewrite was started or scheduled.
      *
-     * @return ValkeyGlide|string  Returns a status string such as
-     *                             "Background append only file rewriting started" or
-     *                             "Background append only file rewriting scheduled".
+     * @return ValkeyGlide|bool|string  Returns true on success, false on failure.
+     *                                  With OPT_REPLY_LITERAL enabled, returns the status string instead.
      *
      * @see https://valkey.io/commands/bgrewriteaof
      */
-    public function bgRewriteAof(): ValkeyGlide|string;
+    public function bgRewriteAof(): ValkeyGlide|bool|string;
 
     /**
      * Functions is an API for managing code to be executed on the server.

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -977,13 +977,11 @@ FLUSHDB_METHOD_IMPL(ValkeyGlideCluster)
 FLUSHALL_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
-/* {{{ proto ValkeyGlideCluster::bgSave(mixed route, [string mode])
- *     Asynchronously saves the dataset to disk in the background. */
+/* {{{ proto ValkeyGlideCluster::bgSave(mixed route, [string mode]) */
 BGSAVE_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
-/* {{{ proto ValkeyGlideCluster::bgRewriteAof(mixed route)
- *     Initiates a background rewrite of the append-only file (AOF). */
+/* {{{ proto ValkeyGlideCluster::bgRewriteAof(mixed route) */
 BGREWRITEAOF_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -982,6 +982,11 @@ FLUSHALL_METHOD_IMPL(ValkeyGlideCluster)
 BGSAVE_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
+/* {{{ proto ValkeyGlideCluster::bgRewriteAof(mixed route)
+ *     Initiates a background rewrite of the append-only file (AOF). */
+BGREWRITEAOF_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
 /* {{{ proto ValkeyGlideCluster::dbsize(string key)
  *     proto ValkeyGlideCluster::dbsize(array host_port) */
 DBSIZE_METHOD_IMPL(ValkeyGlideCluster)

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -579,10 +579,10 @@ class ValkeyGlideCluster
     /**
      * @see ValkeyGlide::bgRewriteAof
      *
-     * For multi-node routes, returns an associative array mapping node addresses to status strings.
-     * For single-node routes, returns a scalar string.
+     * For multi-node routes, returns an associative array mapping node addresses to results.
+     * For single-node routes, returns a scalar (bool or string).
      */
-    public function bgRewriteAof(mixed $route): ValkeyGlideCluster|array|string;
+    public function bgRewriteAof(mixed $route): ValkeyGlideCluster|array|bool|string;
 
     /**
      * @see ValkeyGlide::geoadd

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -577,6 +577,14 @@ class ValkeyGlideCluster
     public function bgSave(mixed $route, ?string $mode = null): ValkeyGlideCluster|array|bool|string;
 
     /**
+     * @see ValkeyGlide::bgRewriteAof
+     *
+     * For multi-node routes, returns an associative array mapping node addresses to status strings.
+     * For single-node routes, returns a scalar string.
+     */
+    public function bgRewriteAof(mixed $route): ValkeyGlideCluster|array|string;
+
+    /**
      * @see ValkeyGlide::geoadd
      */
     public function geoadd(string $key, float $lng, float $lat, string $member, mixed ...$other_triples_and_options): ValkeyGlideCluster|int|false;

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -335,6 +335,64 @@ int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_clas
     return 1;
 }
 
+/* Execute a BGREWRITEAOF command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
+int execute_bgrewriteaof_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    zval*                args       = NULL;
+    int                  args_count = 0;
+    zend_bool            is_cluster = (ce == get_valkey_glide_cluster_ce());
+
+    /* Get ValkeyGlide object */
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    if (is_cluster && valkey_glide->is_in_batch_mode) {
+        /* BGREWRITEAOF cannot be used in batch mode for cluster */
+        return 0;
+    }
+
+    /* Setup core command arguments */
+    core_command_args_t core_args = {0};
+    core_args.glide_client        = valkey_glide->glide_client;
+    core_args.cmd_type            = BgRewriteAof;
+    core_args.is_cluster          = is_cluster;
+
+    if (is_cluster) {
+        /* Parse parameters for cluster - route parameter is required */
+        if (zend_parse_method_parameters(argc, object, "O*", &object, ce, &args, &args_count) ==
+            FAILURE) {
+            return 0;
+        }
+
+        if (args_count == 0) {
+            /* Need the route parameter */
+            return 0;
+        }
+
+        /* Set up routing */
+        core_args.has_route   = 1;
+        core_args.route_param = &args[0];
+    } else {
+        /* Non-cluster case - no parameters */
+        if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
+            return 0;
+        }
+    }
+
+    /* Execute using unified core framework - always returns string */
+    if (!execute_core_command(
+            valkey_glide, &core_args, NULL, process_core_string_result, return_value)) {
+        return 0;
+    }
+    if (valkey_glide->is_in_batch_mode) {
+        /* In batch mode, return $this for method chaining */
+        ZVAL_COPY(return_value, object);
+    }
+    return 1;
+}
+
 /* Execute a TIME command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
 int execute_time_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
     valkey_glide_object* valkey_glide;

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -381,9 +381,16 @@ int execute_bgrewriteaof_command(zval* object, int argc, zval* return_value, zen
         }
     }
 
-    /* Execute using unified core framework - always returns string */
-    if (!execute_core_command(
-            valkey_glide, &core_args, NULL, process_core_string_result, return_value)) {
+    /* Select processor based on OPT_REPLY_LITERAL:
+     * - With OPT_REPLY_LITERAL: return raw string (process_core_bgsave_string_result)
+     * - Without OPT_REPLY_LITERAL: return bool (process_core_bgsave_bool_result)
+     * This matches PHPRedis behavior where bgrewriteaof() returns bool. */
+    z_result_processor_t processor = valkey_glide->opt_reply_literal
+                                         ? process_core_bgsave_string_result
+                                         : process_core_bgsave_bool_result;
+
+    /* Execute using unified core framework */
+    if (!execute_core_command(valkey_glide, &core_args, NULL, processor, return_value)) {
         return 0;
     }
     if (valkey_glide->is_in_batch_mode) {

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -157,20 +157,9 @@ int execute_flushdb_command(zval* object, int argc, zval* return_value, zend_cla
     core_args.is_cluster          = is_cluster;
 
     if (is_cluster) {
-        /* Parse parameters for cluster - first parameter is route, optional second is async */
-        if (zend_parse_method_parameters(argc, object, "O*", &object, ce, &args, &args_count) ==
-            FAILURE) {
+        if (!parse_cluster_route(argc, &object, ce, &args, &args_count, &core_args)) {
             return 0;
         }
-
-        if (args_count == 0) {
-            /* Need at least the route parameter */
-            return 0;
-        }
-
-        /* Set up routing */
-        core_args.has_route   = 1;
-        core_args.route_param = &args[0];
 
         /* Get optional async parameter */
         if (args_count > 1) {
@@ -233,20 +222,9 @@ int execute_flushall_command(zval* object, int argc, zval* return_value, zend_cl
     core_args.is_cluster          = is_cluster;
 
     if (is_cluster) {
-        /* Parse parameters for cluster - first parameter is route, optional second is async */
-        if (zend_parse_method_parameters(argc, object, "O*", &object, ce, &args, &args_count) ==
-            FAILURE) {
+        if (!parse_cluster_route(argc, &object, ce, &args, &args_count, &core_args)) {
             return 0;
         }
-
-        if (args_count == 0) {
-            /* Need at least the route parameter */
-            return 0;
-        }
-
-        /* Set up routing */
-        core_args.has_route   = 1;
-        core_args.route_param = &args[0];
 
         /* Get optional async parameter */
         if (args_count > 1) {
@@ -306,20 +284,9 @@ int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_clas
     core_args.is_cluster          = is_cluster;
 
     if (is_cluster) {
-        /* Parse parameters for cluster - first parameter is route, optional second is mode */
-        if (zend_parse_method_parameters(argc, object, "O*", &object, ce, &args, &args_count) ==
-            FAILURE) {
+        if (!parse_cluster_route(argc, &object, ce, &args, &args_count, &core_args)) {
             return 0;
         }
-
-        if (args_count == 0) {
-            /* Need at least the route parameter */
-            return 0;
-        }
-
-        /* Set up routing */
-        core_args.has_route   = 1;
-        core_args.route_param = &args[0];
 
         /* Get optional mode parameter */
         if (args_count > 1 && Z_TYPE(args[1]) == IS_STRING) {
@@ -434,20 +401,9 @@ int execute_time_command(zval* object, int argc, zval* return_value, zend_class_
     core_args.is_cluster          = is_cluster;
 
     if (is_cluster) {
-        /* Parse parameters for cluster - route parameter is required */
-        if (zend_parse_method_parameters(argc, object, "O*", &object, ce, &args, &args_count) ==
-            FAILURE) {
+        if (!parse_cluster_route(argc, &object, ce, &args, &args_count, &core_args)) {
             return 0;
         }
-
-        if (args_count == 0) {
-            /* Need the route parameter */
-            return 0;
-        }
-
-        /* Set up routing */
-        core_args.has_route   = 1;
-        core_args.route_param = &args[0];
     } else {
         /* Non-cluster case - parse no parameters */
         if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -52,6 +52,26 @@ static int parse_cluster_route(int                  argc,
     return 1;
 }
 
+/**
+ * Execute a core command and handle batch mode.
+ * If in batch mode, copies the object to return_value for method chaining.
+ *
+ * Returns 1 on success, 0 on failure.
+ */
+static int execute_and_handle_batch(valkey_glide_object* valkey_glide,
+                                    core_command_args_t* core_args,
+                                    z_result_processor_t processor,
+                                    zval*                return_value,
+                                    zval*                object) {
+    if (!execute_core_command(valkey_glide, core_args, NULL, processor, return_value)) {
+        return 0;
+    }
+    if (valkey_glide->is_in_batch_mode) {
+        ZVAL_COPY(return_value, object);
+    }
+    return 1;
+}
+
 /* Execute an MSET command using the Valkey Glide client - MIGRATED TO CORE FRAMEWORK */
 int execute_mset_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
     valkey_glide_object* valkey_glide;
@@ -367,14 +387,7 @@ int execute_bgrewriteaof_command(zval* object, int argc, zval* return_value, zen
                                          : process_core_status_bool_result;
 
     /* Execute using unified core framework */
-    if (!execute_core_command(valkey_glide, &core_args, NULL, processor, return_value)) {
-        return 0;
-    }
-    if (valkey_glide->is_in_batch_mode) {
-        /* In batch mode, return $this for method chaining */
-        ZVAL_COPY(return_value, object);
-    }
-    return 1;
+    return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
 }
 
 /* Execute a TIME command using the Valkey Glide client - UNIFIED IMPLEMENTATION */

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -203,18 +203,8 @@ int execute_flushdb_command(zval* object, int argc, zval* return_value, zend_cla
     }
 
     /* Execute using unified core framework */
-    if (execute_core_command(
-            valkey_glide, &core_args, NULL, process_core_bool_result, return_value)) {
-        if (valkey_glide->is_in_batch_mode) {
-            /* In batch mode, return $this for method chaining */
-            ZVAL_COPY(return_value, object);
-            return 1;
-        }
-
-        return 1;
-    } else {
-        return 0;
-    }
+    return execute_and_handle_batch(
+        valkey_glide, &core_args, process_core_bool_result, return_value, object);
 }
 
 /* Execute a FLUSHALL command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
@@ -268,18 +258,8 @@ int execute_flushall_command(zval* object, int argc, zval* return_value, zend_cl
     }
 
     /* Execute using unified core framework */
-    if (execute_core_command(
-            valkey_glide, &core_args, NULL, process_core_bool_result, return_value)) {
-        if (valkey_glide->is_in_batch_mode) {
-            /* In batch mode, return $this for method chaining */
-            ZVAL_COPY(return_value, object);
-            return 1;
-        }
-
-        return 1;
-    } else {
-        return 0;
-    }
+    return execute_and_handle_batch(
+        valkey_glide, &core_args, process_core_bool_result, return_value, object);
 }
 
 /* Execute a BGSAVE command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
@@ -338,14 +318,7 @@ int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_clas
                                          : process_core_status_bool_result;
 
     /* Execute using unified core framework */
-    if (!execute_core_command(valkey_glide, &core_args, NULL, processor, return_value)) {
-        return 0;
-    }
-    if (valkey_glide->is_in_batch_mode) {
-        /* In batch mode, return $this for method chaining */
-        ZVAL_COPY(return_value, object);
-    }
-    return 1;
+    return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
 }
 
 /* Execute a BGREWRITEAOF command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
@@ -425,18 +398,8 @@ int execute_time_command(zval* object, int argc, zval* return_value, zend_class_
     }
 
     /* Execute using unified core framework */
-    if (execute_core_command(
-            valkey_glide, &core_args, NULL, process_core_array_result, return_value)) {
-        if (valkey_glide->is_in_batch_mode) {
-            /* In batch mode, return $this for method chaining */
-            ZVAL_COPY(return_value, object);
-            return 1;
-        }
-
-        return 1;
-    } else {
-        return 0;
-    }
+    return execute_and_handle_batch(
+        valkey_glide, &core_args, process_core_array_result, return_value, object);
 }
 
 /* Execute a WATCH command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
@@ -825,19 +788,8 @@ int execute_pfadd_command(zval* object, int argc, zval* return_value, zend_class
     args.args[0].data.array_arg.count = elements_count;
     args.arg_count                    = 1;
 
-    if (execute_core_command(valkey_glide, &args, NULL, process_core_int_result, return_value)) {
-        if (valkey_glide->is_in_batch_mode) {
-            /* In batch mode, return $this for method chaining */
-            ZVAL_COPY(return_value, object);
-            return 1;
-        }
-
-        return 1;
-    } else {
-        return 0;
-    }
-
-    return 0;
+    return execute_and_handle_batch(
+        valkey_glide, &args, process_core_int_result, return_value, object);
 }
 
 /* Unified PFCOUNT command implementation */
@@ -906,18 +858,8 @@ int execute_pfmerge_command(zval* object, int argc, zval* return_value, zend_cla
     args.args[0].data.array_arg.count = keys_count;
     args.arg_count                    = 1;
 
-    if (execute_core_command(valkey_glide, &args, NULL, process_core_bool_result, return_value)) {
-        if (valkey_glide->is_in_batch_mode) {
-            /* In batch mode, return $this for method chaining */
-            ZVAL_COPY(return_value, object);
-            return 1;
-        }
-
-        return 1;
-    }
-
-
-    return 0;
+    return execute_and_handle_batch(
+        valkey_glide, &args, process_core_bool_result, return_value, object);
 }
 
 /* Execute a SELECT command using the Valkey Glide client */

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -317,12 +317,12 @@ int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_clas
     }
 
     /* Select processor based on OPT_REPLY_LITERAL:
-     * - With OPT_REPLY_LITERAL: return raw string (process_core_bgsave_string_result)
-     * - Without OPT_REPLY_LITERAL: return bool (process_core_bgsave_bool_result)
+     * - With OPT_REPLY_LITERAL: return raw string (process_core_status_string_result)
+     * - Without OPT_REPLY_LITERAL: return bool (process_core_status_bool_result)
      * This ensures correct types in both normal and batch/pipeline mode. */
     z_result_processor_t processor = valkey_glide->opt_reply_literal
-                                         ? process_core_bgsave_string_result
-                                         : process_core_bgsave_bool_result;
+                                         ? process_core_status_string_result
+                                         : process_core_status_bool_result;
 
     /* Execute using unified core framework */
     if (!execute_core_command(valkey_glide, &core_args, NULL, processor, return_value)) {
@@ -377,12 +377,12 @@ int execute_bgrewriteaof_command(zval* object, int argc, zval* return_value, zen
     }
 
     /* Select processor based on OPT_REPLY_LITERAL:
-     * - With OPT_REPLY_LITERAL: return raw string (process_core_bgsave_string_result)
-     * - Without OPT_REPLY_LITERAL: return bool (process_core_bgsave_bool_result)
+     * - With OPT_REPLY_LITERAL: return raw string (process_core_status_string_result)
+     * - Without OPT_REPLY_LITERAL: return bool (process_core_status_bool_result)
      * This matches PHPRedis behavior where bgrewriteaof() returns bool. */
     z_result_processor_t processor = valkey_glide->opt_reply_literal
-                                         ? process_core_bgsave_string_result
-                                         : process_core_bgsave_bool_result;
+                                         ? process_core_status_string_result
+                                         : process_core_status_bool_result;
 
     /* Execute using unified core framework */
     if (!execute_core_command(valkey_glide, &core_args, NULL, processor, return_value)) {

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -348,11 +348,6 @@ int execute_bgrewriteaof_command(zval* object, int argc, zval* return_value, zen
         return 0;
     }
 
-    if (is_cluster && valkey_glide->is_in_batch_mode) {
-        /* BGREWRITEAOF cannot be used in batch mode for cluster */
-        return 0;
-    }
-
     /* Setup core command arguments */
     core_command_args_t core_args = {0};
     core_args.glide_client        = valkey_glide->glide_client;

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -26,6 +26,32 @@
 #include "valkey_glide_z_common.h"
 #include "zend_exceptions.h"
 
+/**
+ * Parse cluster route from method parameters.
+ * Parses variadic args, validates that at least one arg (the route) is present,
+ * and populates core_args routing fields.
+ *
+ * Returns 1 on success, 0 on failure.
+ * On success, *args and *args_count are set for further argument processing.
+ */
+static int parse_cluster_route(int                  argc,
+                               zval**               object,
+                               zend_class_entry*    ce,
+                               zval**               args,
+                               int*                 args_count,
+                               core_command_args_t* core_args) {
+    if (zend_parse_method_parameters(argc, *object, "O*", object, ce, args, args_count) ==
+        FAILURE) {
+        return 0;
+    }
+    if (*args_count == 0) {
+        return 0;
+    }
+    core_args->has_route   = 1;
+    core_args->route_param = &(*args)[0];
+    return 1;
+}
+
 /* Execute an MSET command using the Valkey Glide client - MIGRATED TO CORE FRAMEWORK */
 int execute_mset_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
     valkey_glide_object* valkey_glide;
@@ -355,20 +381,9 @@ int execute_bgrewriteaof_command(zval* object, int argc, zval* return_value, zen
     core_args.is_cluster          = is_cluster;
 
     if (is_cluster) {
-        /* Parse parameters for cluster - route parameter is required */
-        if (zend_parse_method_parameters(argc, object, "O*", &object, ce, &args, &args_count) ==
-            FAILURE) {
+        if (!parse_cluster_route(argc, &object, ce, &args, &args_count, &core_args)) {
             return 0;
         }
-
-        if (args_count == 0) {
-            /* Need the route parameter */
-            return 0;
-        }
-
-        /* Set up routing */
-        core_args.has_route   = 1;
-        core_args.route_param = &args[0];
     } else {
         /* Non-cluster case - no parameters */
         if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -206,6 +206,7 @@ int execute_unwatch_command(zval* object, int argc, zval* return_value, zend_cla
 int execute_flushdb_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_flushall_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_bgrewriteaof_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_time_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_scan_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_cluster_scan_command(const void* glide_client,
@@ -704,6 +705,20 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
         }                                                                         \
         zval_dtor(return_value);                                                  \
         RETURN_FALSE;                                                             \
+    }
+
+#define BGREWRITEAOF_METHOD_IMPL(class_name)                                            \
+    PHP_METHOD(class_name, bgRewriteAof) {                                              \
+        if (execute_bgrewriteaof_command(getThis(),                                     \
+                                         ZEND_NUM_ARGS(),                               \
+                                         return_value,                                  \
+                                         strcmp(#class_name, "ValkeyGlideCluster") == 0 \
+                                             ? get_valkey_glide_cluster_ce()            \
+                                             : get_valkey_glide_ce())) {                \
+            return;                                                                     \
+        }                                                                               \
+        zval_dtor(return_value);                                                        \
+        RETURN_FALSE;                                                                   \
     }
 
 #define TIME_METHOD_IMPL(class_name)                                            \

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -202,6 +202,7 @@ int prepare_core_args(core_command_args_t* args,
         case Time:
         case Role:
         case DBSize:
+        case BgRewriteAof:
             return prepare_zero_args(args, cmd_args, cmd_args_len);
 
         /* Single key operations */

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -1667,10 +1667,11 @@ int process_core_cluster_result(CommandResponse*     response,
 }
 
 /**
- * Single-node BGSAVE bool processor.
+ * Status-to-bool single-node processor.
  * Converts String/Ok responses to true, anything else to false.
+ * Used by commands like BGSAVE and BGREWRITEAOF that return status strings.
  */
-static int process_bgsave_single_node_bool(CommandResponse* response,
+static int process_status_single_node_bool(CommandResponse* response,
                                            void*            output,
                                            zval*            return_value) {
     if (!response) {
@@ -1688,19 +1689,21 @@ static int process_bgsave_single_node_bool(CommandResponse* response,
 }
 
 /**
- * BGSAVE boolean result processor.
+ * Status-to-bool result processor.
  * For single-node: returns true on success (String/Ok), false otherwise.
  * For multi-node routes: returns an associative array of node => bool.
+ * Used by commands like BGSAVE and BGREWRITEAOF.
  */
 int process_core_status_bool_result(CommandResponse* response, void* output, zval* return_value) {
     return process_core_cluster_result(
-        response, output, return_value, process_bgsave_single_node_bool);
+        response, output, return_value, process_status_single_node_bool);
 }
 
 /**
- * BGSAVE string result processor (OPT_REPLY_LITERAL mode).
+ * Status-to-string result processor (OPT_REPLY_LITERAL mode).
  * For single-node: returns the status string.
  * For multi-node routes: returns an associative array of node => string.
+ * Used by commands like BGSAVE and BGREWRITEAOF.
  */
 int process_core_status_string_result(CommandResponse* response, void* output, zval* return_value) {
     return process_core_cluster_result(response, output, return_value, process_core_string_result);

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -1692,7 +1692,7 @@ static int process_bgsave_single_node_bool(CommandResponse* response,
  * For single-node: returns true on success (String/Ok), false otherwise.
  * For multi-node routes: returns an associative array of node => bool.
  */
-int process_core_bgsave_bool_result(CommandResponse* response, void* output, zval* return_value) {
+int process_core_status_bool_result(CommandResponse* response, void* output, zval* return_value) {
     return process_core_cluster_result(
         response, output, return_value, process_bgsave_single_node_bool);
 }
@@ -1702,7 +1702,7 @@ int process_core_bgsave_bool_result(CommandResponse* response, void* output, zva
  * For single-node: returns the status string.
  * For multi-node routes: returns an associative array of node => string.
  */
-int process_core_bgsave_string_result(CommandResponse* response, void* output, zval* return_value) {
+int process_core_status_string_result(CommandResponse* response, void* output, zval* return_value) {
     return process_core_cluster_result(response, output, return_value, process_core_string_result);
 }
 

--- a/valkey_glide_core_common.h
+++ b/valkey_glide_core_common.h
@@ -215,8 +215,8 @@ int process_core_cluster_result(CommandResponse*     response,
                                 z_result_processor_t single_node_processor);
 
 /* BGSAVE result processors (use process_core_cluster_result internally) */
-int process_core_bgsave_bool_result(CommandResponse* response, void* output, zval* return_value);
-int process_core_bgsave_string_result(CommandResponse* response, void* output, zval* return_value);
+int process_core_status_bool_result(CommandResponse* response, void* output, zval* return_value);
+int process_core_status_string_result(CommandResponse* response, void* output, zval* return_value);
 
 /* Array result processor */
 int process_core_array_result(CommandResponse* response, void* output, zval* return_value);

--- a/valkey_z_php_methods.c
+++ b/valkey_z_php_methods.c
@@ -818,6 +818,10 @@ FLUSHALL_METHOD_IMPL(ValkeyGlide)
 BGSAVE_METHOD_IMPL(ValkeyGlide)
 /* }}} */
 
+/* {{{ proto string ValkeyGlide::bgRewriteAof() */
+BGREWRITEAOF_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
 /* {{{ proto array ValkeyGlide::time() */
 TIME_METHOD_IMPL(ValkeyGlide)
 /* }}} */


### PR DESCRIPTION
### Summary

Implement the BGREWRITEAOF command for both standalone (ValkeyGlide) and cluster (ValkeyGlideCluster) clients. The command initiates a background rewrite of the append-only file (AOF). The return type matches PHPRedis behavior — returns bool by default and the raw status string when OPT_REPLY_LITERAL is enabled.

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide-php/issues/236

### Features / Behaviour Changes

- Added bgRewriteAof() method to ValkeyGlide (standalone, no parameters)
- Added bgRewriteAof(mixed $route) method to ValkeyGlideCluster (cluster, required route parameter)
- Default return: true on success (PHPRedis-compatible)
- With OPT_REPLY_LITERAL enabled: returns the raw status string ("Background append only file rewriting started" or "Background append only file rewriting scheduled")
- Cluster multi-node routes return an associative array of node address → result
- Cluster single-node routes return a scalar value

### Implementation

- Defined method stubs in valkey_glide.stub.php and valkey_glide_cluster.stub.php
- Added execute_bgrewriteaof_command() helper in valkey_glide_commands.c following the same pattern as execute_bgsave_command()
- Added BGREWRITEAOF_METHOD_IMPL macro in valkey_glide_commands_common.h
- Invoked macro in valkey_z_php_methods.c (standalone) and valkey_glide_cluster.c (cluster)
- Registered BgRewriteAof (enum value 1113) as a zero-argument command in prepare_core_args() within valkey_glide_core_common.c
- Reuses process_core_bgsave_bool_result / process_core_bgsave_string_result processors based on OPT_REPLY_LITERAL flag

### Testing

Added integration tests matching all scenarios from other language clients.

Build verified: phpize && ./configure && make passes with zero compilation errors (-Werror enabled).
Linting verified: ./lint-c.sh reports no issues on modified source files.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.