### PR TITLE
Implement save command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* Add `SAVE` command for standalone and cluster clients ([#271](https://github.com/valkey-io/valkey-glide-php/pull/271))
 * Add `BGREWRITEAOF` command for standalone and cluster clients ([#271](https://github.com/valkey-io/valkey-glide-php/pull/271))
 * Add `BGSAVE`, `BGSAVE SCHEDULE`, and `BGSAVE CANCEL` commands for standalone and cluster clients ([#236](https://github.com/valkey-io/valkey-glide-php/issues/236))
 * Fix pie install from Packagist using PIE pre-packaged-source download method ([#233](https://github.com/valkey-io/valkey-glide-php/pull/233))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-* Add `SAVE` command for standalone and cluster clients ([#271](https://github.com/valkey-io/valkey-glide-php/pull/271))
+* Add `SAVE` command for standalone and cluster clients ([#272](https://github.com/valkey-io/valkey-glide-php/pull/272))
 * Add `BGREWRITEAOF` command for standalone and cluster clients ([#271](https://github.com/valkey-io/valkey-glide-php/pull/271))
 * Add `BGSAVE`, `BGSAVE SCHEDULE`, and `BGSAVE CANCEL` commands for standalone and cluster clients ([#236](https://github.com/valkey-io/valkey-glide-php/issues/236))
 * Fix pie install from Packagist using PIE pre-packaged-source download method ([#233](https://github.com/valkey-io/valkey-glide-php/pull/233))

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -496,38 +496,46 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
                 $this->assertIsString($nodeResult);
                 $this->assertContains($nodeResult, $this->bgsaveResponses());
             }
+        });
 
-            $this->waitForSaveNotInProgress();
+        $this->waitForSaveNotInProgress();
 
+        $this->withOptReplyLiteralEnabled(function () {
             $result = $this->valkey_glide->bgSave('randomNode');
             $this->assertIsString($result);
             $this->assertContains($result, $this->bgsaveResponses());
+        });
 
-            $this->waitForSaveNotInProgress();
+        $this->waitForSaveNotInProgress();
 
+        $this->withOptReplyLiteralEnabled(function () {
             $result = $this->valkey_glide->bgSave('allPrimaries', 'SCHEDULE');
             $this->assertIsArray($result);
             foreach ($result as $nodeResult) {
                 $this->assertIsString($nodeResult);
                 $this->assertContains($nodeResult, $this->bgsaveResponses());
             }
+        });
 
-            $this->waitForSaveNotInProgress();
+        $this->waitForSaveNotInProgress();
 
+        $this->withOptReplyLiteralEnabled(function () {
             $result = $this->valkey_glide->bgSave('randomNode', 'SCHEDULE');
             $this->assertIsString($result);
             $this->assertContains($result, $this->bgsaveResponses());
+        });
 
-            if ($this->minVersionCheck('8.1.0')) {
-                $this->waitForSaveNotInProgress();
+        if ($this->minVersionCheck('8.1.0')) {
+            $this->waitForSaveNotInProgress();
 
+            $this->withOptReplyLiteralEnabled(function () {
                 $result = $this->valkey_glide->bgSave('allPrimaries', 'CANCEL');
                 $this->assertFalse($result);
 
                 $result = $this->valkey_glide->bgSave('randomNode', 'CANCEL');
                 $this->assertFalse($result);
-            }
-        });
+            });
+        }
     }
 
     public function testBgSaveBatch()
@@ -600,9 +608,11 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
                 $this->assertIsString($nodeResult);
                 $this->assertContains($nodeResult, $this->bgRewriteAofResponses());
             }
+        });
 
-            $this->waitForSaveNotInProgress();
+        $this->waitForSaveNotInProgress();
 
+        $this->withOptReplyLiteralEnabled(function () {
             $result = $this->valkey_glide->bgRewriteAof('randomNode');
             $this->assertIsString($result);
             $this->assertContains($result, $this->bgRewriteAofResponses());

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -413,11 +413,20 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $info = $this->valkey_glide->info('allPrimaries', 'persistence');
         foreach ($info as $nodeInfo) {
-            if (
-                $nodeInfo['rdb_bgsave_in_progress'] == '1'
-                || $nodeInfo['aof_rewrite_in_progress'] == '1'
-            ) {
-                return true;
+            if (is_array($nodeInfo)) {
+                if (
+                    (isset($nodeInfo['rdb_bgsave_in_progress']) && $nodeInfo['rdb_bgsave_in_progress'] == '1')
+                    || (isset($nodeInfo['aof_rewrite_in_progress']) && $nodeInfo['aof_rewrite_in_progress'] == '1')
+                ) {
+                    return true;
+                }
+            } elseif (is_string($nodeInfo)) {
+                if (
+                    str_contains($nodeInfo, 'rdb_bgsave_in_progress:1')
+                    || str_contains($nodeInfo, 'aof_rewrite_in_progress:1')
+                ) {
+                    return true;
+                }
             }
         }
         return false;
@@ -648,15 +657,18 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
-        // Test with allPrimaries route - returns array of node => bool
+        // Test with randomNode route - returns scalar bool
+        $result = $this->valkey_glide->save('randomNode');
+        $this->assertTrue($result);
+    }
+
+    public function testSaveWithRoute()
+    {
+        $this->waitForSaveNotInProgress();
+
+        // Test with allPrimaries route - succeeds without error
         $result = $this->valkey_glide->save('allPrimaries');
-        $this->assertIsArray($result);
-        $this->assertGT(0, count($result));
-        foreach ($result as $nodeAddress => $nodeResult) {
-            $this->assertIsString($nodeAddress);
-            $this->assertStringContains(':', $nodeAddress);
-            $this->assertTrue($nodeResult);
-        }
+        $this->assertTrue($result);
     }
 
     public function testSaveWithRoute()
@@ -674,17 +686,7 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
 
-        // Test with allPrimaries route - returns array of node => string
-        $result = $this->valkey_glide->save('allPrimaries');
-        $this->assertIsArray($result);
-        foreach ($result as $nodeResult) {
-            $this->assertIsString($nodeResult);
-            $this->assertEquals('OK', $nodeResult);
-        }
-
-        $this->waitForSaveNotInProgress();
-
-        // Test with randomNode route - returns scalar string
+        // Test with randomNode route - returns scalar string "OK"
         $result = $this->valkey_glide->save('randomNode');
         $this->assertIsString($result);
         $this->assertEquals('OK', $result);
@@ -702,12 +704,9 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->waitForSaveNotInProgress();
 
         $this->valkey_glide->pipeline();
-        $this->valkey_glide->save('allPrimaries');
+        $this->valkey_glide->save('randomNode');
         $result = $this->valkey_glide->exec();
-        $this->assertIsArray($result[0]);
-        foreach ($result[0] as $nodeResult) {
-            $this->assertTrue($nodeResult);
-        }
+        $this->assertTrue($result[0]);
     }
 
     public function testInfo()

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -493,52 +493,45 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+        $this->withOptReplyLiteralEnabled(function () {
+            $result = $this->valkey_glide->bgSave('allPrimaries');
+            $this->assertIsArray($result);
+            foreach ($result as $nodeResult) {
+                $this->assertIsString($nodeResult);
+                $this->assertContains($nodeResult, $this->bgsaveResponses());
+            }
 
-        // Test with allPrimaries route - returns array of node => string
-        $result = $this->valkey_glide->bgSave('allPrimaries');
-        $this->assertIsArray($result);
-        foreach ($result as $nodeResult) {
-            $this->assertIsString($nodeResult);
-            $this->assertContains($nodeResult, $this->bgsaveResponses());
-        }
-
-        $this->waitForSaveNotInProgress();
-
-        // Test with randomNode route - returns scalar string
-        $result = $this->valkey_glide->bgSave('randomNode');
-        $this->assertIsString($result);
-        $this->assertContains($result, $this->bgsaveResponses());
-
-        $this->waitForSaveNotInProgress();
-
-        // Test SCHEDULE with allPrimaries route - returns array of node => string
-        $result = $this->valkey_glide->bgSave('allPrimaries', 'SCHEDULE');
-        $this->assertIsArray($result);
-        foreach ($result as $nodeResult) {
-            $this->assertIsString($nodeResult);
-            $this->assertContains($nodeResult, $this->bgsaveResponses());
-        }
-
-        $this->waitForSaveNotInProgress();
-
-        // Test SCHEDULE with randomNode route - returns scalar string
-        $result = $this->valkey_glide->bgSave('randomNode', 'SCHEDULE');
-        $this->assertIsString($result);
-        $this->assertContains($result, $this->bgsaveResponses());
-
-        if ($this->minVersionCheck('8.1.0')) {
             $this->waitForSaveNotInProgress();
 
-            // CANCEL with no save in progress returns false (see testBgSaveCancel comment)
-            $result = $this->valkey_glide->bgSave('allPrimaries', 'CANCEL');
-            $this->assertFalse($result);
+            $result = $this->valkey_glide->bgSave('randomNode');
+            $this->assertIsString($result);
+            $this->assertContains($result, $this->bgsaveResponses());
 
-            $result = $this->valkey_glide->bgSave('randomNode', 'CANCEL');
-            $this->assertFalse($result);
-        }
+            $this->waitForSaveNotInProgress();
 
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+            $result = $this->valkey_glide->bgSave('allPrimaries', 'SCHEDULE');
+            $this->assertIsArray($result);
+            foreach ($result as $nodeResult) {
+                $this->assertIsString($nodeResult);
+                $this->assertContains($nodeResult, $this->bgsaveResponses());
+            }
+
+            $this->waitForSaveNotInProgress();
+
+            $result = $this->valkey_glide->bgSave('randomNode', 'SCHEDULE');
+            $this->assertIsString($result);
+            $this->assertContains($result, $this->bgsaveResponses());
+
+            if ($this->minVersionCheck('8.1.0')) {
+                $this->waitForSaveNotInProgress();
+
+                $result = $this->valkey_glide->bgSave('allPrimaries', 'CANCEL');
+                $this->assertFalse($result);
+
+                $result = $this->valkey_glide->bgSave('randomNode', 'CANCEL');
+                $this->assertFalse($result);
+            }
+        });
     }
 
     public function testBgSaveBatch()
@@ -606,24 +599,20 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+        $this->withOptReplyLiteralEnabled(function () {
+            $result = $this->valkey_glide->bgRewriteAof('allPrimaries');
+            $this->assertIsArray($result);
+            foreach ($result as $nodeResult) {
+                $this->assertIsString($nodeResult);
+                $this->assertContains($nodeResult, $this->bgRewriteAofResponses());
+            }
 
-        // Test with allPrimaries route - returns array of node => string
-        $result = $this->valkey_glide->bgRewriteAof('allPrimaries');
-        $this->assertIsArray($result);
-        foreach ($result as $nodeResult) {
-            $this->assertIsString($nodeResult);
-            $this->assertContains($nodeResult, $this->bgRewriteAofResponses());
-        }
+            $this->waitForSaveNotInProgress();
 
-        $this->waitForSaveNotInProgress();
-
-        // Test with randomNode route - returns scalar string
-        $result = $this->valkey_glide->bgRewriteAof('randomNode');
-        $this->assertIsString($result);
-        $this->assertContains($result, $this->bgRewriteAofResponses());
-
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+            $result = $this->valkey_glide->bgRewriteAof('randomNode');
+            $this->assertIsString($result);
+            $this->assertContains($result, $this->bgRewriteAofResponses());
+        });
     }
 
     public function testBgRewriteAofBatch()
@@ -666,14 +655,11 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
-
-        // Test with randomNode route - returns scalar string "OK"
-        $result = $this->valkey_glide->save('randomNode');
-        $this->assertIsString($result);
-        $this->assertEquals('OK', $result);
-
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+        $this->withOptReplyLiteralEnabled(function () {
+            $result = $this->valkey_glide->save('randomNode');
+            $this->assertIsString($result);
+            $this->assertEquals('OK', $result);
+        });
     }
 
     public function testSaveBatch()
@@ -1454,15 +1440,13 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $rv = $this->valkey_glide->eval("return {redis.call('set', KEYS[1], 'bar'), redis.call('ping')}", ['foo'], 1);
         $this->assertEquals([true, true], $rv);
 
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
-        $this->assertEquals('OK', $this->valkey_glide->rawCommand('foo', 'set', 'foo', 'bar'));
-        $this->assertEquals('OK', $this->valkey_glide->eval("return redis.call('set', KEYS[1], 'bar')", ['foo'], 1));
+        $this->withOptReplyLiteralEnabled(function () {
+            $this->assertEquals('OK', $this->valkey_glide->rawCommand('foo', 'set', 'foo', 'bar'));
+            $this->assertEquals('OK', $this->valkey_glide->eval("return redis.call('set', KEYS[1], 'bar')", ['foo'], 1));
 
-        $rv = $this->valkey_glide->eval("return {redis.call('set', KEYS[1], 'bar'), redis.call('ping')}", ['foo'], 1);
-        $this->assertEquals(['OK', 'PONG'], $rv);
-
-        // Reset
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+            $rv = $this->valkey_glide->eval("return {redis.call('set', KEYS[1], 'bar'), redis.call('ping')}", ['foo'], 1);
+            $this->assertEquals(['OK', 'PONG'], $rv);
+        });
     }
 
     public function testCopyCluster()

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -644,6 +644,72 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         }
     }
 
+    public function testSave()
+    {
+        $this->waitForSaveNotInProgress();
+
+        // Test with allPrimaries route - returns array of node => bool
+        $result = $this->valkey_glide->save('allPrimaries');
+        $this->assertIsArray($result);
+        $this->assertGT(0, count($result));
+        foreach ($result as $nodeAddress => $nodeResult) {
+            $this->assertIsString($nodeAddress);
+            $this->assertStringContains(':', $nodeAddress);
+            $this->assertTrue($nodeResult);
+        }
+    }
+
+    public function testSaveWithRoute()
+    {
+        $this->waitForSaveNotInProgress();
+
+        // Test with randomNode route - returns scalar bool
+        $result = $this->valkey_glide->save('randomNode');
+        $this->assertTrue($result);
+    }
+
+    public function testSaveWithReplyLiteral()
+    {
+        $this->waitForSaveNotInProgress();
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+
+        // Test with allPrimaries route - returns array of node => string
+        $result = $this->valkey_glide->save('allPrimaries');
+        $this->assertIsArray($result);
+        foreach ($result as $nodeResult) {
+            $this->assertIsString($nodeResult);
+            $this->assertEquals('OK', $nodeResult);
+        }
+
+        $this->waitForSaveNotInProgress();
+
+        // Test with randomNode route - returns scalar string
+        $result = $this->valkey_glide->save('randomNode');
+        $this->assertIsString($result);
+        $this->assertEquals('OK', $result);
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+    }
+
+    public function testSaveBatch()
+    {
+        if (!$this->havePipeline()) {
+            $this->markTestSkipped('Pipeline not supported');
+            return;
+        }
+
+        $this->waitForSaveNotInProgress();
+
+        $this->valkey_glide->pipeline();
+        $this->valkey_glide->save('allPrimaries');
+        $result = $this->valkey_glide->exec();
+        $this->assertIsArray($result[0]);
+        foreach ($result[0] as $nodeResult) {
+            $this->assertTrue($nodeResult);
+        }
+    }
+
     public function testInfo()
     {
         $fields = [

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -413,20 +413,11 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $info = $this->valkey_glide->info('allPrimaries', 'persistence');
         foreach ($info as $nodeInfo) {
-            if (is_array($nodeInfo)) {
-                if (
-                    (isset($nodeInfo['rdb_bgsave_in_progress']) && $nodeInfo['rdb_bgsave_in_progress'] == '1')
-                    || (isset($nodeInfo['aof_rewrite_in_progress']) && $nodeInfo['aof_rewrite_in_progress'] == '1')
-                ) {
-                    return true;
-                }
-            } elseif (is_string($nodeInfo)) {
-                if (
-                    str_contains($nodeInfo, 'rdb_bgsave_in_progress:1')
-                    || str_contains($nodeInfo, 'aof_rewrite_in_progress:1')
-                ) {
-                    return true;
-                }
+            if (
+                (isset($nodeInfo['rdb_bgsave_in_progress']) && $nodeInfo['rdb_bgsave_in_progress'] == '1')
+                || (isset($nodeInfo['aof_rewrite_in_progress']) && $nodeInfo['aof_rewrite_in_progress'] == '1')
+            ) {
+                return true;
             }
         }
         return false;
@@ -668,15 +659,6 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         // Test with allPrimaries route - succeeds without error
         $result = $this->valkey_glide->save('allPrimaries');
-        $this->assertTrue($result);
-    }
-
-    public function testSaveWithRoute()
-    {
-        $this->waitForSaveNotInProgress();
-
-        // Test with randomNode route - returns scalar bool
-        $result = $this->valkey_glide->save('randomNode');
         $this->assertTrue($result);
     }
 

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -427,7 +427,6 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
-        // Test with allPrimaries route - returns array of node => bool
         $result = $this->valkey_glide->bgSave('allPrimaries');
         $this->assertIsArray($result);
         $this->assertGT(0, count($result));
@@ -439,7 +438,6 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         $this->waitForSaveNotInProgress();
 
-        // Test with randomNode route - returns scalar bool
         $result = $this->valkey_glide->bgSave('randomNode');
         $this->assertTrue($result);
     }
@@ -448,7 +446,6 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
-        // Test with allPrimaries route - returns array of node => bool
         $result = $this->valkey_glide->bgSave('allPrimaries', 'SCHEDULE');
         $this->assertIsArray($result);
         $this->assertGT(0, count($result));
@@ -460,7 +457,6 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         $this->waitForSaveNotInProgress();
 
-        // Test with randomNode route - returns scalar bool
         $result = $this->valkey_glide->bgSave('randomNode', 'SCHEDULE');
         $this->assertTrue($result);
     }
@@ -575,7 +571,6 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
-        // Test with allPrimaries route - returns array of node => bool
         $result = $this->valkey_glide->bgRewriteAof('allPrimaries');
         $this->assertIsArray($result);
         $this->assertGT(0, count($result));
@@ -590,7 +585,6 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
-        // Test with randomNode route - returns scalar bool
         $result = $this->valkey_glide->bgRewriteAof('randomNode');
         $this->assertTrue($result);
     }
@@ -637,7 +631,6 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
-        // Test with randomNode route - returns scalar bool
         $result = $this->valkey_glide->save('randomNode');
         $this->assertTrue($result);
     }
