### PR TITLE
Implement reset command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* Add `RESET` command for standalone and cluster clients ([#273](https://github.com/valkey-io/valkey-glide-php/pull/273))
 * Add `BGREWRITEAOF` command for standalone and cluster clients ([#271](https://github.com/valkey-io/valkey-glide-php/pull/271))
 * Add `BGSAVE`, `BGSAVE SCHEDULE`, and `BGSAVE CANCEL` commands for standalone and cluster clients ([#236](https://github.com/valkey-io/valkey-glide-php/issues/236))
 * Fix pie install from Packagist using PIE pre-packaged-source download method ([#233](https://github.com/valkey-io/valkey-glide-php/pull/233))

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -639,48 +639,10 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
     public function testReset()
     {
-        $result = $this->valkey_glide->reset();
-        $this->assertTrue($result);
-
-        // Verify client recovers after reset
-        $pong = $this->valkey_glide->ping('randomNode');
-        $this->assertTrue($pong);
-    }
-
-    public function testResetWithReplyLiteral()
-    {
-        $this->withOptReplyLiteralEnabled(function () {
-            $result = $this->valkey_glide->reset();
-            $this->assertIsString($result);
-            $this->assertEquals('RESET', $result);
-
-            // Verify client recovers after reset (ping succeeds)
-            $pong = $this->valkey_glide->ping('randomNode');
-            $this->assertTrue($pong);
-        });
-    }
-
-    public function testResetBatch()
-    {
-        if (!$this->havePipeline()) {
-            $this->markTestSkipped('Pipeline not supported');
-            return;
-        }
-
-        $this->valkey_glide->pipeline();
-        $this->valkey_glide->reset();
-        $result = $this->valkey_glide->exec();
-        $this->assertTrue($result[0]);
-    }
-
-    public function testResetClearsConnectionState()
-    {
         $key = '{reset_test}_' . uniqid();
 
-        // Set initial value
+        // Set initial value and WATCH the key
         $this->valkey_glide->set($key, 'initial');
-
-        // WATCH the key
         $this->valkey_glide->watch($key);
 
         // Modify the key (triggers the WATCH)
@@ -702,6 +664,28 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         // Cleanup
         $this->valkey_glide->del($key);
+    }
+
+    public function testResetWithReplyLiteral()
+    {
+        $this->withOptReplyLiteralEnabled(function () {
+            $result = $this->valkey_glide->reset();
+            $this->assertIsString($result);
+            $this->assertEquals('RESET', $result);
+        });
+    }
+
+    public function testResetBatch()
+    {
+        if (!$this->havePipeline()) {
+            $this->markTestSkipped('Pipeline not supported');
+            return;
+        }
+
+        $this->valkey_glide->pipeline();
+        $this->valkey_glide->reset();
+        $result = $this->valkey_glide->exec();
+        $this->assertTrue($result[0]);
     }
 
     public function testSave()

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -649,17 +649,15 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
     public function testResetWithReplyLiteral()
     {
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+        $this->withOptReplyLiteralEnabled(function () {
+            $result = $this->valkey_glide->reset();
+            $this->assertIsString($result);
+            $this->assertEquals('RESET', $result);
 
-        $result = $this->valkey_glide->reset();
-        $this->assertIsString($result);
-        $this->assertEquals('RESET', $result);
-
-        // Verify client recovers after reset (ping succeeds)
-        $pong = $this->valkey_glide->ping('randomNode');
-        $this->assertTrue($pong);
-
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+            // Verify client recovers after reset (ping succeeds)
+            $pong = $this->valkey_glide->ping('randomNode');
+            $this->assertTrue($pong);
+        });
     }
 
     public function testResetBatch()

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -673,6 +673,37 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->assertTrue($result[0]);
     }
 
+    public function testResetClearsConnectionState()
+    {
+        $key = '{reset_test}_' . uniqid();
+
+        // Set initial value
+        $this->valkey_glide->set($key, 'initial');
+
+        // WATCH the key
+        $this->valkey_glide->watch($key);
+
+        // Modify the key (triggers the WATCH)
+        $this->valkey_glide->set($key, 'modified');
+
+        // RESET should clear the WATCH
+        $result = $this->valkey_glide->reset();
+        $this->assertTrue($result);
+
+        // Start a transaction on the same key
+        $this->valkey_glide->multi();
+        $this->valkey_glide->set($key, 'in_transaction');
+        $execResult = $this->valkey_glide->exec();
+
+        // If RESET cleared the WATCH, EXEC succeeds.
+        // If WATCH was still active, EXEC would return false (transaction aborted).
+        $this->assertIsArray($execResult);
+        $this->assertTrue($execResult[0]);
+
+        // Cleanup
+        $this->valkey_glide->del($key);
+    }
+
     public function testSave()
     {
         $this->waitForSaveNotInProgress();

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -668,11 +668,26 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
     public function testResetWithReplyLiteral()
     {
-        $this->withOptReplyLiteralEnabled(function () {
+        $key = '{reset_test}_' . uniqid();
+
+        $this->valkey_glide->set($key, 'initial');
+        $this->valkey_glide->watch($key);
+        $this->valkey_glide->set($key, 'modified');
+
+        $this->withOptReplyLiteralEnabled(function () use ($key) {
             $result = $this->valkey_glide->reset();
             $this->assertIsString($result);
             $this->assertEquals('RESET', $result);
         });
+
+        // Verify RESET cleared the WATCH
+        $this->valkey_glide->multi();
+        $this->valkey_glide->set($key, 'in_transaction');
+        $execResult = $this->valkey_glide->exec();
+        $this->assertIsArray($execResult);
+        $this->assertTrue($execResult[0]);
+
+        $this->valkey_glide->del($key);
     }
 
     public function testResetBatch()

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -662,10 +662,9 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->assertIsString($result);
         $this->assertEquals('RESET', $result);
 
-        // Verify client recovers after reset
+        // Verify client recovers after reset (ping succeeds)
         $pong = $this->valkey_glide->ping('randomNode');
-        $this->assertIsString($pong);
-        $this->assertEquals('PONG', $pong);
+        $this->assertTrue($pong);
 
         $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
     }

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -644,6 +644,45 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         }
     }
 
+    public function testReset()
+    {
+        $result = $this->valkey_glide->reset();
+        $this->assertTrue($result);
+
+        // Verify client recovers after reset
+        $pong = $this->valkey_glide->ping('randomNode');
+        $this->assertTrue($pong);
+    }
+
+    public function testResetWithReplyLiteral()
+    {
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+
+        $result = $this->valkey_glide->reset();
+        $this->assertIsString($result);
+        $this->assertEquals('RESET', $result);
+
+        // Verify client recovers after reset
+        $pong = $this->valkey_glide->ping('randomNode');
+        $this->assertIsString($pong);
+        $this->assertEquals('PONG', $pong);
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+    }
+
+    public function testResetBatch()
+    {
+        if (!$this->havePipeline()) {
+            $this->markTestSkipped('Pipeline not supported');
+            return;
+        }
+
+        $this->valkey_glide->pipeline();
+        $this->valkey_glide->reset();
+        $result = $this->valkey_glide->exec();
+        $this->assertTrue($result[0]);
+    }
+
     public function testInfo()
     {
         $fields = [

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2757,6 +2757,37 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->assertTrue($result[0]);
     }
 
+    public function testResetClearsConnectionState()
+    {
+        $key = '{reset_test}_' . $this->createRandomString();
+
+        // Set initial value
+        $this->valkey_glide->set($key, 'initial');
+
+        // WATCH the key
+        $this->valkey_glide->watch($key);
+
+        // Modify the key (triggers the WATCH)
+        $this->valkey_glide->set($key, 'modified');
+
+        // RESET should clear the WATCH
+        $result = $this->valkey_glide->reset();
+        $this->assertTrue($result);
+
+        // Start a transaction on the same key
+        $this->valkey_glide->multi();
+        $this->valkey_glide->set($key, 'in_transaction');
+        $execResult = $this->valkey_glide->exec();
+
+        // If RESET cleared the WATCH, EXEC succeeds.
+        // If WATCH was still active, EXEC would return false (transaction aborted).
+        $this->assertIsArray($execResult);
+        $this->assertTrue($execResult[0]);
+
+        // Cleanup
+        $this->valkey_glide->del($key);
+    }
+
     /**
      * Valid BGSAVE response strings (used when OPT_REPLY_LITERAL is enabled).
      */

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2752,11 +2752,26 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
 
     public function testResetWithReplyLiteral()
     {
-        $this->withOptReplyLiteralEnabled(function () {
+        $key = '{reset_test}_' . $this->createRandomString();
+
+        $this->valkey_glide->set($key, 'initial');
+        $this->valkey_glide->watch($key);
+        $this->valkey_glide->set($key, 'modified');
+
+        $this->withOptReplyLiteralEnabled(function () use ($key) {
             $result = $this->valkey_glide->reset();
             $this->assertIsString($result);
             $this->assertEquals('RESET', $result);
         });
+
+        // Verify RESET cleared the WATCH
+        $this->valkey_glide->multi();
+        $this->valkey_glide->set($key, 'in_transaction');
+        $execResult = $this->valkey_glide->exec();
+        $this->assertIsArray($execResult);
+        $this->assertTrue($execResult[0]);
+
+        $this->valkey_glide->del($key);
     }
 
     public function testResetBatch()

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2723,48 +2723,10 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
 
     public function testReset()
     {
-        $result = $this->valkey_glide->reset();
-        $this->assertTrue($result);
-
-        // Verify client recovers after reset
-        $pong = $this->valkey_glide->ping();
-        $this->assertTrue($pong);
-    }
-
-    public function testResetWithReplyLiteral()
-    {
-        $this->withOptReplyLiteralEnabled(function () {
-            $result = $this->valkey_glide->reset();
-            $this->assertIsString($result);
-            $this->assertEquals('RESET', $result);
-
-            // Verify client recovers after reset (ping succeeds)
-            $pong = $this->valkey_glide->ping();
-            $this->assertTrue($pong);
-        });
-    }
-
-    public function testResetBatch()
-    {
-        if (!$this->havePipeline()) {
-            $this->markTestSkipped('Pipeline not supported');
-            return;
-        }
-
-        $this->valkey_glide->pipeline();
-        $this->valkey_glide->reset();
-        $result = $this->valkey_glide->exec();
-        $this->assertTrue($result[0]);
-    }
-
-    public function testResetClearsConnectionState()
-    {
         $key = '{reset_test}_' . $this->createRandomString();
 
-        // Set initial value
+        // Set initial value and WATCH the key
         $this->valkey_glide->set($key, 'initial');
-
-        // WATCH the key
         $this->valkey_glide->watch($key);
 
         // Modify the key (triggers the WATCH)
@@ -2786,6 +2748,28 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
 
         // Cleanup
         $this->valkey_glide->del($key);
+    }
+
+    public function testResetWithReplyLiteral()
+    {
+        $this->withOptReplyLiteralEnabled(function () {
+            $result = $this->valkey_glide->reset();
+            $this->assertIsString($result);
+            $this->assertEquals('RESET', $result);
+        });
+    }
+
+    public function testResetBatch()
+    {
+        if (!$this->havePipeline()) {
+            $this->markTestSkipped('Pipeline not supported');
+            return;
+        }
+
+        $this->valkey_glide->pipeline();
+        $this->valkey_glide->reset();
+        $result = $this->valkey_glide->exec();
+        $this->assertTrue($result[0]);
     }
 
     /**

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2707,6 +2707,45 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->assertTrue($result[0]);
     }
 
+    public function testReset()
+    {
+        $result = $this->valkey_glide->reset();
+        $this->assertTrue($result);
+
+        // Verify client recovers after reset
+        $pong = $this->valkey_glide->ping();
+        $this->assertTrue($pong);
+    }
+
+    public function testResetWithReplyLiteral()
+    {
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+
+        $result = $this->valkey_glide->reset();
+        $this->assertIsString($result);
+        $this->assertEquals('RESET', $result);
+
+        // Verify client recovers after reset
+        $pong = $this->valkey_glide->ping();
+        $this->assertIsString($pong);
+        $this->assertEquals('PONG', $pong);
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+    }
+
+    public function testResetBatch()
+    {
+        if (!$this->havePipeline()) {
+            $this->markTestSkipped('Pipeline not supported');
+            return;
+        }
+
+        $this->valkey_glide->pipeline();
+        $this->valkey_glide->reset();
+        $result = $this->valkey_glide->exec();
+        $this->assertTrue($result[0]);
+    }
+
     /**
      * Valid BGSAVE response strings (used when OPT_REPLY_LITERAL is enabled).
      */

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2725,10 +2725,9 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->assertIsString($result);
         $this->assertEquals('RESET', $result);
 
-        // Verify client recovers after reset
+        // Verify client recovers after reset (ping succeeds)
         $pong = $this->valkey_glide->ping();
-        $this->assertIsString($pong);
-        $this->assertEquals('PONG', $pong);
+        $this->assertTrue($pong);
 
         $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
     }

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2733,17 +2733,15 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
 
     public function testResetWithReplyLiteral()
     {
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+        $this->withOptReplyLiteralEnabled(function () {
+            $result = $this->valkey_glide->reset();
+            $this->assertIsString($result);
+            $this->assertEquals('RESET', $result);
 
-        $result = $this->valkey_glide->reset();
-        $this->assertIsString($result);
-        $this->assertEquals('RESET', $result);
-
-        // Verify client recovers after reset (ping succeeds)
-        $pong = $this->valkey_glide->ping();
-        $this->assertTrue($pong);
-
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+            // Verify client recovers after reset (ping succeeds)
+            $pong = $this->valkey_glide->ping();
+            $this->assertTrue($pong);
+        });
     }
 
     public function testResetBatch()

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -2347,6 +2347,20 @@ class ValkeyGlide
     public function ping(?string $message = null): ValkeyGlide|string|bool;
 
     /**
+     * Reset the connection's server-side context.
+     *
+     * This command resets the connection state, clearing any subscriptions,
+     * watches, and other server-side state associated with the connection.
+     * The client remains connected and can issue new commands after reset.
+     *
+     * @return ValkeyGlide|bool|string  Returns true on success, false on failure.
+     *                                  With OPT_REPLY_LITERAL enabled, returns "RESET" instead.
+     *
+     * @see https://valkey.io/commands/reset
+     */
+    public function reset(): ValkeyGlide|bool|string;
+
+    /**
      * Enter into pipeline mode.
      *
      * Pipeline mode is the highest performance way to send many commands to ValkeyGlide

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -2363,12 +2363,9 @@ class ValkeyGlide
     /**
      * Reset the connection's server-side context.
      *
-     * This command resets the connection state, clearing any subscriptions,
-     * watches, and other server-side state associated with the connection.
-     * The client remains connected and can issue new commands after reset.
-     *
      * @return ValkeyGlide|bool|string  Returns true on success, false on failure.
-     *                                  With OPT_REPLY_LITERAL enabled, returns "RESET" instead.
+     *                                  With OPT_REPLY_LITERAL enabled, returns "RESET" on success,
+     *                                  false on failure.
      *
      * @see https://valkey.io/commands/reset
      */

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -985,6 +985,10 @@ BGSAVE_METHOD_IMPL(ValkeyGlideCluster)
 BGREWRITEAOF_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
+/* {{{ proto ValkeyGlideCluster::reset() */
+RESET_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
 /* {{{ proto ValkeyGlideCluster::dbsize(string key)
  *     proto ValkeyGlideCluster::dbsize(array host_port) */
 DBSIZE_METHOD_IMPL(ValkeyGlideCluster)

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -967,6 +967,13 @@ class ValkeyGlideCluster
     public function ping(mixed $route, ?string $message = null): mixed;
 
     /**
+     * @see ValkeyGlide::reset
+     *
+     * Returns true on success (or "RESET" with OPT_REPLY_LITERAL enabled).
+     */
+    public function reset(): ValkeyGlideCluster|bool|string;
+
+    /**
      * @see ValkeyGlide::psetex
      */
     public function psetex(string $key, int $timeout, string $value): ValkeyGlideCluster|bool;

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -973,8 +973,6 @@ class ValkeyGlideCluster
 
     /**
      * @see ValkeyGlide::reset
-     *
-     * Returns true on success (or "RESET" with OPT_REPLY_LITERAL enabled).
      */
     public function reset(): ValkeyGlideCluster|bool|string;
 

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -363,6 +363,39 @@ int execute_bgrewriteaof_command(zval* object, int argc, zval* return_value, zen
     return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
 }
 
+/* Execute a RESET command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
+int execute_valkey_reset_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+
+    /* Get ValkeyGlide object */
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    /* No parameters - validate object only */
+    if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
+        return 0;
+    }
+
+    /* Setup core command arguments */
+    core_command_args_t core_args = {0};
+    core_args.glide_client        = valkey_glide->glide_client;
+    core_args.cmd_type            = Reset;
+    core_args.is_cluster          = (ce == get_valkey_glide_cluster_ce());
+
+    /* Select processor based on OPT_REPLY_LITERAL:
+     * - With OPT_REPLY_LITERAL: return raw string "RESET"
+     * - Without OPT_REPLY_LITERAL: return bool true
+     * This matches PHPRedis behavior where reset() returns bool. */
+    z_result_processor_t processor = valkey_glide->opt_reply_literal
+                                         ? process_core_status_string_result
+                                         : process_core_status_bool_result;
+
+    /* Execute using unified core framework */
+    return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
+}
+
 /* Execute a TIME command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
 int execute_time_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
     valkey_glide_object* valkey_glide;

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -401,7 +401,7 @@ int execute_save_command(zval* object, int argc, zval* return_value, zend_class_
 }
 
 /* Execute a RESET command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
-int execute_valkey_reset_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+int execute_reset_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
     valkey_glide_object* valkey_glide;
 
     /* Get ValkeyGlide object */

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -429,7 +429,6 @@ int execute_valkey_reset_command(zval* object, int argc, zval* return_value, zen
                                          ? process_core_status_string_result
                                          : process_core_status_bool_result;
 
-    /* Execute using unified core framework */
     return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
 }
 

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -488,6 +488,9 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
 
 #define SAVE_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, save, execute_save_command)
 
+#define RESET_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, reset, execute_valkey_reset_command)
+
 #define TIME_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, time, execute_time_command)
 
 #define SCAN_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, scan, execute_scan_command)

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -160,7 +160,6 @@ int execute_randomkey_command(zval* object, int argc, zval* return_value, zend_c
 /* Server operations */
 int execute_echo_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_ping_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
-int execute_reset_command(const void* glide_client);
 int execute_info_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 
 /* Additional operations */
@@ -207,7 +206,7 @@ int execute_flushdb_command(zval* object, int argc, zval* return_value, zend_cla
 int execute_flushall_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_bgrewriteaof_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
-int execute_valkey_reset_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_reset_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_save_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_time_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_scan_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
@@ -489,7 +488,7 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
 #define SAVE_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, save, execute_save_command)
 
 #define RESET_METHOD_IMPL(class_name) \
-    STANDARD_METHOD_IMPL(class_name, reset, execute_valkey_reset_command)
+    STANDARD_METHOD_IMPL(class_name, reset, execute_reset_command)
 
 #define TIME_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, time, execute_time_command)
 

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -487,8 +487,7 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
 
 #define SAVE_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, save, execute_save_command)
 
-#define RESET_METHOD_IMPL(class_name) \
-    STANDARD_METHOD_IMPL(class_name, reset, execute_reset_command)
+#define RESET_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, reset, execute_reset_command)
 
 #define TIME_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, time, execute_time_command)
 

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -207,6 +207,7 @@ int execute_flushdb_command(zval* object, int argc, zval* return_value, zend_cla
 int execute_flushall_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_bgrewriteaof_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_valkey_reset_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_time_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_scan_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_cluster_scan_command(const void* glide_client,
@@ -710,6 +711,20 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
 #define BGREWRITEAOF_METHOD_IMPL(class_name)                                            \
     PHP_METHOD(class_name, bgRewriteAof) {                                              \
         if (execute_bgrewriteaof_command(getThis(),                                     \
+                                         ZEND_NUM_ARGS(),                               \
+                                         return_value,                                  \
+                                         strcmp(#class_name, "ValkeyGlideCluster") == 0 \
+                                             ? get_valkey_glide_cluster_ce()            \
+                                             : get_valkey_glide_ce())) {                \
+            return;                                                                     \
+        }                                                                               \
+        zval_dtor(return_value);                                                        \
+        RETURN_FALSE;                                                                   \
+    }
+
+#define RESET_METHOD_IMPL(class_name)                                                   \
+    PHP_METHOD(class_name, reset) {                                                     \
+        if (execute_valkey_reset_command(getThis(),                                     \
                                          ZEND_NUM_ARGS(),                               \
                                          return_value,                                  \
                                          strcmp(#class_name, "ValkeyGlideCluster") == 0 \

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -203,6 +203,7 @@ int prepare_core_args(core_command_args_t* args,
         case Role:
         case DBSize:
         case BgRewriteAof:
+        case Reset:
             return prepare_zero_args(args, cmd_args, cmd_args_len);
 
         /* Single key operations */

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -201,8 +201,8 @@ int prepare_core_args(core_command_args_t* args,
         case Discard:
         case Exec:
         case RandomKey:
-        case Role:
         case Reset:
+        case Role:
         case Save:
         case Time:
             return prepare_zero_args(args, cmd_args, cmd_args_len);

--- a/valkey_z_php_methods.c
+++ b/valkey_z_php_methods.c
@@ -822,6 +822,10 @@ BGSAVE_METHOD_IMPL(ValkeyGlide)
 BGREWRITEAOF_METHOD_IMPL(ValkeyGlide)
 /* }}} */
 
+/* {{{ proto bool ValkeyGlide::reset() */
+RESET_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
 /* {{{ proto array ValkeyGlide::time() */
 TIME_METHOD_IMPL(ValkeyGlide)
 /* }}} */


### PR DESCRIPTION
### Summary

Implement the RESET command for both standalone and cluster clients. RESET resets the connection's server-side state (subscriptions, watches, etc.) while keeping the connection alive. 

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide-php/issues/236

### Features / Behaviour Changes

- Add ValkeyGlide::reset(): ValkeyGlide|bool|string for standalone client
- Add ValkeyGlideCluster::reset(): ValkeyGlideCluster|bool|string for cluster client
- **No route parameter** — RESET is a connection-level command, glide-core handles routing internally
- With OPT_REPLY_LITERAL enabled, returns the raw status string "RESET"
- Client remains functional after reset (can issue new commands immediately)

### Implementation

- execute_valkey_reset_command() in valkey_glide_commands.c — zero-arg command using execute_and_handle_batch() helper
- Named execute_valkey_reset_command to avoid conflict with existing internal execute_reset_command(const void*) declaration
- RESET_METHOD_IMPL macro in valkey_glide_commands_common.h
- Reset case added to prepare_zero_args switch in valkey_glide_core_common.c
- Reuses existing process_core_status_bool_result / process_core_status_string_result processors

### Limitations

None. Full feature parity with other GLIDE clients.

### Testing

Standalone tests (tests/ValkeyGlideTest.php) added
Cluster tests (tests/ValkeyGlideClusterTest.php) added
Build passes with -Werror, lint clean on all modified files.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.