### PR TITLE
Implement client Pause and Unpause command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* Add `CLIENT PAUSE` and `CLIENT UNPAUSE` commands for standalone and cluster clients ([#274](https://github.com/valkey-io/valkey-glide-php/pull/274))
 * Add `BGREWRITEAOF` command for standalone and cluster clients ([#271](https://github.com/valkey-io/valkey-glide-php/pull/271))
 * Add `BGSAVE`, `BGSAVE SCHEDULE`, and `BGSAVE CANCEL` commands for standalone and cluster clients ([#236](https://github.com/valkey-io/valkey-glide-php/issues/236))
 * Fix pie install from Packagist using PIE pre-packaged-source download method ([#233](https://github.com/valkey-io/valkey-glide-php/pull/233))

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -665,8 +665,8 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
     public function testClientPauseAndUnpause()
     {
-        // Pause then immediately unpause
-        $this->assertTrue($this->valkey_glide->clientPause(5000));
+        // Use a short pause so it expires before the unpause command times out
+        $this->assertTrue($this->valkey_glide->clientPause(200));
         $this->assertTrue($this->valkey_glide->clientUnpause());
     }
 

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -672,16 +672,18 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $result = $this->valkey_glide->clientPause($pauseMs, 'WRITE');
         $this->assertTrue($result);
 
-        // Reads should still work quickly during WRITE pause
-        $start = microtime(true);
-        $value = $this->valkey_glide->get($key);
-        $elapsed = (microtime(true) - $start) * 1000;
+        try {
+            // Reads should still work quickly during WRITE pause
+            $start = microtime(true);
+            $value = $this->valkey_glide->get($key);
+            $elapsed = (microtime(true) - $start) * 1000;
 
-        $this->assertEquals('value', $value);
-        $this->assertLT($pauseMs, $elapsed);
+            $this->assertEquals('value', $value);
+            $this->assertLT($pauseMs, $elapsed);
+        } finally {
+            $this->valkey_glide->clientUnpause();
+        }
 
-        // Unpause to restore normal operation
-        $this->valkey_glide->clientUnpause();
         $this->valkey_glide->del($key);
     }
 

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -659,6 +659,11 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
     public function testClientPauseWithMode()
     {
+        if (!$this->minVersionCheck('6.2.0')) {
+            $this->markTestSkipped('CLIENT PAUSE WRITE requires 6.2.0+');
+            return;
+        }
+
         $key = '{client_pause_write}_' . uniqid();
         $this->valkey_glide->set($key, 'value');
 
@@ -682,6 +687,11 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
     public function testClientUnpause()
     {
+        if (!$this->minVersionCheck('6.2.0')) {
+            $this->markTestSkipped('CLIENT PAUSE WRITE requires 6.2.0+');
+            return;
+        }
+
         $key = '{client_unpause}_' . uniqid();
         $this->valkey_glide->set($key, 'before');
 

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -675,17 +675,15 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
     public function testClientPauseWithReplyLiteral()
     {
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+        $this->withOptReplyLiteralEnabled(function () {
+            $result = $this->valkey_glide->clientPause(100);
+            $this->assertIsString($result);
+            $this->assertEquals('OK', $result);
 
-        $result = $this->valkey_glide->clientPause(100);
-        $this->assertIsString($result);
-        $this->assertEquals('OK', $result);
-
-        $result = $this->valkey_glide->clientUnpause();
-        $this->assertIsString($result);
-        $this->assertEquals('OK', $result);
-
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+            $result = $this->valkey_glide->clientUnpause();
+            $this->assertIsString($result);
+            $this->assertEquals('OK', $result);
+        });
     }
 
     public function testClientPauseBatch()

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -644,6 +644,62 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         }
     }
 
+    public function testClientPause()
+    {
+        $result = $this->valkey_glide->clientPause(100);
+        $this->assertTrue($result);
+    }
+
+    public function testClientPauseWithMode()
+    {
+        // Test with WRITE mode
+        $result = $this->valkey_glide->clientPause(100, 'WRITE');
+        $this->assertTrue($result);
+    }
+
+    public function testClientUnpause()
+    {
+        $result = $this->valkey_glide->clientUnpause();
+        $this->assertTrue($result);
+    }
+
+    public function testClientPauseAndUnpause()
+    {
+        // Pause then immediately unpause
+        $this->assertTrue($this->valkey_glide->clientPause(5000));
+        $this->assertTrue($this->valkey_glide->clientUnpause());
+    }
+
+    public function testClientPauseWithReplyLiteral()
+    {
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+
+        $result = $this->valkey_glide->clientPause(100);
+        $this->assertIsString($result);
+        $this->assertEquals('OK', $result);
+
+        $result = $this->valkey_glide->clientUnpause();
+        $this->assertIsString($result);
+        $this->assertEquals('OK', $result);
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+    }
+
+    public function testClientPauseBatch()
+    {
+        if (!$this->havePipeline()) {
+            $this->markTestSkipped('Pipeline not supported');
+            return;
+        }
+
+        $this->valkey_glide->pipeline();
+        $this->valkey_glide->clientPause(100);
+        $this->valkey_glide->clientUnpause();
+        $result = $this->valkey_glide->exec();
+        $this->assertTrue($result[0]);
+        $this->assertTrue($result[1]);
+    }
+
     public function testInfo()
     {
         $fields = [

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -652,9 +652,19 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
     public function testClientPauseWithMode()
     {
-        // Test with WRITE mode
-        $result = $this->valkey_glide->clientPause(100, 'WRITE');
+        // Set a value before pausing
+        $this->valkey_glide->set('client_pause_test', 'value');
+
+        // Pause with WRITE mode - only writes are blocked, reads still allowed
+        $result = $this->valkey_glide->clientPause(2000, 'WRITE');
         $this->assertTrue($result);
+
+        // Reads should still work during WRITE pause
+        $value = $this->valkey_glide->get('client_pause_test');
+        $this->assertEquals('value', $value);
+
+        // Unpause to restore normal operation
+        $this->valkey_glide->clientUnpause();
     }
 
     public function testClientUnpause()

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -639,38 +639,69 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
     public function testClientPause()
     {
-        $result = $this->valkey_glide->clientPause(100);
+        $key = '{client_pause_all}_' . uniqid();
+        $this->valkey_glide->set($key, 'before');
+
+        $pauseMs = 2000;
+        $result = $this->valkey_glide->clientPause($pauseMs);
         $this->assertTrue($result);
+
+        // Verify that reads are blocked until the pause expires
+        $start = microtime(true);
+        $value = $this->valkey_glide->get($key);
+        $elapsed = (microtime(true) - $start) * 1000;
+
+        $this->assertEquals('before', $value);
+        $this->assertGTE($pauseMs * 0.8, $elapsed);
+
+        $this->valkey_glide->del($key);
     }
 
     public function testClientPauseWithMode()
     {
-        // Set a value before pausing
-        $this->valkey_glide->set('client_pause_test', 'value');
+        $key = '{client_pause_write}_' . uniqid();
+        $this->valkey_glide->set($key, 'value');
 
         // Pause with WRITE mode - only writes are blocked, reads still allowed
-        $result = $this->valkey_glide->clientPause(2000, 'WRITE');
+        $pauseMs = 60000;
+        $result = $this->valkey_glide->clientPause($pauseMs, 'WRITE');
         $this->assertTrue($result);
 
-        // Reads should still work during WRITE pause
-        $value = $this->valkey_glide->get('client_pause_test');
+        // Reads should still work quickly during WRITE pause
+        $start = microtime(true);
+        $value = $this->valkey_glide->get($key);
+        $elapsed = (microtime(true) - $start) * 1000;
+
         $this->assertEquals('value', $value);
+        $this->assertLT($pauseMs, $elapsed);
 
         // Unpause to restore normal operation
         $this->valkey_glide->clientUnpause();
+        $this->valkey_glide->del($key);
     }
 
     public function testClientUnpause()
     {
+        $key = '{client_unpause}_' . uniqid();
+        $this->valkey_glide->set($key, 'before');
+
+        // Pause writes for a long time
+        $pauseMs = 60000;
+        $this->valkey_glide->clientPause($pauseMs, 'WRITE');
+
+        // Unpause should unblock immediately
         $result = $this->valkey_glide->clientUnpause();
         $this->assertTrue($result);
-    }
 
-    public function testClientPauseAndUnpause()
-    {
-        // Use a short pause so it expires before the unpause command times out
-        $this->assertTrue($this->valkey_glide->clientPause(200));
-        $this->assertTrue($this->valkey_glide->clientUnpause());
+        // Verify writes work quickly after unpause
+        $start = microtime(true);
+        $this->valkey_glide->set($key, 'after');
+        $elapsed = (microtime(true) - $start) * 1000;
+
+        $this->assertLT($pauseMs, $elapsed);
+        $this->assertEquals('after', $this->valkey_glide->get($key));
+
+        $this->valkey_glide->del($key);
     }
 
     public function testClientPauseWithReplyLiteral()
@@ -701,7 +732,7 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->assertTrue($result[1]);
     }
   
-      public function testReset()
+    public function testReset()
     {
         $key = '{reset_test}_' . uniqid();
 

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -731,7 +731,7 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->assertTrue($result[0]);
         $this->assertTrue($result[1]);
     }
-  
+
     public function testReset()
     {
         $key = '{reset_test}_' . uniqid();

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2723,38 +2723,69 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
 
     public function testClientPause()
     {
-        $result = $this->valkey_glide->clientPause(100);
+        $key = 'client_pause_all_' . $this->createRandomString();
+        $this->valkey_glide->set($key, 'before');
+
+        $pauseMs = 2000;
+        $result = $this->valkey_glide->clientPause($pauseMs);
         $this->assertTrue($result);
+
+        // Verify that reads are blocked until the pause expires
+        $start = microtime(true);
+        $value = $this->valkey_glide->get($key);
+        $elapsed = (microtime(true) - $start) * 1000;
+
+        $this->assertEquals('before', $value);
+        $this->assertGTE($pauseMs * 0.8, $elapsed);
+
+        $this->valkey_glide->del($key);
     }
 
     public function testClientPauseWithMode()
     {
-        // Set a value before pausing
-        $this->valkey_glide->set('client_pause_test', 'value');
+        $key = 'client_pause_write_' . $this->createRandomString();
+        $this->valkey_glide->set($key, 'value');
 
         // Pause with WRITE mode - only writes are blocked, reads still allowed
-        $result = $this->valkey_glide->clientPause(2000, 'WRITE');
+        $pauseMs = 60000;
+        $result = $this->valkey_glide->clientPause($pauseMs, 'WRITE');
         $this->assertTrue($result);
 
-        // Reads should still work during WRITE pause
-        $value = $this->valkey_glide->get('client_pause_test');
+        // Reads should still work quickly during WRITE pause
+        $start = microtime(true);
+        $value = $this->valkey_glide->get($key);
+        $elapsed = (microtime(true) - $start) * 1000;
+
         $this->assertEquals('value', $value);
+        $this->assertLT($pauseMs, $elapsed);
 
         // Unpause to restore normal operation
         $this->valkey_glide->clientUnpause();
+        $this->valkey_glide->del($key);
     }
 
     public function testClientUnpause()
     {
+        $key = 'client_unpause_' . $this->createRandomString();
+        $this->valkey_glide->set($key, 'before');
+
+        // Pause writes for a long time
+        $pauseMs = 60000;
+        $this->valkey_glide->clientPause($pauseMs, 'WRITE');
+
+        // Unpause should unblock immediately
         $result = $this->valkey_glide->clientUnpause();
         $this->assertTrue($result);
-    }
 
-    public function testClientPauseAndUnpause()
-    {
-        // Use a short pause so it expires before the unpause command times out
-        $this->assertTrue($this->valkey_glide->clientPause(200));
-        $this->assertTrue($this->valkey_glide->clientUnpause());
+        // Verify writes work quickly after unpause
+        $start = microtime(true);
+        $this->valkey_glide->set($key, 'after');
+        $elapsed = (microtime(true) - $start) * 1000;
+
+        $this->assertLT($pauseMs, $elapsed);
+        $this->assertEquals('after', $this->valkey_glide->get($key));
+
+        $this->valkey_glide->del($key);
     }
 
     public function testClientPauseWithReplyLiteral()

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2743,6 +2743,11 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
 
     public function testClientPauseWithMode()
     {
+        if (!$this->minVersionCheck('6.2.0')) {
+            $this->markTestSkipped('CLIENT PAUSE WRITE requires 6.2.0+');
+            return;
+        }
+
         $key = 'client_pause_write_' . $this->createRandomString();
         $this->valkey_glide->set($key, 'value');
 
@@ -2766,6 +2771,11 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
 
     public function testClientUnpause()
     {
+        if (!$this->minVersionCheck('6.2.0')) {
+            $this->markTestSkipped('CLIENT PAUSE WRITE requires 6.2.0+');
+            return;
+        }
+
         $key = 'client_unpause_' . $this->createRandomString();
         $this->valkey_glide->set($key, 'before');
 

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2707,6 +2707,65 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->assertTrue($result[0]);
     }
 
+    public function testClientPause()
+    {
+        $result = $this->valkey_glide->clientPause(100);
+        $this->assertTrue($result);
+    }
+
+    public function testClientPauseWithMode()
+    {
+        // Test with WRITE mode - reads still allowed
+        $result = $this->valkey_glide->clientPause(100, 'WRITE');
+        $this->assertTrue($result);
+
+        // Reads should still work during WRITE pause
+        $this->valkey_glide->set('client_pause_test', 'value');
+    }
+
+    public function testClientUnpause()
+    {
+        $result = $this->valkey_glide->clientUnpause();
+        $this->assertTrue($result);
+    }
+
+    public function testClientPauseAndUnpause()
+    {
+        // Pause then immediately unpause
+        $this->assertTrue($this->valkey_glide->clientPause(5000));
+        $this->assertTrue($this->valkey_glide->clientUnpause());
+    }
+
+    public function testClientPauseWithReplyLiteral()
+    {
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+
+        $result = $this->valkey_glide->clientPause(100);
+        $this->assertIsString($result);
+        $this->assertEquals('OK', $result);
+
+        $result = $this->valkey_glide->clientUnpause();
+        $this->assertIsString($result);
+        $this->assertEquals('OK', $result);
+
+        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+    }
+
+    public function testClientPauseBatch()
+    {
+        if (!$this->havePipeline()) {
+            $this->markTestSkipped('Pipeline not supported');
+            return;
+        }
+
+        $this->valkey_glide->pipeline();
+        $this->valkey_glide->clientPause(100);
+        $this->valkey_glide->clientUnpause();
+        $result = $this->valkey_glide->exec();
+        $this->assertTrue($result[0]);
+        $this->assertTrue($result[1]);
+    }
+
     /**
      * Valid BGSAVE response strings (used when OPT_REPLY_LITERAL is enabled).
      */

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2715,12 +2715,19 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
 
     public function testClientPauseWithMode()
     {
-        // Test with WRITE mode - reads still allowed
-        $result = $this->valkey_glide->clientPause(100, 'WRITE');
+        // Set a value before pausing
+        $this->valkey_glide->set('client_pause_test', 'value');
+
+        // Pause with WRITE mode - only writes are blocked, reads still allowed
+        $result = $this->valkey_glide->clientPause(2000, 'WRITE');
         $this->assertTrue($result);
 
         // Reads should still work during WRITE pause
-        $this->valkey_glide->set('client_pause_test', 'value');
+        $value = $this->valkey_glide->get('client_pause_test');
+        $this->assertEquals('value', $value);
+
+        // Unpause to restore normal operation
+        $this->valkey_glide->clientUnpause();
     }
 
     public function testClientUnpause()

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2731,8 +2731,8 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
 
     public function testClientPauseAndUnpause()
     {
-        // Pause then immediately unpause
-        $this->assertTrue($this->valkey_glide->clientPause(5000));
+        // Use a short pause so it expires before the unpause command times out
+        $this->assertTrue($this->valkey_glide->clientPause(200));
         $this->assertTrue($this->valkey_glide->clientUnpause());
     }
 

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2815,7 +2815,7 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->assertTrue($result[0]);
         $this->assertTrue($result[1]);
     }
-  
+
     public function testReset()
     {
         $key = '{reset_test}_' . $this->createRandomString();

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2759,17 +2759,15 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
 
     public function testClientPauseWithReplyLiteral()
     {
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, true);
+        $this->withOptReplyLiteralEnabled(function () {
+            $result = $this->valkey_glide->clientPause(100);
+            $this->assertIsString($result);
+            $this->assertEquals('OK', $result);
 
-        $result = $this->valkey_glide->clientPause(100);
-        $this->assertIsString($result);
-        $this->assertEquals('OK', $result);
-
-        $result = $this->valkey_glide->clientUnpause();
-        $this->assertIsString($result);
-        $this->assertEquals('OK', $result);
-
-        $this->valkey_glide->setOption(ValkeyGlide::OPT_REPLY_LITERAL, false);
+            $result = $this->valkey_glide->clientUnpause();
+            $this->assertIsString($result);
+            $this->assertEquals('OK', $result);
+        });
     }
 
     public function testClientPauseBatch()

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -2756,16 +2756,18 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $result = $this->valkey_glide->clientPause($pauseMs, 'WRITE');
         $this->assertTrue($result);
 
-        // Reads should still work quickly during WRITE pause
-        $start = microtime(true);
-        $value = $this->valkey_glide->get($key);
-        $elapsed = (microtime(true) - $start) * 1000;
+        try {
+            // Reads should still work quickly during WRITE pause
+            $start = microtime(true);
+            $value = $this->valkey_glide->get($key);
+            $elapsed = (microtime(true) - $start) * 1000;
 
-        $this->assertEquals('value', $value);
-        $this->assertLT($pauseMs, $elapsed);
+            $this->assertEquals('value', $value);
+            $this->assertLT($pauseMs, $elapsed);
+        } finally {
+            $this->valkey_glide->clientUnpause();
+        }
 
-        // Unpause to restore normal operation
-        $this->valkey_glide->clientUnpause();
         $this->valkey_glide->del($key);
     }
 

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -2371,7 +2371,8 @@ class ValkeyGlide
      *                              "WRITE" pauses only write commands (reads still allowed).
      *
      * @return ValkeyGlide|bool|string  Returns true on success, false on failure.
-     *                                  With OPT_REPLY_LITERAL enabled, returns "OK" instead.
+     *                                  With OPT_REPLY_LITERAL enabled, returns "OK" on success,
+     *                                  false on failure.
      *
      * @see https://valkey.io/commands/client-pause
      */
@@ -2381,7 +2382,8 @@ class ValkeyGlide
      * Resume processing commands on all clients that were paused by CLIENT PAUSE.
      *
      * @return ValkeyGlide|bool|string  Returns true on success, false on failure.
-     *                                  With OPT_REPLY_LITERAL enabled, returns "OK" instead.
+     *                                  With OPT_REPLY_LITERAL enabled, returns "OK" on success,
+     *                                  false on failure.
      *
      * @see https://valkey.io/commands/client-unpause
      */

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -2347,6 +2347,33 @@ class ValkeyGlide
     public function ping(?string $message = null): ValkeyGlide|string|bool;
 
     /**
+     * Suspend all clients for the specified timeout.
+     *
+     * All subsequent commands from all clients will be blocked until the timeout expires
+     * or CLIENT UNPAUSE is called.
+     *
+     * @param int         $timeout  The time in milliseconds to pause clients.
+     * @param string|null $mode     Optional pause mode: "ALL" (default) pauses all commands,
+     *                              "WRITE" pauses only write commands (reads still allowed).
+     *
+     * @return ValkeyGlide|bool|string  Returns true on success, false on failure.
+     *                                  With OPT_REPLY_LITERAL enabled, returns "OK" instead.
+     *
+     * @see https://valkey.io/commands/client-pause
+     */
+    public function clientPause(int $timeout, ?string $mode = null): ValkeyGlide|bool|string;
+
+    /**
+     * Resume processing commands on all clients that were paused by CLIENT PAUSE.
+     *
+     * @return ValkeyGlide|bool|string  Returns true on success, false on failure.
+     *                                  With OPT_REPLY_LITERAL enabled, returns "OK" instead.
+     *
+     * @see https://valkey.io/commands/client-unpause
+     */
+    public function clientUnpause(): ValkeyGlide|bool|string;
+
+    /**
      * Enter into pipeline mode.
      *
      * Pipeline mode is the highest performance way to send many commands to ValkeyGlide

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -991,7 +991,7 @@ CLIENT_PAUSE_METHOD_IMPL(ValkeyGlideCluster)
 
 /* {{{ proto ValkeyGlideCluster::clientUnpause() */
 CLIENT_UNPAUSE_METHOD_IMPL(ValkeyGlideCluster)
-/* }}} */  
+/* }}} */
 
 /* {{{ proto ValkeyGlideCluster::reset() */
 RESET_METHOD_IMPL(ValkeyGlideCluster)

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -985,6 +985,14 @@ BGSAVE_METHOD_IMPL(ValkeyGlideCluster)
 BGREWRITEAOF_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
+/* {{{ proto ValkeyGlideCluster::clientPause(int timeout [, string mode]) */
+CLIENT_PAUSE_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto ValkeyGlideCluster::clientUnpause() */
+CLIENT_UNPAUSE_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
 /* {{{ proto ValkeyGlideCluster::dbsize(string key)
  *     proto ValkeyGlideCluster::dbsize(array host_port) */
 DBSIZE_METHOD_IMPL(ValkeyGlideCluster)

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -967,6 +967,20 @@ class ValkeyGlideCluster
     public function ping(mixed $route, ?string $message = null): mixed;
 
     /**
+     * @see ValkeyGlide::clientPause
+     *
+     * Routes to all primary nodes by default.
+     */
+    public function clientPause(int $timeout, ?string $mode = null): ValkeyGlideCluster|bool|string;
+
+    /**
+     * @see ValkeyGlide::clientUnpause
+     *
+     * Routes to all primary nodes by default.
+     */
+    public function clientUnpause(): ValkeyGlideCluster|bool|string;
+
+    /**
      * @see ValkeyGlide::psetex
      */
     public function psetex(string $key, int $timeout, string $value): ValkeyGlideCluster|bool;

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -973,15 +973,11 @@ class ValkeyGlideCluster
 
     /**
      * @see ValkeyGlide::clientPause
-     *
-     * Routes to all primary nodes by default.
      */
     public function clientPause(int $timeout, ?string $mode = null): ValkeyGlideCluster|bool|string;
 
     /**
      * @see ValkeyGlide::clientUnpause
-     *
-     * Routes to all primary nodes by default.
      */
     public function clientUnpause(): ValkeyGlideCluster|bool|string;
 

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -981,7 +981,7 @@ class ValkeyGlideCluster
      */
     public function clientUnpause(): ValkeyGlideCluster|bool|string;
 
-    /**  
+    /**
      * @see ValkeyGlide::reset
      */
     public function reset(): ValkeyGlideCluster|bool|string;

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -363,6 +363,86 @@ int execute_bgrewriteaof_command(zval* object, int argc, zval* return_value, zen
     return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
 }
 
+/* Execute a CLIENT PAUSE command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
+int execute_client_pause_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    long                 timeout;
+    char*                mode     = NULL;
+    size_t               mode_len = 0;
+
+    /* Get ValkeyGlide object */
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    /* Parse parameters: timeout (required), mode (optional) */
+    if (zend_parse_method_parameters(
+            argc, object, "Ol|s!", &object, ce, &timeout, &mode, &mode_len) == FAILURE) {
+        return 0;
+    }
+
+    /* Setup core command arguments */
+    core_command_args_t core_args = {0};
+    core_args.glide_client        = valkey_glide->glide_client;
+    core_args.cmd_type            = ClientPause;
+    core_args.is_cluster          = (ce == get_valkey_glide_cluster_ce());
+
+    /* Add timeout argument */
+    core_args.args[0].type                = CORE_ARG_TYPE_LONG;
+    core_args.args[0].data.long_arg.value = timeout;
+    core_args.arg_count                   = 1;
+
+    /* Add optional mode argument (ALL or WRITE) */
+    if (mode && mode_len > 0) {
+        core_args.args[1].type                  = CORE_ARG_TYPE_STRING;
+        core_args.args[1].data.string_arg.value = mode;
+        core_args.args[1].data.string_arg.len   = mode_len;
+        core_args.arg_count                     = 2;
+    }
+
+    /* Select processor based on OPT_REPLY_LITERAL */
+    z_result_processor_t processor = valkey_glide->opt_reply_literal
+                                         ? process_core_status_string_result
+                                         : process_core_status_bool_result;
+
+    /* Execute using unified core framework */
+    return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
+}
+
+/* Execute a CLIENT UNPAUSE command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
+int execute_client_unpause_command(zval*             object,
+                                   int               argc,
+                                   zval*             return_value,
+                                   zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+
+    /* Get ValkeyGlide object */
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    /* No parameters - validate object only */
+    if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
+        return 0;
+    }
+
+    /* Setup core command arguments */
+    core_command_args_t core_args = {0};
+    core_args.glide_client        = valkey_glide->glide_client;
+    core_args.cmd_type            = ClientUnpause;
+    core_args.is_cluster          = (ce == get_valkey_glide_cluster_ce());
+
+    /* Select processor based on OPT_REPLY_LITERAL */
+    z_result_processor_t processor = valkey_glide->opt_reply_literal
+                                         ? process_core_status_string_result
+                                         : process_core_status_bool_result;
+
+    /* Execute using unified core framework */
+    return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
+}
+
 /* Execute a TIME command using the Valkey Glide client - UNIFIED IMPLEMENTATION */
 int execute_time_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
     valkey_glide_object* valkey_glide;

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -475,7 +475,6 @@ int execute_client_pause_command(zval* object, int argc, zval* return_value, zen
                                          ? process_core_status_string_result
                                          : process_core_status_bool_result;
 
-    /* Execute using unified core framework */
     return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
 }
 
@@ -508,7 +507,6 @@ int execute_client_unpause_command(zval*             object,
                                          ? process_core_status_string_result
                                          : process_core_status_bool_result;
 
-    /* Execute using unified core framework */
     return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
 }
 
@@ -611,7 +609,6 @@ int execute_unwatch_command(zval* object, int argc, zval* return_value, zend_cla
         return 0;
     }
 
-    /* Execute using core framework */
     core_command_args_t args = {0};
     args.glide_client        = valkey_glide->glide_client;
     args.cmd_type            = UnWatch;

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -207,6 +207,11 @@ int execute_flushdb_command(zval* object, int argc, zval* return_value, zend_cla
 int execute_flushall_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_bgsave_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_bgrewriteaof_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_client_pause_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_client_unpause_command(zval*             object,
+                                   int               argc,
+                                   zval*             return_value,
+                                   zend_class_entry* ce);
 int execute_time_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_scan_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_cluster_scan_command(const void* glide_client,
@@ -719,6 +724,34 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
         }                                                                               \
         zval_dtor(return_value);                                                        \
         RETURN_FALSE;                                                                   \
+    }
+
+#define CLIENT_PAUSE_METHOD_IMPL(class_name)                                            \
+    PHP_METHOD(class_name, clientPause) {                                               \
+        if (execute_client_pause_command(getThis(),                                     \
+                                         ZEND_NUM_ARGS(),                               \
+                                         return_value,                                  \
+                                         strcmp(#class_name, "ValkeyGlideCluster") == 0 \
+                                             ? get_valkey_glide_cluster_ce()            \
+                                             : get_valkey_glide_ce())) {                \
+            return;                                                                     \
+        }                                                                               \
+        zval_dtor(return_value);                                                        \
+        RETURN_FALSE;                                                                   \
+    }
+
+#define CLIENT_UNPAUSE_METHOD_IMPL(class_name)                                            \
+    PHP_METHOD(class_name, clientUnpause) {                                               \
+        if (execute_client_unpause_command(getThis(),                                     \
+                                           ZEND_NUM_ARGS(),                               \
+                                           return_value,                                  \
+                                           strcmp(#class_name, "ValkeyGlideCluster") == 0 \
+                                               ? get_valkey_glide_cluster_ce()            \
+                                               : get_valkey_glide_ce())) {                \
+            return;                                                                       \
+        }                                                                                 \
+        zval_dtor(return_value);                                                          \
+        RETURN_FALSE;                                                                     \
     }
 
 #define TIME_METHOD_IMPL(class_name)                                            \

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -494,6 +494,12 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
 
 #define RESET_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, reset, execute_reset_command)
 
+#define CLIENT_PAUSE_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, clientPause, execute_client_pause_command)
+
+#define CLIENT_UNPAUSE_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, clientUnpause, execute_client_unpause_command)
+
 #define TIME_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, time, execute_time_command)
 
 #define SCAN_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, scan, execute_scan_command)

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -203,6 +203,7 @@ int prepare_core_args(core_command_args_t* args,
         case Role:
         case DBSize:
         case BgRewriteAof:
+        case ClientUnpause:
             return prepare_zero_args(args, cmd_args, cmd_args_len);
 
         /* Single key operations */
@@ -316,6 +317,7 @@ int prepare_core_args(core_command_args_t* args,
         case FlushDB:
         case FlushAll:
         case BgSave:
+        case ClientPause:
         case Select:
         case SwapDb:
             return prepare_message_args(

--- a/valkey_z_php_methods.c
+++ b/valkey_z_php_methods.c
@@ -822,6 +822,14 @@ BGSAVE_METHOD_IMPL(ValkeyGlide)
 BGREWRITEAOF_METHOD_IMPL(ValkeyGlide)
 /* }}} */
 
+/* {{{ proto bool ValkeyGlide::clientPause(int timeout [, string mode]) */
+CLIENT_PAUSE_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto bool ValkeyGlide::clientUnpause() */
+CLIENT_UNPAUSE_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
 /* {{{ proto array ValkeyGlide::time() */
 TIME_METHOD_IMPL(ValkeyGlide)
 /* }}} */

--- a/valkey_z_php_methods.c
+++ b/valkey_z_php_methods.c
@@ -828,7 +828,7 @@ CLIENT_PAUSE_METHOD_IMPL(ValkeyGlide)
 
 /* {{{ proto bool ValkeyGlide::clientUnpause() */
 CLIENT_UNPAUSE_METHOD_IMPL(ValkeyGlide)
-/* }}} */  
+/* }}} */
 
 /* {{{ proto bool ValkeyGlide::reset() */
 RESET_METHOD_IMPL(ValkeyGlide)


### PR DESCRIPTION
### Summary

Implement CLIENT PAUSE and CLIENT UNPAUSE commands for both standalone and cluster clients. CLIENT PAUSE suspends all client commands for a specified timeout, and CLIENT UNPAUSE resumes processing.

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide-php/issues/236

### Features / Behaviour Changes

- Add ValkeyGlide::clientPause(int $timeout, ?string $mode = null): ValkeyGlide|bool|string
- Add ValkeyGlide::clientUnpause(): ValkeyGlide|bool|string
- Add ValkeyGlideCluster::clientPause(int $timeout, ?string $mode = null): ValkeyGlideCluster|bool|string
- Add ValkeyGlideCluster::clientUnpause(): ValkeyGlideCluster|bool|string
- With OPT_REPLY_LITERAL enabled, returns "OK" string
- Supports pause modes: "ALL" (default, blocks all commands) and "WRITE" (blocks only writes)
- In cluster mode, glide-core routes to all primary nodes by default (no explicit route param needed)

### Implementation

- execute_client_pause_command() in valkey_glide_commands.c — takes timeout (long) + optional mode (string)
- execute_client_unpause_command() in valkey_glide_commands.c — zero-arg command
- CLIENT_PAUSE_METHOD_IMPL and CLIENT_UNPAUSE_METHOD_IMPL macros in valkey_glide_commands_common.h
- ClientPause uses prepare_message_args (handles long + optional string args)
- ClientUnpause uses prepare_zero_args
- Both use execute_and_handle_batch helper and status processors

### Testing

Standalone tests (tests/ValkeyGlideTest.php) added.
Cluster tests (tests/ValkeyGlideClusterTest.php) added.
Build passes with -Werror, lint clean on all modified files.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.