@@ -646,7 +639,6 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->waitForSaveNotInProgress();
 
-        // Test with allPrimaries route - succeeds without error
         $result = $this->valkey_glide->save('allPrimaries');
         $this->assertTrue($result);
     }

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2636,20 +2636,24 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
             $result = $this->valkey_glide->bgSave();
             $this->assertIsString($result);
             $this->assertContains($result, $this->bgsaveResponses());
+        });
 
-            $this->waitForSaveNotInProgress();
+        $this->waitForSaveNotInProgress();
 
+        $this->withOptReplyLiteralEnabled(function () {
             $result = $this->valkey_glide->bgSave('SCHEDULE');
             $this->assertIsString($result);
             $this->assertContains($result, $this->bgsaveResponses());
+        });
 
-            if ($this->minVersionCheck('8.1.0')) {
-                $this->waitForSaveNotInProgress();
+        if ($this->minVersionCheck('8.1.0')) {
+            $this->waitForSaveNotInProgress();
 
+            $this->withOptReplyLiteralEnabled(function () {
                 $result = $this->valkey_glide->bgSave('CANCEL');
                 $this->assertFalse($result);
-            }
-        });
+            });
+        }
     }
 
     public function testBgSaveBatch()

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -89,6 +89,20 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
     }
 
     /**
+     * Execute a callable with OPT_REPLY_LITERAL enabled, ensuring it is
+     * always disabled afterwards even if an exception is thrown.
+     */
+    protected function withOptReplyLiteralEnabled(callable $fn)
+    {
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+        try {
+            return $fn();
+        } finally {
+            $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+        }
+    }
+
+    /**
      * Compare major version number against a minimum required version
      *
      * @param int $minMajorVersion Minimum required major version
@@ -2618,26 +2632,24 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
     {
         $this->waitForSaveNotInProgress();
 
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+        $this->withOptReplyLiteralEnabled(function () {
+            $result = $this->valkey_glide->bgSave();
+            $this->assertIsString($result);
+            $this->assertContains($result, $this->bgsaveResponses());
 
-        $result = $this->valkey_glide->bgSave();
-        $this->assertIsString($result);
-        $this->assertContains($result, $this->bgsaveResponses());
-
-        $this->waitForSaveNotInProgress();
-
-        $result = $this->valkey_glide->bgSave('SCHEDULE');
-        $this->assertIsString($result);
-        $this->assertContains($result, $this->bgsaveResponses());
-
-        if ($this->minVersionCheck('8.1.0')) {
             $this->waitForSaveNotInProgress();
 
-            $result = $this->valkey_glide->bgSave('CANCEL');
-            $this->assertFalse($result);
-        }
+            $result = $this->valkey_glide->bgSave('SCHEDULE');
+            $this->assertIsString($result);
+            $this->assertContains($result, $this->bgsaveResponses());
 
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+            if ($this->minVersionCheck('8.1.0')) {
+                $this->waitForSaveNotInProgress();
+
+                $result = $this->valkey_glide->bgSave('CANCEL');
+                $this->assertFalse($result);
+            }
+        });
     }
 
     public function testBgSaveBatch()
@@ -2683,13 +2695,11 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
     {
         $this->waitForSaveNotInProgress();
 
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
-
-        $result = $this->valkey_glide->bgRewriteAof();
-        $this->assertIsString($result);
-        $this->assertContains($result, $this->bgRewriteAofResponses());
-
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+        $this->withOptReplyLiteralEnabled(function () {
+            $result = $this->valkey_glide->bgRewriteAof();
+            $this->assertIsString($result);
+            $this->assertContains($result, $this->bgRewriteAofResponses());
+        });
     }
 
     public function testBgRewriteAofBatch()
@@ -2741,13 +2751,11 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
     {
         $this->waitForSaveNotInProgress();
 
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
-
-        $result = $this->valkey_glide->save();
-        $this->assertIsString($result);
-        $this->assertEquals('OK', $result);
-
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+        $this->withOptReplyLiteralEnabled(function () {
+            $result = $this->valkey_glide->save();
+            $this->assertIsString($result);
+            $this->assertEquals('OK', $result);
+        });
     }
 
     public function testSaveBatch()

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2729,6 +2729,42 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         ];
     }
 
+    public function testSave()
+    {
+        $this->waitForSaveNotInProgress();
+
+        $result = $this->valkey_glide->save();
+        $this->assertTrue($result);
+    }
+
+    public function testSaveWithReplyLiteral()
+    {
+        $this->waitForSaveNotInProgress();
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+
+        $result = $this->valkey_glide->save();
+        $this->assertIsString($result);
+        $this->assertEquals('OK', $result);
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+    }
+
+    public function testSaveBatch()
+    {
+        if (!$this->havePipeline()) {
+            $this->markTestSkipped('Pipeline not supported');
+            return;
+        }
+
+        $this->waitForSaveNotInProgress();
+
+        $this->valkey_glide->pipeline();
+        $this->valkey_glide->save();
+        $result = $this->valkey_glide->exec();
+        $this->assertTrue($result[0]);
+    }
+
     /**
      * Returns true if a background save (RDB or AOF) is currently in progress.
      */

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -1201,6 +1201,19 @@ class ValkeyGlide
     public function bgRewriteAof(): ValkeyGlide|bool|string;
 
     /**
+     * Synchronously saves the dataset to disk (blocking).
+     *
+     * This command blocks the server until the save is complete. For a non-blocking
+     * alternative, use {@see bgSave()}.
+     *
+     * @return ValkeyGlide|bool|string  Returns true on success, false on failure.
+     *                                  With OPT_REPLY_LITERAL enabled, returns "OK" instead.
+     *
+     * @see https://valkey.io/commands/save
+     */
+    public function save(): ValkeyGlide|bool|string;
+
+    /**
      * Functions is an API for managing code to be executed on the server.
      *
      * @param string $operation         The subcommand you intend to execute.  Valid options are as follows

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -1207,7 +1207,8 @@ class ValkeyGlide
      * alternative, use {@see bgSave()}.
      *
      * @return ValkeyGlide|bool|string  Returns true on success, false on failure.
-     *                                  With OPT_REPLY_LITERAL enabled, returns "OK" instead.
+     *                                  With OPT_REPLY_LITERAL enabled, returns "OK" on success,
+     *                                  false on failure.
      *
      * @see https://valkey.io/commands/save
      */

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -985,6 +985,10 @@ BGSAVE_METHOD_IMPL(ValkeyGlideCluster)
 BGREWRITEAOF_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
+/* {{{ proto ValkeyGlideCluster::save(mixed route) */
+SAVE_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
 /* {{{ proto ValkeyGlideCluster::dbsize(string key)
  *     proto ValkeyGlideCluster::dbsize(array host_port) */
 DBSIZE_METHOD_IMPL(ValkeyGlideCluster)

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -586,9 +586,6 @@ class ValkeyGlideCluster
 
     /**
      * @see ValkeyGlide::save
-     *
-     * Returns true on success, false on failure.
-     * With OPT_REPLY_LITERAL enabled, returns "OK" on success, false on failure.
      */
     public function save(mixed $route): ValkeyGlideCluster|bool|string;
 

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -587,10 +587,9 @@ class ValkeyGlideCluster
     /**
      * @see ValkeyGlide::save
      *
-     * For multi-node routes, returns an associative array mapping node addresses to results.
-     * For single-node routes, returns a scalar (bool or string).
+     * Returns true on success (or "OK" with OPT_REPLY_LITERAL enabled).
      */
-    public function save(mixed $route): ValkeyGlideCluster|array|bool|string;
+    public function save(mixed $route): ValkeyGlideCluster|bool|string;
 
     /**
      * @see ValkeyGlide::geoadd

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -585,6 +585,14 @@ class ValkeyGlideCluster
     public function bgRewriteAof(mixed $route): ValkeyGlideCluster|array|bool|string;
 
     /**
+     * @see ValkeyGlide::save
+     *
+     * For multi-node routes, returns an associative array mapping node addresses to results.
+     * For single-node routes, returns a scalar (bool or string).
+     */
+    public function save(mixed $route): ValkeyGlideCluster|array|bool|string;
+
+    /**
      * @see ValkeyGlide::geoadd
      */
     public function geoadd(string $key, float $lng, float $lat, string $member, mixed ...$other_triples_and_options): ValkeyGlideCluster|int|false;

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -587,7 +587,8 @@ class ValkeyGlideCluster
     /**
      * @see ValkeyGlide::save
      *
-     * Returns true on success (or "OK" with OPT_REPLY_LITERAL enabled).
+     * Returns true on success, false on failure.
+     * With OPT_REPLY_LITERAL enabled, returns "OK" on success, false on failure.
      */
     public function save(mixed $route): ValkeyGlideCluster|bool|string;
 

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -363,6 +363,48 @@ int execute_bgrewriteaof_command(zval* object, int argc, zval* return_value, zen
     return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
 }
 
+/* Execute a SAVE command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
+int execute_save_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    zval*                args       = NULL;
+    int                  args_count = 0;
+    zend_bool            is_cluster = (ce == get_valkey_glide_cluster_ce());
+
+    /* Get ValkeyGlide object */
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    /* Setup core command arguments */
+    core_command_args_t core_args = {0};
+    core_args.glide_client        = valkey_glide->glide_client;
+    core_args.cmd_type            = Save;
+    core_args.is_cluster          = is_cluster;
+
+    if (is_cluster) {
+        if (!parse_cluster_route(argc, &object, ce, &args, &args_count, &core_args)) {
+            return 0;
+        }
+    } else {
+        /* Non-cluster case - no parameters */
+        if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
+            return 0;
+        }
+    }
+
+    /* Select processor based on OPT_REPLY_LITERAL:
+     * - With OPT_REPLY_LITERAL: return raw string (process_core_status_string_result)
+     * - Without OPT_REPLY_LITERAL: return bool (process_core_status_bool_result)
+     * This matches PHPRedis behavior where save() returns bool. */
+    z_result_processor_t processor = valkey_glide->opt_reply_literal
+                                         ? process_core_status_string_result
+                                         : process_core_status_bool_result;
+
+    /* Execute using unified core framework */
+    return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
+}
+
 /* Execute a TIME command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
 int execute_time_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
     valkey_glide_object* valkey_glide;

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -202,7 +202,6 @@ int execute_flushdb_command(zval* object, int argc, zval* return_value, zend_cla
         core_args.arg_count                     = 1;
     }
 
-    /* Execute using unified core framework */
     return execute_and_handle_batch(
         valkey_glide, &core_args, process_core_bool_result, return_value, object);
 }
@@ -257,7 +256,6 @@ int execute_flushall_command(zval* object, int argc, zval* return_value, zend_cl
         core_args.arg_count                     = 1;
     }
 
-    /* Execute using unified core framework */
     return execute_and_handle_batch(
         valkey_glide, &core_args, process_core_bool_result, return_value, object);
 }
@@ -317,7 +315,6 @@ int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_clas
                                          ? process_core_status_string_result
                                          : process_core_status_bool_result;
 
-    /* Execute using unified core framework */
     return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
 }
 
@@ -359,7 +356,6 @@ int execute_bgrewriteaof_command(zval* object, int argc, zval* return_value, zen
                                          ? process_core_status_string_result
                                          : process_core_status_bool_result;
 
-    /* Execute using unified core framework */
     return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
 }
 
@@ -401,7 +397,6 @@ int execute_save_command(zval* object, int argc, zval* return_value, zend_class_
                                          ? process_core_status_string_result
                                          : process_core_status_bool_result;
 
-    /* Execute using unified core framework */
     return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
 }
 
@@ -439,7 +434,6 @@ int execute_time_command(zval* object, int argc, zval* return_value, zend_class_
         }
     }
 
-    /* Execute using unified core framework */
     return execute_and_handle_batch(
         valkey_glide, &core_args, process_core_array_result, return_value, object);
 }

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -321,104 +321,40 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
  * METHOD IMPLEMENTATION MACROS
  * ==================================================================== */
 
-#define ECHO_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, echo) {                                              \
-        if (execute_echo_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
+/* Generic helper for commands that follow the standard pattern:
+ * call execute function, return on success, RETURN_FALSE on failure. */
+#define STANDARD_METHOD_IMPL(class_name, method_name, execute_fn)     \
+    PHP_METHOD(class_name, method_name) {                             \
+        if (execute_fn(getThis(),                                     \
+                       ZEND_NUM_ARGS(),                               \
+                       return_value,                                  \
+                       strcmp(#class_name, "ValkeyGlideCluster") == 0 \
+                           ? get_valkey_glide_cluster_ce()            \
+                           : get_valkey_glide_ce())) {                \
+            return;                                                   \
+        }                                                             \
+        zval_dtor(return_value);                                      \
+        RETURN_FALSE;                                                 \
     }
 
-#define BITOP_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, bitop) {                                              \
-        if (execute_bitop_command(getThis(),                                     \
-                                  ZEND_NUM_ARGS(),                               \
-                                  return_value,                                  \
-                                  strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                      ? get_valkey_glide_cluster_ce()            \
-                                      : get_valkey_glide_ce())) {                \
-            return;                                                              \
-        }                                                                        \
-        zval_dtor(return_value);                                                 \
-        RETURN_FALSE;                                                            \
-    }
+#define ECHO_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, echo, execute_echo_command)
 
-#define GETBIT_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, getBit) {                                              \
-        if (execute_getbit_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define BITOP_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, bitop, execute_bitop_command)
 
-#define SETBIT_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, setBit) {                                              \
-        if (execute_setbit_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define GETBIT_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, getBit, execute_getbit_command)
 
-#define BITCOUNT_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, bitcount) {                                              \
-        if (execute_bitcount_command(getThis(),                                     \
-                                     ZEND_NUM_ARGS(),                               \
-                                     return_value,                                  \
-                                     strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                         ? get_valkey_glide_cluster_ce()            \
-                                         : get_valkey_glide_ce())) {                \
-            return;                                                                 \
-        }                                                                           \
-        zval_dtor(return_value);                                                    \
-        RETURN_FALSE;                                                               \
-    }
+#define SETBIT_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, setBit, execute_setbit_command)
 
-#define BITPOS_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, bitpos) {                                              \
-        if (execute_bitpos_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define BITCOUNT_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, bitcount, execute_bitcount_command)
+
+#define BITPOS_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, bitpos, execute_bitpos_command)
 
 /* DEL command needs special handling since it has different signature */
-#define DEL_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, del) {                                              \
-        if (execute_del_command(getThis(),                                     \
-                                ZEND_NUM_ARGS(),                               \
-                                return_value,                                  \
-                                strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                    ? get_valkey_glide_cluster_ce()            \
-                                    : get_valkey_glide_ce())) {                \
-            return;                                                            \
-        }                                                                      \
-        zval_dtor(return_value);                                               \
-        RETURN_FALSE;                                                          \
-    }
+#define DEL_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, del, execute_del_command)
 
 /* Additional unified macros for new converted commands */
 #define SELECT_METHOD_IMPL(class_name)                                            \
@@ -436,103 +372,21 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
         RETURN_FALSE;                                                             \
     }
 
-#define GET_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, get) {                                              \
-        if (execute_get_command(getThis(),                                     \
-                                ZEND_NUM_ARGS(),                               \
-                                return_value,                                  \
-                                strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                    ? get_valkey_glide_cluster_ce()            \
-                                    : get_valkey_glide_ce())) {                \
-            return;                                                            \
-        }                                                                      \
-        zval_dtor(return_value);                                               \
-        RETURN_FALSE;                                                          \
-    }
+#define GET_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, get, execute_get_command)
 
-#define RANDOMKEY_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, randomKey) {                                              \
-        if (execute_randomkey_command(getThis(),                                     \
-                                      ZEND_NUM_ARGS(),                               \
-                                      return_value,                                  \
-                                      strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                          ? get_valkey_glide_cluster_ce()            \
-                                          : get_valkey_glide_ce())) {                \
-            return;                                                                  \
-        }                                                                            \
-        zval_dtor(return_value);                                                     \
-        RETURN_FALSE;                                                                \
-    }
+#define RANDOMKEY_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, randomKey, execute_randomkey_command)
 
-#define STRLEN_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, strlen) {                                              \
-        if (execute_strlen_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define STRLEN_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, strlen, execute_strlen_command)
 
-#define TTL_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, ttl) {                                              \
-        if (execute_ttl_command(getThis(),                                     \
-                                ZEND_NUM_ARGS(),                               \
-                                return_value,                                  \
-                                strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                    ? get_valkey_glide_cluster_ce()            \
-                                    : get_valkey_glide_ce())) {                \
-            return;                                                            \
-        }                                                                      \
-        zval_dtor(return_value);                                               \
-        RETURN_FALSE;                                                          \
-    }
+#define TTL_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, ttl, execute_ttl_command)
 
-#define PTTL_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, pttl) {                                              \
-        if (execute_pttl_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define PTTL_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, pttl, execute_pttl_command)
 
-#define PING_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, ping) {                                              \
-        if (execute_ping_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define PING_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, ping, execute_ping_command)
 
-#define INFO_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, info) {                                              \
-        if (execute_info_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define INFO_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, info, execute_info_command)
 
 /* Additional SET family macros */
 #define SETEX_METHOD_IMPL(class_name)                                            \
@@ -565,47 +419,13 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
         RETURN_FALSE;                                                             \
     }
 
-#define SETNX_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, setnx) {                                              \
-        if (execute_setnx_command(getThis(),                                     \
-                                  ZEND_NUM_ARGS(),                               \
-                                  return_value,                                  \
-                                  strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                      ? get_valkey_glide_cluster_ce()            \
-                                      : get_valkey_glide_ce())) {                \
-            return;                                                              \
-        }                                                                        \
-        zval_dtor(return_value);                                                 \
-        RETURN_FALSE;                                                            \
-    }
+#define SETNX_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, setnx, execute_setnx_command)
 
-#define SETRANGE_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, setRange) {                                              \
-        if (execute_setrange_command(getThis(),                                     \
-                                     ZEND_NUM_ARGS(),                               \
-                                     return_value,                                  \
-                                     strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                         ? get_valkey_glide_cluster_ce()            \
-                                         : get_valkey_glide_ce())) {                \
-            return;                                                                 \
-        }                                                                           \
-        zval_dtor(return_value);                                                    \
-        RETURN_FALSE;                                                               \
-    }
+#define SETRANGE_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, setRange, execute_setrange_command)
 
-#define GETSET_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, getset) {                                              \
-        if (execute_getset_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define GETSET_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, getset, execute_getset_command)
 
 #define SET_METHOD_IMPL(class_name)                                            \
     PHP_METHOD(class_name, set) {                                              \
@@ -622,47 +442,12 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
         RETURN_FALSE;                                                          \
     }
 
-#define LCS_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, lcs) {                                              \
-        if (execute_lcs_command(getThis(),                                     \
-                                ZEND_NUM_ARGS(),                               \
-                                return_value,                                  \
-                                strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                    ? get_valkey_glide_cluster_ce()            \
-                                    : get_valkey_glide_ce())) {                \
-            return;                                                            \
-        }                                                                      \
-        zval_dtor(return_value);                                               \
-        RETURN_FALSE;                                                          \
-    }
+#define LCS_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, lcs, execute_lcs_command)
 
-#define WATCH_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, watch) {                                              \
-        if (execute_watch_command(getThis(),                                     \
-                                  ZEND_NUM_ARGS(),                               \
-                                  return_value,                                  \
-                                  strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                      ? get_valkey_glide_cluster_ce()            \
-                                      : get_valkey_glide_ce())) {                \
-            return;                                                              \
-        }                                                                        \
-        zval_dtor(return_value);                                                 \
-        RETURN_FALSE;                                                            \
-    }
+#define WATCH_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, watch, execute_watch_command)
 
-#define UNWATCH_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, unwatch) {                                              \
-        if (execute_unwatch_command(getThis(),                                     \
-                                    ZEND_NUM_ARGS(),                               \
-                                    return_value,                                  \
-                                    strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                        ? get_valkey_glide_cluster_ce()            \
-                                        : get_valkey_glide_ce())) {                \
-            return;                                                                \
-        }                                                                          \
-        zval_dtor(return_value);                                                   \
-        RETURN_FALSE;                                                              \
-    }
+#define UNWATCH_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, unwatch, execute_unwatch_command)
 
 #define FLUSHDB_METHOD_IMPL(class_name)                                            \
     PHP_METHOD(class_name, flushDB) {                                              \
@@ -694,230 +479,46 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
         RETURN_FALSE;                                                               \
     }
 
-#define BGSAVE_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, bgSave) {                                              \
-        if (execute_bgsave_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define BGSAVE_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, bgSave, execute_bgsave_command)
 
-#define BGREWRITEAOF_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, bgRewriteAof) {                                              \
-        if (execute_bgrewriteaof_command(getThis(),                                     \
-                                         ZEND_NUM_ARGS(),                               \
-                                         return_value,                                  \
-                                         strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                             ? get_valkey_glide_cluster_ce()            \
-                                             : get_valkey_glide_ce())) {                \
-            return;                                                                     \
-        }                                                                               \
-        zval_dtor(return_value);                                                        \
-        RETURN_FALSE;                                                                   \
-    }
+#define BGREWRITEAOF_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, bgRewriteAof, execute_bgrewriteaof_command)
 
-#define SAVE_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, save) {                                              \
-        if (execute_save_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define SAVE_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, save, execute_save_command)
 
-#define TIME_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, time) {                                              \
-        if (execute_time_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define TIME_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, time, execute_time_command)
 
 
-#define SCAN_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, scan) {                                              \
-        if (execute_scan_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define SCAN_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, scan, execute_scan_command)
 
-#define SSCAN_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, sscan) {                                              \
-        if (execute_sscan_command(getThis(),                                     \
-                                  ZEND_NUM_ARGS(),                               \
-                                  return_value,                                  \
-                                  strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                      ? get_valkey_glide_cluster_ce()            \
-                                      : get_valkey_glide_ce())) {                \
-            return;                                                              \
-        }                                                                        \
-        zval_dtor(return_value);                                                 \
-        RETURN_FALSE;                                                            \
-    }
+#define SSCAN_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, sscan, execute_sscan_command)
 
-#define COPY_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, copy) {                                              \
-        if (execute_copy_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define COPY_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, copy, execute_copy_command)
 
-#define HSCAN_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, hscan) {                                              \
-        if (execute_hscan_command(getThis(),                                     \
-                                  ZEND_NUM_ARGS(),                               \
-                                  return_value,                                  \
-                                  strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                      ? get_valkey_glide_cluster_ce()            \
-                                      : get_valkey_glide_ce())) {                \
-            return;                                                              \
-        }                                                                        \
-        zval_dtor(return_value);                                                 \
-        RETURN_FALSE;                                                            \
-    }
+#define HSCAN_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, hscan, execute_hscan_command)
 
-#define PFADD_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, pfadd) {                                              \
-        if (execute_pfadd_command(getThis(),                                     \
-                                  ZEND_NUM_ARGS(),                               \
-                                  return_value,                                  \
-                                  strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                      ? get_valkey_glide_cluster_ce()            \
-                                      : get_valkey_glide_ce())) {                \
-            return;                                                              \
-        }                                                                        \
-        zval_dtor(return_value);                                                 \
-        RETURN_FALSE;                                                            \
-    }
+#define PFADD_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, pfadd, execute_pfadd_command)
 
-#define PFCOUNT_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, pfcount) {                                              \
-        if (execute_pfcount_command(getThis(),                                     \
-                                    ZEND_NUM_ARGS(),                               \
-                                    return_value,                                  \
-                                    strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                        ? get_valkey_glide_cluster_ce()            \
-                                        : get_valkey_glide_ce())) {                \
-            return;                                                                \
-        }                                                                          \
-        zval_dtor(return_value);                                                   \
-        RETURN_FALSE;                                                              \
-    }
+#define PFCOUNT_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, pfcount, execute_pfcount_command)
 
-#define PFMERGE_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, pfmerge) {                                              \
-        if (execute_pfmerge_command(getThis(),                                     \
-                                    ZEND_NUM_ARGS(),                               \
-                                    return_value,                                  \
-                                    strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                        ? get_valkey_glide_cluster_ce()            \
-                                        : get_valkey_glide_ce())) {                \
-            return;                                                                \
-        }                                                                          \
-        zval_dtor(return_value);                                                   \
-        RETURN_FALSE;                                                              \
-    }
+#define PFMERGE_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, pfmerge, execute_pfmerge_command)
 
-#define CLIENT_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, client) {                                              \
-        if (execute_client_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define CLIENT_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, client, execute_client_command)
 
-#define RAWCOMMAND_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, rawcommand) {                                              \
-        if (execute_rawcommand_command(getThis(),                                     \
-                                       ZEND_NUM_ARGS(),                               \
-                                       return_value,                                  \
-                                       strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                           ? get_valkey_glide_cluster_ce()            \
-                                           : get_valkey_glide_ce())) {                \
-            return;                                                                   \
-        }                                                                             \
-        zval_dtor(return_value);                                                      \
-        RETURN_FALSE;                                                                 \
-    }
+#define RAWCOMMAND_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, rawcommand, execute_rawcommand_command)
 
-#define DBSIZE_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, dbSize) {                                              \
-        if (execute_dbsize_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define DBSIZE_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, dbSize, execute_dbsize_command)
 
-#define MOVE_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, move) {                                              \
-        if (execute_move_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define MOVE_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, move, execute_move_command)
 
-#define DECRBY_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, decrBy) {                                              \
-        if (execute_decrby_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define DECRBY_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, decrBy, execute_decrby_command)
 
 #define RENAME_METHOD_IMPL(class_name)                                            \
     PHP_METHOD(class_name, rename) {                                              \
@@ -934,173 +535,35 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
         RETURN_FALSE;                                                             \
     }
 
-#define RENAMENX_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, renameNx) {                                              \
-        if (execute_renamenx_command(getThis(),                                     \
-                                     ZEND_NUM_ARGS(),                               \
-                                     return_value,                                  \
-                                     strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                         ? get_valkey_glide_cluster_ce()            \
-                                         : get_valkey_glide_ce())) {                \
-            return;                                                                 \
-        }                                                                           \
-        zval_dtor(return_value);                                                    \
-        RETURN_FALSE;                                                               \
-    }
+#define RENAMENX_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, renameNx, execute_renamenx_command)
 
-#define GETDEL_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, getDel) {                                              \
-        if (execute_getdel_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define GETDEL_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, getDel, execute_getdel_command)
 
-#define GETEX_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, getEx) {                                              \
-        if (execute_getex_command(getThis(),                                     \
-                                  ZEND_NUM_ARGS(),                               \
-                                  return_value,                                  \
-                                  strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                      ? get_valkey_glide_cluster_ce()            \
-                                      : get_valkey_glide_ce())) {                \
-            return;                                                              \
-        }                                                                        \
-        zval_dtor(return_value);                                                 \
-        RETURN_FALSE;                                                            \
-    }
+#define GETEX_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, getEx, execute_getex_command)
 
-#define INCR_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, incr) {                                              \
-        if (execute_incr_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define INCR_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, incr, execute_incr_command)
 
-#define INCRBY_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, incrBy) {                                              \
-        if (execute_incrby_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define INCRBY_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, incrBy, execute_incrby_command)
 
-#define INCRBYFLOAT_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, incrByFloat) {                                              \
-        if (execute_incrbyfloat_command(getThis(),                                     \
-                                        ZEND_NUM_ARGS(),                               \
-                                        return_value,                                  \
-                                        strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                            ? get_valkey_glide_cluster_ce()            \
-                                            : get_valkey_glide_ce())) {                \
-            return;                                                                    \
-        }                                                                              \
-        zval_dtor(return_value);                                                       \
-        RETURN_FALSE;                                                                  \
-    }
+#define INCRBYFLOAT_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, incrByFloat, execute_incrbyfloat_command)
 
-#define DECR_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, decr) {                                              \
-        if (execute_decr_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define DECR_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, decr, execute_decr_command)
 
-#define MGET_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, mget) {                                              \
-        if (execute_mget_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define MGET_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, mget, execute_mget_command)
 
-#define EXISTS_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, exists) {                                              \
-        if (execute_exists_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define EXISTS_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, exists, execute_exists_command)
 
-#define TOUCH_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, touch) {                                              \
-        if (execute_touch_command(getThis(),                                     \
-                                  ZEND_NUM_ARGS(),                               \
-                                  return_value,                                  \
-                                  strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                      ? get_valkey_glide_cluster_ce()            \
-                                      : get_valkey_glide_ce())) {                \
-            return;                                                              \
-        }                                                                        \
-        zval_dtor(return_value);                                                 \
-        RETURN_FALSE;                                                            \
-    }
+#define TOUCH_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, touch, execute_touch_command)
 
-#define UNLINK_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, unlink) {                                              \
-        if (execute_unlink_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define UNLINK_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, unlink, execute_unlink_command)
 
-#define WAIT_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, wait) {                                              \
-        if (execute_wait_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define WAIT_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, wait, execute_wait_command)
 
 #define CONFIG_METHOD_IMPL(class_name)                                            \
     PHP_METHOD(class_name, config) {                                              \
@@ -1117,19 +580,8 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
         RETURN_FALSE;                                                             \
     }
 
-#define FUNCTION_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, function) {                                              \
-        if (execute_function_command(getThis(),                                     \
-                                     ZEND_NUM_ARGS(),                               \
-                                     return_value,                                  \
-                                     strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                         ? get_valkey_glide_cluster_ce()            \
-                                         : get_valkey_glide_ce())) {                \
-            return;                                                                 \
-        }                                                                           \
-        zval_dtor(return_value);                                                    \
-        RETURN_FALSE;                                                               \
-    }
+#define FUNCTION_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, function, execute_function_command)
 
 #define SCRIPT_METHOD_IMPL(class_name)                                        \
     PHP_METHOD(class_name, script) {                                          \
@@ -1173,89 +625,20 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
                                    strcmp(#class_name, "ValkeyGlideCluster") == 0); \
     }
 
-#define MULTI_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, multi) {                                              \
-        if (execute_multi_command(getThis(),                                     \
-                                  ZEND_NUM_ARGS(),                               \
-                                  return_value,                                  \
-                                  strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                      ? get_valkey_glide_cluster_ce()            \
-                                      : get_valkey_glide_ce())) {                \
-            return;                                                              \
-        }                                                                        \
-        zval_dtor(return_value);                                                 \
-        RETURN_FALSE;                                                            \
-    }
+#define MULTI_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, multi, execute_multi_command)
 
-#define PIPELINE_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, pipeline) {                                              \
-        if (execute_pipeline_command(getThis(),                                     \
-                                     ZEND_NUM_ARGS(),                               \
-                                     return_value,                                  \
-                                     strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                         ? get_valkey_glide_cluster_ce()            \
-                                         : get_valkey_glide_ce())) {                \
-            return;                                                                 \
-        }                                                                           \
-        zval_dtor(return_value);                                                    \
-        RETURN_FALSE;                                                               \
-    }
+#define PIPELINE_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, pipeline, execute_pipeline_command)
 
-#define DISCARD_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, discard) {                                              \
-        if (execute_discard_command(getThis(),                                     \
-                                    ZEND_NUM_ARGS(),                               \
-                                    return_value,                                  \
-                                    strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                        ? get_valkey_glide_cluster_ce()            \
-                                        : get_valkey_glide_ce())) {                \
-            return;                                                                \
-        }                                                                          \
-        zval_dtor(return_value);                                                   \
-        RETURN_FALSE;                                                              \
-    }
+#define DISCARD_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, discard, execute_discard_command)
 
-#define EXEC_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, exec) {                                              \
-        if (execute_exec_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define EXEC_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, exec, execute_exec_command)
 
-#define FCALL_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, fcall) {                                              \
-        if (execute_fcall_command(getThis(),                                     \
-                                  ZEND_NUM_ARGS(),                               \
-                                  return_value,                                  \
-                                  strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                      ? get_valkey_glide_cluster_ce()            \
-                                      : get_valkey_glide_ce())) {                \
-            return;                                                              \
-        }                                                                        \
-        zval_dtor(return_value);                                                 \
-        RETURN_FALSE;                                                            \
-    }
+#define FCALL_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, fcall, execute_fcall_command)
 
-#define FCALL_RO_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, fcall_ro) {                                              \
-        if (execute_fcall_ro_command(getThis(),                                     \
-                                     ZEND_NUM_ARGS(),                               \
-                                     return_value,                                  \
-                                     strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                         ? get_valkey_glide_cluster_ce()            \
-                                         : get_valkey_glide_ce())) {                \
-            return;                                                                 \
-        }                                                                           \
-        zval_dtor(return_value);                                                    \
-        RETURN_FALSE;                                                               \
-    }
+#define FCALL_RO_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, fcall_ro, execute_fcall_ro_command)
 
 #define SCRIPT_EXISTS_METHOD_IMPL(class_name)                                 \
     PHP_METHOD(class_name, scriptExists) {                                    \
@@ -1286,19 +669,7 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
         execute_script_flush_command(getThis(), return_value, false); \
     }
 
-#define DUMP_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, dump) {                                              \
-        if (execute_dump_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define DUMP_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, dump, execute_dump_command)
 
 #define RESTORE_METHOD_IMPL(class_name)                                            \
     PHP_METHOD(class_name, restore) {                                              \
@@ -1315,103 +686,26 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
         RETURN_FALSE;                                                              \
     }
 
-#define EXPIRE_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, expire) {                                              \
-        if (execute_expire_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define EXPIRE_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, expire, execute_expire_command)
 
-#define EXPIREAT_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, expireAt) {                                              \
-        if (execute_expireat_command(getThis(),                                     \
-                                     ZEND_NUM_ARGS(),                               \
-                                     return_value,                                  \
-                                     strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                         ? get_valkey_glide_cluster_ce()            \
-                                         : get_valkey_glide_ce())) {                \
-            return;                                                                 \
-        }                                                                           \
-        zval_dtor(return_value);                                                    \
-        RETURN_FALSE;                                                               \
-    }
+#define EXPIREAT_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, expireAt, execute_expireat_command)
 
-#define PEXPIRE_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, pexpire) {                                              \
-        if (execute_pexpire_command(getThis(),                                     \
-                                    ZEND_NUM_ARGS(),                               \
-                                    return_value,                                  \
-                                    strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                        ? get_valkey_glide_cluster_ce()            \
-                                        : get_valkey_glide_ce())) {                \
-            return;                                                                \
-        }                                                                          \
-        zval_dtor(return_value);                                                   \
-        RETURN_FALSE;                                                              \
-    }
+#define PEXPIRE_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, pexpire, execute_pexpire_command)
 
-#define PEXPIREAT_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, pexpireAt) {                                              \
-        if (execute_pexpireat_command(getThis(),                                     \
-                                      ZEND_NUM_ARGS(),                               \
-                                      return_value,                                  \
-                                      strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                          ? get_valkey_glide_cluster_ce()            \
-                                          : get_valkey_glide_ce())) {                \
-            return;                                                                  \
-        }                                                                            \
-        zval_dtor(return_value);                                                     \
-        RETURN_FALSE;                                                                \
-    }
+#define PEXPIREAT_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, pexpireAt, execute_pexpireat_command)
 
-#define PERSIST_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, persist) {                                              \
-        if (execute_persist_command(getThis(),                                     \
-                                    ZEND_NUM_ARGS(),                               \
-                                    return_value,                                  \
-                                    strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                        ? get_valkey_glide_cluster_ce()            \
-                                        : get_valkey_glide_ce())) {                \
-            return;                                                                \
-        }                                                                          \
-        zval_dtor(return_value);                                                   \
-        RETURN_FALSE;                                                              \
-    }
+#define PERSIST_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, persist, execute_persist_command)
 
-#define EXPIRETIME_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, expiretime) {                                              \
-        if (execute_expiretime_command(getThis(),                                     \
-                                       ZEND_NUM_ARGS(),                               \
-                                       return_value,                                  \
-                                       strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                           ? get_valkey_glide_cluster_ce()            \
-                                           : get_valkey_glide_ce())) {                \
-            return;                                                                   \
-        }                                                                             \
-        zval_dtor(return_value);                                                      \
-        RETURN_FALSE;                                                                 \
-    }
+#define EXPIRETIME_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, expiretime, execute_expiretime_command)
 
-#define PEXPIRETIME_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, pexpiretime) {                                              \
-        if (execute_pexpiretime_command(getThis(),                                     \
-                                        ZEND_NUM_ARGS(),                               \
-                                        return_value,                                  \
-                                        strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                            ? get_valkey_glide_cluster_ce()            \
-                                            : get_valkey_glide_ce())) {                \
-            return;                                                                    \
-        }                                                                              \
-        zval_dtor(return_value);                                                       \
-        RETURN_FALSE;                                                                  \
-    }
+#define PEXPIRETIME_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, pexpiretime, execute_pexpiretime_command)
 
 #define MSET_METHOD_IMPL(class_name)                                            \
     PHP_METHOD(class_name, mset) {                                              \
@@ -1428,104 +722,25 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
         RETURN_FALSE;                                                           \
     }
 
-#define MSETNX_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, msetnx) {                                              \
-        if (execute_msetnx_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define MSETNX_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, msetnx, execute_msetnx_command)
 
-#define TYPE_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, type) {                                              \
-        if (execute_type_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define TYPE_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, type, execute_type_command)
 
-#define APPEND_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, append) {                                              \
-        if (execute_append_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define APPEND_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, append, execute_append_command)
 
-#define GETRANGE_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, getRange) {                                              \
-        if (execute_getrange_command(getThis(),                                     \
-                                     ZEND_NUM_ARGS(),                               \
-                                     return_value,                                  \
-                                     strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                         ? get_valkey_glide_cluster_ce()            \
-                                         : get_valkey_glide_ce())) {                \
-            return;                                                                 \
-        }                                                                           \
-        zval_dtor(return_value);                                                    \
-        RETURN_FALSE;                                                               \
-    }
+#define GETRANGE_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, getRange, execute_getrange_command)
 
-#define SORT_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, sort) {                                              \
-        if (execute_sort_command(getThis(),                                     \
-                                 ZEND_NUM_ARGS(),                               \
-                                 return_value,                                  \
-                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                     ? get_valkey_glide_cluster_ce()            \
-                                     : get_valkey_glide_ce())) {                \
-            return;                                                             \
-        }                                                                       \
-        zval_dtor(return_value);                                                \
-        RETURN_FALSE;                                                           \
-    }
+#define SORT_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, sort, execute_sort_command)
 
-#define SORT_RO_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, sort_ro) {                                              \
-        if (execute_sort_ro_command(getThis(),                                     \
-                                    ZEND_NUM_ARGS(),                               \
-                                    return_value,                                  \
-                                    strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                        ? get_valkey_glide_cluster_ce()            \
-                                        : get_valkey_glide_ce())) {                \
-            return;                                                                \
-        }                                                                          \
-        zval_dtor(return_value);                                                   \
-        RETURN_FALSE;                                                              \
-    }
+#define SORT_RO_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, sort_ro, execute_sort_ro_command)
 
 
-#define OBJECT_METHOD_IMPL(class_name)                                            \
-    PHP_METHOD(class_name, object) {                                              \
-        if (execute_object_command(getThis(),                                     \
-                                   ZEND_NUM_ARGS(),                               \
-                                   return_value,                                  \
-                                   strcmp(#class_name, "ValkeyGlideCluster") == 0 \
-                                       ? get_valkey_glide_cluster_ce()            \
-                                       : get_valkey_glide_ce())) {                \
-            return;                                                               \
-        }                                                                         \
-        zval_dtor(return_value);                                                  \
-        RETURN_FALSE;                                                             \
-    }
+#define OBJECT_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, object, execute_object_command)
 
 /* Function command declarations */
 int  execute_function_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -207,6 +207,7 @@ int execute_flushdb_command(zval* object, int argc, zval* return_value, zend_cla
 int execute_flushall_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_bgrewriteaof_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_save_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_time_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_scan_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_cluster_scan_command(const void* glide_client,
@@ -719,6 +720,20 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
         }                                                                               \
         zval_dtor(return_value);                                                        \
         RETURN_FALSE;                                                                   \
+    }
+
+#define SAVE_METHOD_IMPL(class_name)                                            \
+    PHP_METHOD(class_name, save) {                                              \
+        if (execute_save_command(getThis(),                                     \
+                                 ZEND_NUM_ARGS(),                               \
+                                 return_value,                                  \
+                                 strcmp(#class_name, "ValkeyGlideCluster") == 0 \
+                                     ? get_valkey_glide_cluster_ce()            \
+                                     : get_valkey_glide_ce())) {                \
+            return;                                                             \
+        }                                                                       \
+        zval_dtor(return_value);                                                \
+        RETURN_FALSE;                                                           \
     }
 
 #define TIME_METHOD_IMPL(class_name)                                            \

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -203,6 +203,7 @@ int prepare_core_args(core_command_args_t* args,
         case Role:
         case DBSize:
         case BgRewriteAof:
+        case Save:
             return prepare_zero_args(args, cmd_args, cmd_args_len);
 
         /* Single key operations */

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -196,27 +196,27 @@ int prepare_core_args(core_command_args_t* args,
     /* Determine preparation strategy based on command type */
     switch (args->cmd_type) {
         /* Zero argument operations */
-        case RandomKey:
+        case BgRewriteAof:
+        case DBSize:
         case Discard:
         case Exec:
-        case Time:
+        case RandomKey:
         case Role:
-        case DBSize:
-        case BgRewriteAof:
         case Save:
+        case Time:
             return prepare_zero_args(args, cmd_args, cmd_args_len);
 
         /* Single key operations */
-        case GetDel:
-        case Get:
-        case Strlen:
-        case Type:
-        case TTL:
-        case PTTL:
-        case ExpireTime:
-        case PExpireTime:
-        case Persist:
         case Dump:
+        case ExpireTime:
+        case Get:
+        case GetDel:
+        case PExpireTime:
+        case PTTL:
+        case Persist:
+        case Strlen:
+        case TTL:
+        case Type:
             return prepare_key_only_args(args, cmd_args, cmd_args_len);
 
         /* Pattern-based operations */
@@ -229,24 +229,22 @@ int prepare_core_args(core_command_args_t* args,
             return prepare_zero_args(args, cmd_args, cmd_args_len);
 
         /* Key-value operations */
-        case Set:
-        case SetEx:
-        case PSetEx:
-        case SetNX:
-
-        case GetSet:
-
-        case GetEx:
         case Append:
-        case Incr:
+        case Copy:
         case Decr:
-        case IncrBy:
         case DecrBy:
-        case Rename:
-        case RenameNX:
+        case GetEx:
+        case GetSet:
+        case Incr:
+        case IncrBy:
         case IncrByFloat:
         case Move:
-        case Copy:
+        case PSetEx:
+        case Rename:
+        case RenameNX:
+        case Set:
+        case SetEx:
+        case SetNX:
             return prepare_key_value_args(
                 args, cmd_args, cmd_args_len, allocated_strings, allocated_count);
 
@@ -267,10 +265,10 @@ int prepare_core_args(core_command_args_t* args,
 
         /* Multi-key operations */
         case Exists:
-        case Touch:
         case MGet:
-        case Watch:
         case PfCount:
+        case Touch:
+        case Watch:
             /* Check if single key or multi-key operation */
             if (args->key && args->key_len > 0 && args->arg_count == 0) {
                 /* Single key: PFCOUNT key */
@@ -289,10 +287,10 @@ int prepare_core_args(core_command_args_t* args,
 
         /* Bit operations */
         case BitCount:
+        case BitOp:
         case BitPos:
         case GetBit:
         case SetBit:
-        case BitOp:
             return prepare_bit_operation_args(
                 args, cmd_args, cmd_args_len, allocated_strings, allocated_count);
 
@@ -311,14 +309,14 @@ int prepare_core_args(core_command_args_t* args,
                 args, cmd_args, cmd_args_len, allocated_strings, allocated_count);
 
         /* Message operations (no key, just arguments) */
-        case Ping:
-        case Echo:
-        case Wait:
-        case FlushDB:
-        case FlushAll:
         case BgSave:
+        case Echo:
+        case FlushAll:
+        case FlushDB:
+        case Ping:
         case Select:
         case SwapDb:
+        case Wait:
             return prepare_message_args(
                 args, cmd_args, cmd_args_len, allocated_strings, allocated_count);
 

--- a/valkey_z_php_methods.c
+++ b/valkey_z_php_methods.c
@@ -822,6 +822,10 @@ BGSAVE_METHOD_IMPL(ValkeyGlide)
 BGREWRITEAOF_METHOD_IMPL(ValkeyGlide)
 /* }}} */
 
+/* {{{ proto bool ValkeyGlide::save() */
+SAVE_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
 /* {{{ proto array ValkeyGlide::time() */
 TIME_METHOD_IMPL(ValkeyGlide)
 /* }}} */


### PR DESCRIPTION
### Summary

Implement the SAVE command for both standalone and cluster clients.

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide-php/issues/236

### Features / Behaviour Changes

- Add ValkeyGlide::save(): ValkeyGlide|bool|string for standalone client
- Add ValkeyGlideCluster::save(mixed $route): ValkeyGlideCluster|array|bool|string for cluster client
- Returns true on success by default
- With OPT_REPLY_LITERAL enabled, returns the raw status string "OK"
- Cluster multi-node routes return an associative array of node => bool|string

### Implementation

- execute_save_command() in valkey_glide_commands.c — zero-arg command using parse_cluster_route() helper and execute_and_handle_batch() helper
- SAVE_METHOD_IMPL macro in valkey_glide_commands_common.h
- Save case added to prepare_zero_args switch in valkey_glide_core_common.c
- Reuses existing process_core_status_bool_result / process_core_status_string_result processors
- **Refactoring**: execute_and_handle_batch() helper extracted and applied to flushdb, flushall, bgsave, bgrewriteaof, time, pfadd, pfmerge (net -58 lines)

### Limitations

None. Full feature parity with other GLIDE clients.

### Testing

1. Standalone tests (tests/ValkeyGlideTest.php) updated.
2. Cluster tests (tests/ValkeyGlideClusterTest.php) updated.
3. All tests use waitForSaveNotInProgress() pre-condition to avoid flakiness.

Build passes with -Werror, lint clean on all modified files.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.