### PR TITLE
Implement LATENCY HISTORY, LATEST, and RESET commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* Add `LATENCY HISTORY`, `LATENCY LATEST`, and `LATENCY RESET` commands for standalone and cluster clients ([#283](https://github.com/valkey-io/valkey-glide-php/pull/283))
 * Add `MEMORY DOCTOR`, `MEMORY MALLOC-STATS`, `MEMORY PURGE`, and `MEMORY STATS` commands for standalone and cluster clients ([#285](https://github.com/valkey-io/valkey-glide-php/pull/285))
 * Add `REPLICAOF` and `FAILOVER` commands for standalone client ([#282](https://github.com/valkey-io/valkey-glide-php/pull/282))
 * Add circuit breaker configuration support for standalone and cluster clients ([#238](https://github.com/valkey-io/valkey-glide-php/issues/238))

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -900,6 +900,12 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         $result = $this->valkey_glide->latencyHistory('command');
         $this->assertIsArray($result);
+        $this->assertGT(0, count($result));
+
+        // Non-existent event returns empty array
+        $unknown = $this->valkey_glide->latencyHistory('nonexistent_event');
+        $this->assertIsArray($unknown);
+        $this->assertEquals(0, count($unknown));
     }
 
     public function testLatencyLatest()
@@ -908,14 +914,24 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         $result = $this->valkey_glide->latencyLatest();
         $this->assertIsArray($result);
+        $this->assertGT(0, count($result));
     }
 
     public function testLatencyReset()
     {
         $this->triggerLatencySpike();
 
+        // Verify history exists before reset
+        $history = $this->valkey_glide->latencyHistory('command');
+        $this->assertGT(0, count($history));
+
         $result = $this->valkey_glide->latencyReset();
-        $this->assertTrue(is_int($result) || is_array($result));
+        $this->assertIsInt($result);
+        $this->assertGT(0, $result);
+
+        // History should be empty after reset
+        $history = $this->valkey_glide->latencyHistory('command');
+        $this->assertEquals(0, count($history));
     }
 
     public function testLatencyResetSpecificEvent()
@@ -923,15 +939,26 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->triggerLatencySpike();
 
         $result = $this->valkey_glide->latencyReset('command');
-        $this->assertTrue(is_int($result) || is_array($result));
+        $this->assertIsInt($result);
+        $this->assertGT(0, $result);
+
+        // History for "command" should be empty
+        $history = $this->valkey_glide->latencyHistory('command');
+        $this->assertEquals(0, count($history));
     }
 
     public function testLatencyResetUnknownEvent()
     {
         $this->triggerLatencySpike();
 
+        // Reset unknown event returns 0
         $result = $this->valkey_glide->latencyReset('unknown_event');
-        $this->assertTrue(is_int($result) || is_array($result));
+        $this->assertIsInt($result);
+        $this->assertEquals(0, $result);
+
+        // History for "command" should still exist
+        $history = $this->valkey_glide->latencyHistory('command');
+        $this->assertGT(0, count($history));
     }
 
     public function testLatencyHistoryWithRoute()

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -1042,6 +1042,26 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->assertIsInt($result);
     }
 
+    public function testLatencyHistoryWithNullRoute()
+    {
+        $this->triggerLatencySpike();
+
+        // Explicit null should behave like an omitted route
+        $result = $this->valkey_glide->latencyHistory('command', null);
+        $this->assertIsArray($result);
+        $this->assertGT(0, count($result));
+    }
+
+    public function testLatencyLatestWithNullRoute()
+    {
+        $this->triggerLatencySpike();
+
+        // Explicit null should behave like an omitted route
+        $result = $this->valkey_glide->latencyLatest(null);
+        $this->assertIsArray($result);
+        $this->assertGT(0, count($result));
+    }
+
     public function testReset()
     {
         $key = '{reset_test}_' . uniqid();

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -907,7 +907,7 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
         try {
             // DEBUG SLEEP on a random node — all nodes have threshold=1 so the spike is recorded
-            $this->valkey_glide->rawCommand('', 'DEBUG', 'SLEEP', '0.05');
+            $this->valkey_glide->rawCommand('randomNode', 'DEBUG', 'SLEEP', '0.05');
         } finally {
             $this->valkey_glide->rawCommand('allPrimaries', 'CONFIG', 'SET', 'latency-monitor-threshold', $prevThreshold);
         }

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -977,6 +977,14 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->assertIsArray($result);
     }
 
+    public function testLatencyResetWithRoute()
+    {
+        $this->triggerLatencySpike();
+
+        $result = $this->valkey_glide->latencyResetWithRoute('randomNode');
+        $this->assertIsInt($result);
+    }
+
     public function testReset()
     {
         $key = '{reset_test}_' . uniqid();

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -1022,24 +1022,42 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->triggerLatencySpike();
 
+        // randomNode returns a flat array of [timestamp, duration] pairs from one node
         $result = $this->valkey_glide->latencyHistory('command', 'randomNode');
         $this->assertIsArray($result);
+        // Verify entries have correct shape if any exist
+        foreach ($result as $entry) {
+            $this->assertIsArray($entry);
+            $this->assertEquals(2, count($entry));
+            $this->assertGT(0, $entry[0]); // timestamp > 0
+            $this->assertGT(0, $entry[1]); // duration > 0
+        }
     }
 
     public function testLatencyLatestWithRoute()
     {
         $this->triggerLatencySpike();
 
+        // randomNode returns a flat array of latest events from one node
         $result = $this->valkey_glide->latencyLatest('randomNode');
         $this->assertIsArray($result);
+        // Verify entries have correct shape if any exist
+        foreach ($result as $entry) {
+            $this->assertIsArray($entry);
+            $this->assertGTE(4, count($entry));
+            $this->assertIsString($entry[0]); // event name
+            $this->assertGT(0, $entry[1]);    // timestamp > 0
+        }
     }
 
     public function testLatencyResetWithRoute()
     {
         $this->triggerLatencySpike();
 
+        // randomNode returns an integer count from one node
         $result = $this->valkey_glide->latencyResetWithRoute('randomNode');
         $this->assertIsInt($result);
+        $this->assertGTE(0, $result);
     }
 
     public function testLatencyHistoryWithNullRoute()

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -896,18 +896,20 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
     protected function triggerLatencySpike()
     {
-        // Cluster rawCommand requires route as first arg
-        $config = $this->valkey_glide->rawCommand('', 'CONFIG', 'GET', 'latency-monitor-threshold');
+        // Get current threshold from one node (all should have same value)
+        $config = $this->valkey_glide->rawCommand('randomNode', 'CONFIG', 'GET', 'latency-monitor-threshold');
         $prevThreshold = $config['latency-monitor-threshold'] ?? '0';
 
         $this->valkey_glide->latencyReset();
 
-        $this->valkey_glide->rawCommand('', 'CONFIG', 'SET', 'latency-monitor-threshold', '1');
+        // Set threshold on all primaries so any node records spikes
+        $this->valkey_glide->rawCommand('allPrimaries', 'CONFIG', 'SET', 'latency-monitor-threshold', '1');
 
         try {
+            // DEBUG SLEEP on a random node — all nodes have threshold=1 so the spike is recorded
             $this->valkey_glide->rawCommand('', 'DEBUG', 'SLEEP', '0.05');
         } finally {
-            $this->valkey_glide->rawCommand('', 'CONFIG', 'SET', 'latency-monitor-threshold', $prevThreshold);
+            $this->valkey_glide->rawCommand('allPrimaries', 'CONFIG', 'SET', 'latency-monitor-threshold', $prevThreshold);
         }
     }
 

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -894,6 +894,23 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->assertGT(0, $result['peak.allocated']);
     }
 
+    protected function triggerLatencySpike()
+    {
+        // Cluster rawCommand requires route as first arg
+        $config = $this->valkey_glide->rawCommand('', 'CONFIG', 'GET', 'latency-monitor-threshold');
+        $prevThreshold = $config['latency-monitor-threshold'] ?? '0';
+
+        $this->valkey_glide->latencyReset();
+
+        $this->valkey_glide->rawCommand('', 'CONFIG', 'SET', 'latency-monitor-threshold', '1');
+
+        try {
+            $this->valkey_glide->rawCommand('', 'DEBUG', 'SLEEP', '0.05');
+        } finally {
+            $this->valkey_glide->rawCommand('', 'CONFIG', 'SET', 'latency-monitor-threshold', $prevThreshold);
+        }
+    }
+
     public function testLatencyHistory()
     {
         $this->triggerLatencySpike();

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -917,12 +917,12 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->triggerLatencySpike();
 
-        $result = $this->valkey_glide->latencyHistory('command');
+        $result = $this->valkey_glide->latencyHistory('command', 'randomNode');
         $this->assertIsArray($result);
         $this->assertGT(0, count($result));
 
         // Non-existent event returns empty array
-        $unknown = $this->valkey_glide->latencyHistory('nonexistent_event');
+        $unknown = $this->valkey_glide->latencyHistory('nonexistent_event', 'randomNode');
         $this->assertIsArray($unknown);
         $this->assertEquals(0, count($unknown));
     }
@@ -940,8 +940,8 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->triggerLatencySpike();
 
-        // Verify history exists before reset
-        $history = $this->valkey_glide->latencyHistory('command');
+        // Verify history exists before reset (use randomNode for scalar response)
+        $history = $this->valkey_glide->latencyHistory('command', 'randomNode');
         $this->assertGT(0, count($history));
 
         $result = $this->valkey_glide->latencyReset();
@@ -949,7 +949,7 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->assertGT(0, $result);
 
         // History should be empty after reset
-        $history = $this->valkey_glide->latencyHistory('command');
+        $history = $this->valkey_glide->latencyHistory('command', 'randomNode');
         $this->assertEquals(0, count($history));
     }
 
@@ -962,7 +962,7 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->assertGT(0, $result);
 
         // History for "command" should be empty
-        $history = $this->valkey_glide->latencyHistory('command');
+        $history = $this->valkey_glide->latencyHistory('command', 'randomNode');
         $this->assertEquals(0, count($history));
     }
 
@@ -976,7 +976,7 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->assertEquals(0, $result);
 
         // History for "command" should still exist
-        $history = $this->valkey_glide->latencyHistory('command');
+        $history = $this->valkey_glide->latencyHistory('command', 'randomNode');
         $this->assertGT(0, count($history));
     }
 

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -894,6 +894,62 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->assertGT(0, $result['peak.allocated']);
     }
 
+    public function testLatencyHistory()
+    {
+        $this->triggerLatencySpike();
+
+        $result = $this->valkey_glide->latencyHistory('command');
+        $this->assertIsArray($result);
+    }
+
+    public function testLatencyLatest()
+    {
+        $this->triggerLatencySpike();
+
+        $result = $this->valkey_glide->latencyLatest();
+        $this->assertIsArray($result);
+    }
+
+    public function testLatencyReset()
+    {
+        $this->triggerLatencySpike();
+
+        $result = $this->valkey_glide->latencyReset();
+        $this->assertTrue(is_int($result) || is_array($result));
+    }
+
+    public function testLatencyResetSpecificEvent()
+    {
+        $this->triggerLatencySpike();
+
+        $result = $this->valkey_glide->latencyReset('command');
+        $this->assertTrue(is_int($result) || is_array($result));
+    }
+
+    public function testLatencyResetUnknownEvent()
+    {
+        $this->triggerLatencySpike();
+
+        $result = $this->valkey_glide->latencyReset('unknown_event');
+        $this->assertTrue(is_int($result) || is_array($result));
+    }
+
+    public function testLatencyHistoryWithRoute()
+    {
+        $this->triggerLatencySpike();
+
+        $result = $this->valkey_glide->latencyHistory('command', 'randomNode');
+        $this->assertIsArray($result);
+    }
+
+    public function testLatencyLatestWithRoute()
+    {
+        $this->triggerLatencySpike();
+
+        $result = $this->valkey_glide->latencyLatest('randomNode');
+        $this->assertIsArray($result);
+    }
+
     public function testReset()
     {
         $key = '{reset_test}_' . uniqid();

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -917,12 +917,26 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->triggerLatencySpike();
 
-        // Use default route (allPrimaries with Special policy) to ensure we hit the node with the spike
+        // Default route returns per-node map: {node_address => [[timestamp, duration], ...]}
         $result = $this->valkey_glide->latencyHistory('command');
         $this->assertIsArray($result);
         $this->assertGT(0, count($result));
+        // Verify at least one node has history entries
+        $hasEntries = false;
+        foreach ($result as $nodeAddress => $entries) {
+            $this->assertIsString($nodeAddress);
+            $this->assertIsArray($entries);
+            if (count($entries) > 0) {
+                $hasEntries = true;
+                foreach ($entries as $entry) {
+                    $this->assertIsArray($entry);
+                    $this->assertEquals(2, count($entry));
+                }
+            }
+        }
+        $this->assertTrue($hasEntries);
 
-        // Non-existent event returns empty array on any node
+        // Non-existent event — each node returns empty
         $unknown = $this->valkey_glide->latencyHistory('nonexistent_event', 'randomNode');
         $this->assertIsArray($unknown);
         $this->assertEquals(0, count($unknown));
@@ -932,51 +946,76 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->triggerLatencySpike();
 
+        // Default route returns per-node map: {node_address => [[event, ts, dur, max], ...]}
         $result = $this->valkey_glide->latencyLatest();
         $this->assertIsArray($result);
         $this->assertGT(0, count($result));
+        // Verify at least one node reports latency events
+        $hasEntries = false;
+        foreach ($result as $nodeAddress => $entries) {
+            $this->assertIsString($nodeAddress);
+            $this->assertIsArray($entries);
+            if (count($entries) > 0) {
+                $hasEntries = true;
+            }
+        }
+        $this->assertTrue($hasEntries);
     }
 
     public function testLatencyReset()
     {
         $this->triggerLatencySpike();
 
-        // Assert reset count > 0 (aggregated across all primaries)
+        // Reset count is aggregated (Sum) across all primaries
         $result = $this->valkey_glide->latencyReset();
         $this->assertIsInt($result);
         $this->assertGT(0, $result);
 
-        // History should be empty after reset on any node
-        $history = $this->valkey_glide->latencyHistory('command', 'randomNode');
-        $this->assertEquals(0, count($history));
+        // After reset, every node's history should be empty
+        $history = $this->valkey_glide->latencyHistory('command');
+        $this->assertIsArray($history);
+        foreach ($history as $nodeAddress => $entries) {
+            $this->assertIsArray($entries);
+            $this->assertEquals(0, count($entries));
+        }
     }
 
     public function testLatencyResetSpecificEvent()
     {
         $this->triggerLatencySpike();
 
-        // Assert reset count > 0
         $result = $this->valkey_glide->latencyReset('command');
         $this->assertIsInt($result);
         $this->assertGT(0, $result);
 
-        // History for "command" should be empty on any node
-        $history = $this->valkey_glide->latencyHistory('command', 'randomNode');
-        $this->assertEquals(0, count($history));
+        // After reset, every node's history should be empty
+        $history = $this->valkey_glide->latencyHistory('command');
+        $this->assertIsArray($history);
+        foreach ($history as $nodeAddress => $entries) {
+            $this->assertIsArray($entries);
+            $this->assertEquals(0, count($entries));
+        }
     }
 
     public function testLatencyResetUnknownEvent()
     {
         $this->triggerLatencySpike();
 
-        // Reset unknown event returns 0 (aggregated sum across nodes)
+        // Reset unknown event returns 0
         $result = $this->valkey_glide->latencyReset('unknown_event');
         $this->assertIsInt($result);
         $this->assertEquals(0, $result);
 
-        // History for "command" should still exist (check via default route)
+        // History for "command" should still have entries on at least one node
         $history = $this->valkey_glide->latencyHistory('command');
-        $this->assertGT(0, count($history));
+        $this->assertIsArray($history);
+        $hasEntries = false;
+        foreach ($history as $nodeAddress => $entries) {
+            if (count($entries) > 0) {
+                $hasEntries = true;
+            }
+        }
+        $this->assertTrue($hasEntries);
     }
 
     public function testLatencyHistoryWithRoute()

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -917,11 +917,12 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->triggerLatencySpike();
 
-        $result = $this->valkey_glide->latencyHistory('command', 'randomNode');
+        // Use default route (allPrimaries with Special policy) to ensure we hit the node with the spike
+        $result = $this->valkey_glide->latencyHistory('command');
         $this->assertIsArray($result);
         $this->assertGT(0, count($result));
 
-        // Non-existent event returns empty array
+        // Non-existent event returns empty array on any node
         $unknown = $this->valkey_glide->latencyHistory('nonexistent_event', 'randomNode');
         $this->assertIsArray($unknown);
         $this->assertEquals(0, count($unknown));
@@ -940,15 +941,12 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->triggerLatencySpike();
 
-        // Verify history exists before reset (use randomNode for scalar response)
-        $history = $this->valkey_glide->latencyHistory('command', 'randomNode');
-        $this->assertGT(0, count($history));
-
+        // Assert reset count > 0 (aggregated across all primaries)
         $result = $this->valkey_glide->latencyReset();
         $this->assertIsInt($result);
         $this->assertGT(0, $result);
 
-        // History should be empty after reset
+        // History should be empty after reset on any node
         $history = $this->valkey_glide->latencyHistory('command', 'randomNode');
         $this->assertEquals(0, count($history));
     }
@@ -957,11 +955,12 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->triggerLatencySpike();
 
+        // Assert reset count > 0
         $result = $this->valkey_glide->latencyReset('command');
         $this->assertIsInt($result);
         $this->assertGT(0, $result);
 
-        // History for "command" should be empty
+        // History for "command" should be empty on any node
         $history = $this->valkey_glide->latencyHistory('command', 'randomNode');
         $this->assertEquals(0, count($history));
     }
@@ -970,13 +969,13 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->triggerLatencySpike();
 
-        // Reset unknown event returns 0
+        // Reset unknown event returns 0 (aggregated sum across nodes)
         $result = $this->valkey_glide->latencyReset('unknown_event');
         $this->assertIsInt($result);
         $this->assertEquals(0, $result);
 
-        // History for "command" should still exist
-        $history = $this->valkey_glide->latencyHistory('command', 'randomNode');
+        // History for "command" should still exist (check via default route)
+        $history = $this->valkey_glide->latencyHistory('command');
         $this->assertGT(0, count($history));
     }
 

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -3260,6 +3260,107 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->valkey_glide->del($key);
     }
 
+    // TODO: Replace rawCommand CONFIG calls with config() once config() is available on cluster client.
+    // See: https://github.com/valkey-io/valkey-glide-php/issues/284
+    protected function triggerLatencySpike()
+    {
+        // Save current threshold
+        $config = $this->valkey_glide->rawCommand('', 'CONFIG', 'GET', 'latency-monitor-threshold');
+        $prevThreshold = $config['latency-monitor-threshold'] ?? '0';
+
+        // Reset existing latency data
+        $this->valkey_glide->latencyReset();
+
+        // Set threshold to 1ms so any command triggers a spike
+        $this->valkey_glide->rawCommand('', 'CONFIG', 'SET', 'latency-monitor-threshold', '1');
+
+        try {
+            // Trigger a latency spike using DEBUG SLEEP
+            $this->valkey_glide->rawCommand('', 'DEBUG', 'SLEEP', '0.05');
+        } finally {
+            // Restore original threshold
+            $this->valkey_glide->rawCommand('', 'CONFIG', 'SET', 'latency-monitor-threshold', $prevThreshold);
+        }
+    }
+
+    public function testLatencyHistory()
+    {
+        $this->triggerLatencySpike();
+
+        $history = $this->valkey_glide->latencyHistory('command');
+        $this->assertIsArray($history);
+        $this->assertGT(0, count($history));
+
+        foreach ($history as $entry) {
+            $this->assertIsArray($entry);
+            $this->assertEquals(2, count($entry));
+            $this->assertGT(0, $entry[0]);
+            $this->assertGT(0, $entry[1]);
+        }
+
+        $unknown = $this->valkey_glide->latencyHistory('nonexistent_event');
+        $this->assertIsArray($unknown);
+        $this->assertEquals(0, count($unknown));
+    }
+
+    public function testLatencyLatest()
+    {
+        $this->triggerLatencySpike();
+
+        $latest = $this->valkey_glide->latencyLatest();
+        $this->assertIsArray($latest);
+        $this->assertGT(0, count($latest));
+
+        $found = false;
+        foreach ($latest as $entry) {
+            $this->assertIsArray($entry);
+            $this->assertGTE(4, count($entry));
+            if ($entry[0] === 'command') {
+                $found = true;
+                $this->assertGT(0, $entry[1]);
+                $this->assertGT(0, $entry[2]);
+                $this->assertGTE($entry[2], $entry[3]);
+            }
+        }
+        $this->assertTrue($found);
+    }
+
+    public function testLatencyReset()
+    {
+        $this->triggerLatencySpike();
+
+        $history = $this->valkey_glide->latencyHistory('command');
+        $this->assertGT(0, count($history));
+
+        $resetCount = $this->valkey_glide->latencyReset();
+        $this->assertGT(0, $resetCount);
+
+        $history = $this->valkey_glide->latencyHistory('command');
+        $this->assertEquals(0, count($history));
+    }
+
+    public function testLatencyResetSpecificEvent()
+    {
+        $this->triggerLatencySpike();
+
+        $resetCount = $this->valkey_glide->latencyReset('command');
+        $this->assertGT(0, $resetCount);
+
+        $history = $this->valkey_glide->latencyHistory('command');
+        $this->assertEquals(0, count($history));
+    }
+
+    public function testLatencyResetUnknownEvent()
+    {
+        $this->triggerLatencySpike();
+
+        $resetCount = $this->valkey_glide->latencyReset('unknown_event');
+        $this->assertEquals(0, $resetCount);
+
+        $history = $this->valkey_glide->latencyHistory('command');
+        $this->assertGT(0, count($history));
+    }
+
     public function testSave()
     {
         $this->waitForSaveNotInProgress();

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -3265,21 +3265,21 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
     protected function triggerLatencySpike()
     {
         // Save current threshold
-        $config = $this->valkey_glide->rawCommand('', 'CONFIG', 'GET', 'latency-monitor-threshold');
+        $config = $this->valkey_glide->rawCommand('CONFIG', 'GET', 'latency-monitor-threshold');
         $prevThreshold = $config['latency-monitor-threshold'] ?? '0';
 
         // Reset existing latency data
         $this->valkey_glide->latencyReset();
 
         // Set threshold to 1ms so any command triggers a spike
-        $this->valkey_glide->rawCommand('', 'CONFIG', 'SET', 'latency-monitor-threshold', '1');
+        $this->valkey_glide->rawCommand('CONFIG', 'SET', 'latency-monitor-threshold', '1');
 
         try {
             // Trigger a latency spike using DEBUG SLEEP
-            $this->valkey_glide->rawCommand('', 'DEBUG', 'SLEEP', '0.05');
+            $this->valkey_glide->rawCommand('DEBUG', 'SLEEP', '0.05');
         } finally {
             // Restore original threshold
-            $this->valkey_glide->rawCommand('', 'CONFIG', 'SET', 'latency-monitor-threshold', $prevThreshold);
+            $this->valkey_glide->rawCommand('CONFIG', 'SET', 'latency-monitor-threshold', $prevThreshold);
         }
     }
 

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -2598,3 +2598,73 @@
    fun:*glide_ffi*create_client*
    ...
 }
+
+# Rustls TLS session ticket handling - not a real leak, memory held by async runtime
+{
+   rustls_tls13_new_session_ticket
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:*rustls*msgs*handshake*NewSessionTicketPayloadTls13*
+   ...
+}
+
+# Rustls TLS client session persistence - memory held until connection close
+{
+   rustls_client_session_common_new
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:*rustls*msgs*persist*ClientSessionCommon*new*
+   ...
+}
+
+# Rustls TLS certificate cloning during session ticket handling
+{
+   rustls_tls13_certificate_clone
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:*rustls_pki_types*CertificateDer*clone*
+   ...
+   fun:*rustls*client*tls13*ExpectTraffic*handle_new_ticket_impl*
+   ...
+}
+
+# Rustls TLS session cache key exchange hint
+{
+   rustls_client_session_cache_kx_hint
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:*rustls*client*handy*cache*ClientSessionMemoryCache*set_kx_hint*
+   ...
+}
+
+# Rustls TLS payload read during session handling
+{
+   rustls_payload_read_session
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:*rustls*msgs*base*PayloadU16*read*
+   ...
+   fun:*rustls*client*tls13*ExpectTraffic*handle_new_ticket_impl*
+   ...
+}
+
+# Rustls TLS client config builder allocation
+{
+   rustls_client_config_builder
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:*rustls*client*client_conn*ClientConfig*builder_with_protocol_versions*
+   ...
+}

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -2668,3 +2668,16 @@
    fun:*rustls*client*client_conn*ClientConfig*builder_with_protocol_versions*
    ...
 }
+
+# Rustls TLS session resumption cache allocation
+{
+   rustls_resumption_default
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:*rustls*client*client_conn*Resumption*default*
+   ...
+   fun:*redis*connection*create_rustls_config*
+   ...
+}

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -2522,6 +2522,40 @@ class ValkeyGlide
     public function memoryStats(): ValkeyGlide|array|false;
 
     /**
+     * Returns the latency spike time series for the specified event.
+     *
+     * @param string $event The name of the event to get latency history for.
+     *
+     * @return ValkeyGlide|array|false  Returns an array of [timestamp, duration_ms] pairs,
+     *                                  or an empty array if the event does not exist.
+     *                                  Returns false on failure.
+     *
+     * @see https://valkey.io/commands/latency-history
+     */
+    public function latencyHistory(string $event): ValkeyGlide|array|false;
+
+    /**
+     * Reports the latest latency events logged by the server.
+     *
+     * @return ValkeyGlide|array|false  Returns an array of [event_name, timestamp, duration_ms, max_duration_ms]
+     *                                  entries for each event that has recorded latency spikes.
+     *                                  Returns false on failure.
+     *
+     * @see https://valkey.io/commands/latency-latest
+     */
+    public function latencyLatest(): ValkeyGlide|array|false;
+
+    /**
+     * Resets the latency spike time series for the specified events, or all events if none specified.
+     *
+     * @return ValkeyGlide|int|false  Returns the number of events that were reset.
+     *                                Returns false on failure.
+     *
+     * @see https://valkey.io/commands/latency-reset
+     */
+    public function latencyReset(string ...$events): ValkeyGlide|int|false;
+
+    /**
      * Enter into pipeline mode.
      *
      * Pipeline mode is the highest performance way to send many commands to ValkeyGlide

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -1018,6 +1018,18 @@ MEMORY_PURGE_METHOD_IMPL(ValkeyGlideCluster)
 MEMORY_STATS_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
+/* {{{ proto array ValkeyGlideCluster::latencyHistory(string event) */
+LATENCY_HISTORY_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto array ValkeyGlideCluster::latencyLatest() */
+LATENCY_LATEST_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto int ValkeyGlideCluster::latencyReset(string ...events) */
+LATENCY_RESET_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
 /* {{{ proto ValkeyGlideCluster::reset() */
 RESET_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -1030,6 +1030,10 @@ LATENCY_LATEST_METHOD_IMPL(ValkeyGlideCluster)
 LATENCY_RESET_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
+/* {{{ proto int ValkeyGlideCluster::latencyResetWithRoute(mixed route, string ...events) */
+LATENCY_RESET_WITH_ROUTE_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
 /* {{{ proto ValkeyGlideCluster::reset() */
 RESET_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1036,6 +1036,25 @@ class ValkeyGlideCluster
     public function memoryStats(mixed $route = null): ValkeyGlideCluster|array|false;
 
     /**
+     * @see ValkeyGlide::latencyHistory
+     *
+     * @param mixed $route Optional routing: 'allPrimaries', 'allNodes', 'randomNode', or a specific node address.
+     */
+    public function latencyHistory(string $event, mixed $route = null): ValkeyGlideCluster|array|false;
+
+    /**
+     * @see ValkeyGlide::latencyLatest
+     *
+     * @param mixed $route Optional routing: 'allPrimaries', 'allNodes', 'randomNode', or a specific node address.
+     */
+    public function latencyLatest(mixed $route = null): ValkeyGlideCluster|array|false;
+
+    /**
+     * @see ValkeyGlide::latencyReset
+     */
+    public function latencyReset(string ...$events): ValkeyGlideCluster|int|false;
+
+    /**
      * @see ValkeyGlide::psetex
      */
     public function psetex(string $key, int $timeout, string $value): ValkeyGlideCluster|bool;

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1058,7 +1058,6 @@ class ValkeyGlideCluster
      * Resets latency data with explicit routing.
      *
      * @param mixed  $route  Routing: 'allPrimaries', 'allNodes', 'randomNode', or a specific node address.
-     * @param string ...$events The event names to reset. If none specified, all events are reset.
      *
      * @return ValkeyGlideCluster|int|false Returns the number of events reset. Returns false on failure.
      *

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1055,6 +1055,18 @@ class ValkeyGlideCluster
     public function latencyReset(string ...$events): ValkeyGlideCluster|int|false;
 
     /**
+     * Resets latency data with explicit routing.
+     *
+     * @param mixed  $route  Routing: 'allPrimaries', 'allNodes', 'randomNode', or a specific node address.
+     * @param string ...$events The event names to reset. If none specified, all events are reset.
+     *
+     * @return ValkeyGlideCluster|int|false Returns the number of events reset. Returns false on failure.
+     *
+     * @see https://valkey.io/commands/latency-reset
+     */
+    public function latencyResetWithRoute(mixed $route, string ...$events): ValkeyGlideCluster|int|false;
+
+    /**
      * @see ValkeyGlide::psetex
      */
     public function psetex(string $key, int $timeout, string $value): ValkeyGlideCluster|bool;

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1039,6 +1039,13 @@ class ValkeyGlideCluster
      * @see ValkeyGlide::latencyHistory
      *
      * @param mixed $route Optional routing: 'allPrimaries', 'allNodes', 'randomNode', or a specific node address.
+     *                     If omitted, the command is routed to all primary nodes.
+     *
+     * @return ValkeyGlideCluster|array|false For a single-node route, returns a list of
+     *                                        [timestamp, duration] entries. For 'allPrimaries',
+     *                                        'allNodes', or the default route, returns an associative
+     *                                        array that maps each node address to its list of entries.
+     *                                        Returns false on failure.
      */
     public function latencyHistory(string $event, mixed $route = null): ValkeyGlideCluster|array|false;
 
@@ -1046,11 +1053,23 @@ class ValkeyGlideCluster
      * @see ValkeyGlide::latencyLatest
      *
      * @param mixed $route Optional routing: 'allPrimaries', 'allNodes', 'randomNode', or a specific node address.
+     *                     If omitted, the command is routed to all primary nodes.
+     *
+     * @return ValkeyGlideCluster|array|false For a single-node route, returns a list of
+     *                                        [event, timestamp, latest latency, maximum latency]
+     *                                        entries. For 'allPrimaries', 'allNodes', or the default
+     *                                        route, returns an associative array that maps each node
+     *                                        address to its list of entries. Returns false on failure.
      */
     public function latencyLatest(mixed $route = null): ValkeyGlideCluster|array|false;
 
     /**
-     * @see ValkeyGlide::latencyReset
+     * Resets latency data on all primary nodes.
+     *
+     * @return ValkeyGlideCluster|int|false The sum of the numbers of events reset on all primary nodes.
+     *                                      Returns false on failure.
+     *
+     * @see https://valkey.io/commands/latency-reset
      */
     public function latencyReset(string ...$events): ValkeyGlideCluster|int|false;
 
@@ -1059,7 +1078,9 @@ class ValkeyGlideCluster
      *
      * @param mixed  $route  Routing: 'allPrimaries', 'allNodes', 'randomNode', or a specific node address.
      *
-     * @return ValkeyGlideCluster|int|false Returns the number of events reset. Returns false on failure.
+     * @return ValkeyGlideCluster|int|false The number of events reset. When the route targets multiple
+     *                                      nodes, returns the sum of the per-node counts. Returns false
+     *                                      on failure.
      *
      * @see https://valkey.io/commands/latency-reset
      */

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -735,6 +735,17 @@ int execute_latency_reset_command(zval*             object,
         return 0;
     }
 
+    /* Validate all variadic arguments are strings */
+    for (int i = 0; i < args_count; i++) {
+        if (Z_TYPE(args[i]) != IS_STRING) {
+            zend_type_error(
+                "ValkeyGlide::latencyReset(): Argument #%d must be of type string, %s given",
+                i + 1,
+                zend_zval_value_name(&args[i]));
+            return 0;
+        }
+    }
+
     core_command_args_t core_args = {0};
     core_args.glide_client        = valkey_glide->glide_client;
     core_args.cmd_type            = LatencyReset;
@@ -745,22 +756,18 @@ int execute_latency_reset_command(zval*             object,
 
     if (args_count <= 12) {
         for (int i = 0; i < args_count; i++) {
-            if (Z_TYPE(args[i]) == IS_STRING) {
-                core_args.args[arg_idx].type                  = CORE_ARG_TYPE_STRING;
-                core_args.args[arg_idx].data.string_arg.value = Z_STRVAL(args[i]);
-                core_args.args[arg_idx].data.string_arg.len   = Z_STRLEN(args[i]);
-                arg_idx++;
-            }
+            core_args.args[arg_idx].type                  = CORE_ARG_TYPE_STRING;
+            core_args.args[arg_idx].data.string_arg.value = Z_STRVAL(args[i]);
+            core_args.args[arg_idx].data.string_arg.len   = Z_STRLEN(args[i]);
+            arg_idx++;
         }
     } else {
         core_arg_t* all = (core_arg_t*) ecalloc(args_count, sizeof(core_arg_t));
         for (int i = 0; i < args_count; i++) {
-            if (Z_TYPE(args[i]) == IS_STRING) {
-                all[arg_idx].type                  = CORE_ARG_TYPE_STRING;
-                all[arg_idx].data.string_arg.value = Z_STRVAL(args[i]);
-                all[arg_idx].data.string_arg.len   = Z_STRLEN(args[i]);
-                arg_idx++;
-            }
+            all[arg_idx].type                  = CORE_ARG_TYPE_STRING;
+            all[arg_idx].data.string_arg.value = Z_STRVAL(args[i]);
+            all[arg_idx].data.string_arg.len   = Z_STRLEN(args[i]);
+            arg_idx++;
         }
         core_args.all_args = all;
     }

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -724,7 +724,7 @@ static int latency_reset_build_and_execute(valkey_glide_object* valkey_glide,
                                            zval*                object) {
     int arg_idx = 0;
 
-    if (event_count <= 12) {
+    if (event_count <= CORE_ARGS_FIXED_MAX) {
         for (int i = 0; i < event_count; i++) {
             core_args->args[arg_idx].type                  = CORE_ARG_TYPE_STRING;
             core_args->args[arg_idx].data.string_arg.value = Z_STRVAL(events[i]);

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -778,7 +778,7 @@ int execute_latency_reset_command(zval*             object,
             zend_type_error(
                 "ValkeyGlide::latencyReset(): Argument #%d must be of type string, %s given",
                 i + 1,
-                zend_zval_value_name(&args[i]));
+                zend_zval_type_name(&args[i]));
             return 0;
         }
     }
@@ -824,7 +824,7 @@ int execute_latency_reset_with_route_command(zval*             object,
                 "ValkeyGlideCluster::latencyResetWithRoute(): Argument #%d must be of type "
                 "string, %s given",
                 i + 1,
-                zend_zval_value_name(&args[i]));
+                zend_zval_type_name(&args[i]));
             return 0;
         }
     }

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -620,6 +620,16 @@ static int process_memory_stats_result(CommandResponse* response,
         response, return_value, COMMAND_RESPONSE_ASSOSIATIVE_ARRAY_MAP, true);
 }
 
+static int process_cluster_array_result(CommandResponse* response,
+                                        void*            output,
+                                        zval*            return_value) {
+    if (!response || !return_value) {
+        return 0;
+    }
+    return command_response_to_zval(
+        response, return_value, COMMAND_RESPONSE_ASSOSIATIVE_ARRAY_MAP, true);
+}
+
 int execute_latency_history_command(zval*             object,
                                     int               argc,
                                     zval*             return_value,
@@ -670,7 +680,7 @@ int execute_latency_history_command(zval*             object,
     core_args.arg_count                     = 1;
 
     return execute_and_handle_batch(
-        valkey_glide, &core_args, process_core_array_result, return_value, object);
+        valkey_glide, &core_args, process_cluster_array_result, return_value, object);
 }
 
 int execute_latency_latest_command(zval*             object,
@@ -713,7 +723,7 @@ int execute_latency_latest_command(zval*             object,
     }
 
     return execute_and_handle_batch(
-        valkey_glide, &core_args, process_core_array_result, return_value, object);
+        valkey_glide, &core_args, process_cluster_array_result, return_value, object);
 }
 
 static int latency_reset_build_and_execute(valkey_glide_object* valkey_glide,

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -716,6 +716,43 @@ int execute_latency_latest_command(zval*             object,
         valkey_glide, &core_args, process_core_array_result, return_value, object);
 }
 
+static int latency_reset_build_and_execute(valkey_glide_object* valkey_glide,
+                                           core_command_args_t* core_args,
+                                           zval*                events,
+                                           int                  event_count,
+                                           zval*                return_value,
+                                           zval*                object) {
+    int arg_idx = 0;
+
+    if (event_count <= 12) {
+        for (int i = 0; i < event_count; i++) {
+            core_args->args[arg_idx].type                  = CORE_ARG_TYPE_STRING;
+            core_args->args[arg_idx].data.string_arg.value = Z_STRVAL(events[i]);
+            core_args->args[arg_idx].data.string_arg.len   = Z_STRLEN(events[i]);
+            arg_idx++;
+        }
+    } else {
+        core_arg_t* all = (core_arg_t*) ecalloc(event_count, sizeof(core_arg_t));
+        for (int i = 0; i < event_count; i++) {
+            all[arg_idx].type                  = CORE_ARG_TYPE_STRING;
+            all[arg_idx].data.string_arg.value = Z_STRVAL(events[i]);
+            all[arg_idx].data.string_arg.len   = Z_STRLEN(events[i]);
+            arg_idx++;
+        }
+        core_args->all_args = all;
+    }
+    core_args->arg_count = arg_idx;
+
+    int result = execute_and_handle_batch(
+        valkey_glide, core_args, process_core_int_result, return_value, object);
+
+    if (core_args->all_args) {
+        efree(core_args->all_args);
+    }
+
+    return result;
+}
+
 int execute_latency_reset_command(zval*             object,
                                   int               argc,
                                   zval*             return_value,
@@ -751,36 +788,56 @@ int execute_latency_reset_command(zval*             object,
     core_args.cmd_type            = LatencyReset;
     core_args.is_cluster          = is_cluster;
 
-    /* Add variadic event names as arguments */
-    int arg_idx = 0;
+    return latency_reset_build_and_execute(
+        valkey_glide, &core_args, args, args_count, return_value, object);
+}
 
-    if (args_count <= 12) {
-        for (int i = 0; i < args_count; i++) {
-            core_args.args[arg_idx].type                  = CORE_ARG_TYPE_STRING;
-            core_args.args[arg_idx].data.string_arg.value = Z_STRVAL(args[i]);
-            core_args.args[arg_idx].data.string_arg.len   = Z_STRLEN(args[i]);
-            arg_idx++;
-        }
-    } else {
-        core_arg_t* all = (core_arg_t*) ecalloc(args_count, sizeof(core_arg_t));
-        for (int i = 0; i < args_count; i++) {
-            all[arg_idx].type                  = CORE_ARG_TYPE_STRING;
-            all[arg_idx].data.string_arg.value = Z_STRVAL(args[i]);
-            all[arg_idx].data.string_arg.len   = Z_STRLEN(args[i]);
-            arg_idx++;
-        }
-        core_args.all_args = all;
-    }
-    core_args.arg_count = arg_idx;
+int execute_latency_reset_with_route_command(zval*             object,
+                                             int               argc,
+                                             zval*             return_value,
+                                             zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    zval*                args       = NULL;
+    int                  args_count = 0;
 
-    int result = execute_and_handle_batch(
-        valkey_glide, &core_args, process_core_int_result, return_value, object);
-
-    if (core_args.all_args) {
-        efree(core_args.all_args);
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
     }
 
-    return result;
+    if (zend_parse_method_parameters(argc, object, "O*", &object, ce, &args, &args_count) ==
+        FAILURE) {
+        return 0;
+    }
+
+    if (args_count < 1) {
+        zend_throw_exception(get_valkey_glide_exception_ce(),
+                             "latencyResetWithRoute() requires a route argument",
+                             0);
+        return 0;
+    }
+
+    /* Validate remaining args (events) are strings */
+    for (int i = 1; i < args_count; i++) {
+        if (Z_TYPE(args[i]) != IS_STRING) {
+            zend_type_error(
+                "ValkeyGlideCluster::latencyResetWithRoute(): Argument #%d must be of type "
+                "string, %s given",
+                i + 1,
+                zend_zval_value_name(&args[i]));
+            return 0;
+        }
+    }
+
+    core_command_args_t core_args = {0};
+    core_args.glide_client        = valkey_glide->glide_client;
+    core_args.cmd_type            = LatencyReset;
+    core_args.is_cluster          = 1;
+    core_args.has_route           = 1;
+    core_args.route_param         = &args[0];
+
+    return latency_reset_build_and_execute(
+        valkey_glide, &core_args, &args[1], args_count - 1, return_value, object);
 }
 
 int execute_memory_doctor_command(zval*             object,

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -620,6 +620,162 @@ static int process_memory_stats_result(CommandResponse* response,
         response, return_value, COMMAND_RESPONSE_ASSOSIATIVE_ARRAY_MAP, true);
 }
 
+int execute_latency_history_command(zval*             object,
+                                    int               argc,
+                                    zval*             return_value,
+                                    zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    char*                event      = NULL;
+    size_t               event_len  = 0;
+    zval*                args       = NULL;
+    int                  args_count = 0;
+    zend_bool            is_cluster = (ce == get_valkey_glide_cluster_ce());
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    core_command_args_t core_args = {0};
+    core_args.glide_client        = valkey_glide->glide_client;
+    core_args.cmd_type            = LatencyHistory;
+    core_args.is_cluster          = is_cluster;
+
+    if (is_cluster) {
+        if (zend_parse_method_parameters(
+                argc, object, "Os*", &object, ce, &event, &event_len, &args, &args_count) ==
+            FAILURE) {
+            return 0;
+        }
+        if (args_count > 1) {
+            zend_throw_exception(get_valkey_glide_exception_ce(),
+                                 "Expected at most 1 additional argument (route)",
+                                 0);
+            return 0;
+        }
+        if (args_count == 1) {
+            core_args.has_route   = 1;
+            core_args.route_param = &args[0];
+        }
+    } else {
+        if (zend_parse_method_parameters(argc, object, "Os", &object, ce, &event, &event_len) ==
+            FAILURE) {
+            return 0;
+        }
+    }
+
+    core_args.args[0].type                  = CORE_ARG_TYPE_STRING;
+    core_args.args[0].data.string_arg.value = event;
+    core_args.args[0].data.string_arg.len   = event_len;
+    core_args.arg_count                     = 1;
+
+    return execute_and_handle_batch(
+        valkey_glide, &core_args, process_core_array_result, return_value, object);
+}
+
+int execute_latency_latest_command(zval*             object,
+                                   int               argc,
+                                   zval*             return_value,
+                                   zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    zval*                args       = NULL;
+    int                  args_count = 0;
+    zend_bool            is_cluster = (ce == get_valkey_glide_cluster_ce());
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    core_command_args_t core_args = {0};
+    core_args.glide_client        = valkey_glide->glide_client;
+    core_args.cmd_type            = LatencyLatest;
+    core_args.is_cluster          = is_cluster;
+
+    if (is_cluster) {
+        if (zend_parse_method_parameters(argc, object, "O*", &object, ce, &args, &args_count) ==
+            FAILURE) {
+            return 0;
+        }
+        if (args_count > 1) {
+            zend_throw_exception(
+                get_valkey_glide_exception_ce(), "Expected at most 1 argument (route)", 0);
+            return 0;
+        }
+        if (args_count == 1) {
+            core_args.has_route   = 1;
+            core_args.route_param = &args[0];
+        }
+    } else {
+        if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
+            return 0;
+        }
+    }
+
+    return execute_and_handle_batch(
+        valkey_glide, &core_args, process_core_array_result, return_value, object);
+}
+
+int execute_latency_reset_command(zval*             object,
+                                  int               argc,
+                                  zval*             return_value,
+                                  zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    zval*                args       = NULL;
+    int                  args_count = 0;
+    zend_bool            is_cluster = (ce == get_valkey_glide_cluster_ce());
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    if (zend_parse_method_parameters(argc, object, "O*", &object, ce, &args, &args_count) ==
+        FAILURE) {
+        return 0;
+    }
+
+    core_command_args_t core_args = {0};
+    core_args.glide_client        = valkey_glide->glide_client;
+    core_args.cmd_type            = LatencyReset;
+    core_args.is_cluster          = is_cluster;
+
+    /* Add variadic event names as arguments */
+    int arg_idx = 0;
+
+    if (args_count <= 12) {
+        for (int i = 0; i < args_count; i++) {
+            if (Z_TYPE(args[i]) == IS_STRING) {
+                core_args.args[arg_idx].type                  = CORE_ARG_TYPE_STRING;
+                core_args.args[arg_idx].data.string_arg.value = Z_STRVAL(args[i]);
+                core_args.args[arg_idx].data.string_arg.len   = Z_STRLEN(args[i]);
+                arg_idx++;
+            }
+        }
+    } else {
+        core_arg_t* all = (core_arg_t*) ecalloc(args_count, sizeof(core_arg_t));
+        for (int i = 0; i < args_count; i++) {
+            if (Z_TYPE(args[i]) == IS_STRING) {
+                all[arg_idx].type                  = CORE_ARG_TYPE_STRING;
+                all[arg_idx].data.string_arg.value = Z_STRVAL(args[i]);
+                all[arg_idx].data.string_arg.len   = Z_STRLEN(args[i]);
+                arg_idx++;
+            }
+        }
+        core_args.all_args = all;
+    }
+    core_args.arg_count = arg_idx;
+
+    int result = execute_and_handle_batch(
+        valkey_glide, &core_args, process_core_int_result, return_value, object);
+
+    if (core_args.all_args) {
+        efree(core_args.all_args);
+    }
+
+    return result;
+}
+
 int execute_memory_doctor_command(zval*             object,
                                   int               argc,
                                   zval*             return_value,

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -663,7 +663,7 @@ int execute_latency_history_command(zval*             object,
                                  0);
             return 0;
         }
-        if (args_count == 1) {
+        if (args_count == 1 && Z_TYPE(args[0]) != IS_NULL) {
             core_args.has_route   = 1;
             core_args.route_param = &args[0];
         }
@@ -712,7 +712,7 @@ int execute_latency_latest_command(zval*             object,
                 get_valkey_glide_exception_ce(), "Expected at most 1 argument (route)", 0);
             return 0;
         }
-        if (args_count == 1) {
+        if (args_count == 1 && Z_TYPE(args[0]) != IS_NULL) {
             core_args.has_route   = 1;
             core_args.route_param = &args[0];
         }
@@ -880,7 +880,7 @@ int execute_memory_doctor_command(zval*             object,
                                  0);
             return 0;
         }
-        if (args_count == 1) {
+        if (args_count == 1 && Z_TYPE(args[0]) != IS_NULL) {
             core_args.has_route   = 1;
             core_args.route_param = &args[0];
         }
@@ -924,7 +924,7 @@ int execute_memory_malloc_stats_command(zval*             object,
                                  0);
             return 0;
         }
-        if (args_count == 1) {
+        if (args_count == 1 && Z_TYPE(args[0]) != IS_NULL) {
             core_args.has_route   = 1;
             core_args.route_param = &args[0];
         }
@@ -965,7 +965,7 @@ int execute_memory_purge_command(zval* object, int argc, zval* return_value, zen
                                  0);
             return 0;
         }
-        if (args_count == 1) {
+        if (args_count == 1 && Z_TYPE(args[0]) != IS_NULL) {
             core_args.has_route   = 1;
             core_args.route_param = &args[0];
         }
@@ -1009,7 +1009,7 @@ int execute_memory_stats_command(zval* object, int argc, zval* return_value, zen
                                  0);
             return 0;
         }
-        if (args_count == 1) {
+        if (args_count == 1 && Z_TYPE(args[0]) != IS_NULL) {
             core_args.has_route   = 1;
             core_args.route_param = &args[0];
         }

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -222,6 +222,15 @@ int execute_client_unpause_command(zval*             object,
                                    int               argc,
                                    zval*             return_value,
                                    zend_class_entry* ce);
+int execute_latency_history_command(zval*             object,
+                                    int               argc,
+                                    zval*             return_value,
+                                    zend_class_entry* ce);
+int execute_latency_latest_command(zval*             object,
+                                   int               argc,
+                                   zval*             return_value,
+                                   zend_class_entry* ce);
+int execute_latency_reset_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_memory_doctor_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_memory_malloc_stats_command(zval*             object,
                                         int               argc,
@@ -516,6 +525,15 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
 
 #define REPLICAOF_METHOD_IMPL(class_name) \
     STANDARD_METHOD_IMPL(class_name, replicaof, execute_replicaof_command)
+
+#define LATENCY_HISTORY_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, latencyHistory, execute_latency_history_command)
+
+#define LATENCY_LATEST_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, latencyLatest, execute_latency_latest_command)
+
+#define LATENCY_RESET_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, latencyReset, execute_latency_reset_command)
 
 #define MEMORY_DOCTOR_METHOD_IMPL(class_name) \
     STANDARD_METHOD_IMPL(class_name, memoryDoctor, execute_memory_doctor_command)

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -231,6 +231,10 @@ int execute_latency_latest_command(zval*             object,
                                    zval*             return_value,
                                    zend_class_entry* ce);
 int execute_latency_reset_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_latency_reset_with_route_command(zval*             object,
+                                             int               argc,
+                                             zval*             return_value,
+                                             zend_class_entry* ce);
 int execute_memory_doctor_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_memory_malloc_stats_command(zval*             object,
                                         int               argc,
@@ -534,6 +538,10 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
 
 #define LATENCY_RESET_METHOD_IMPL(class_name) \
     STANDARD_METHOD_IMPL(class_name, latencyReset, execute_latency_reset_command)
+
+#define LATENCY_RESET_WITH_ROUTE_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(                                \
+        class_name, latencyResetWithRoute, execute_latency_reset_with_route_command)
 
 #define MEMORY_DOCTOR_METHOD_IMPL(class_name) \
     STANDARD_METHOD_IMPL(class_name, memoryDoctor, execute_memory_doctor_command)

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -1831,23 +1831,25 @@ void debug_print_core_args(core_command_args_t* args) {
                          args->key_len);
     VALKEY_LOG_DEBUG_FMT("debug_core_args", "  arg_count: %d", args->arg_count);
 
+    core_arg_t* arg_array = args->all_args ? args->all_args : args->args;
+
     for (int i = 0; i < args->arg_count; i++) {
-        VALKEY_LOG_DEBUG_FMT("debug_core_args", "  arg[%d]: type=%d", i, args->args[i].type);
-        switch (args->args[i].type) {
+        VALKEY_LOG_DEBUG_FMT("debug_core_args", "  arg[%d]: type=%d", i, arg_array[i].type);
+        switch (arg_array[i].type) {
             case CORE_ARG_TYPE_STRING:
                 VALKEY_LOG_DEBUG_FMT("debug_core_args",
                                      "    string: %.*s (len: %zu)",
-                                     (int) args->args[i].data.string_arg.len,
-                                     args->args[i].data.string_arg.value,
-                                     args->args[i].data.string_arg.len);
+                                     (int) arg_array[i].data.string_arg.len,
+                                     arg_array[i].data.string_arg.value,
+                                     arg_array[i].data.string_arg.len);
                 break;
             case CORE_ARG_TYPE_LONG:
                 VALKEY_LOG_DEBUG_FMT(
-                    "debug_core_args", "    long: %ld", args->args[i].data.long_arg.value);
+                    "debug_core_args", "    long: %ld", arg_array[i].data.long_arg.value);
                 break;
             case CORE_ARG_TYPE_DOUBLE:
                 VALKEY_LOG_DEBUG_FMT(
-                    "debug_core_args", "    double: %f", args->args[i].data.double_arg.value);
+                    "debug_core_args", "    double: %f", arg_array[i].data.double_arg.value);
                 break;
             default:
                 VALKEY_LOG_DEBUG("debug_core_args", "    (other type)");

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -201,6 +201,7 @@ int prepare_core_args(core_command_args_t* args,
         case DBSize:
         case Discard:
         case Exec:
+        case LatencyLatest:
         case MemoryDoctor:
         case MemoryMallocStats:
         case MemoryPurge:
@@ -321,6 +322,8 @@ int prepare_core_args(core_command_args_t* args,
         case FailOver:
         case FlushAll:
         case FlushDB:
+        case LatencyHistory:
+        case LatencyReset:
         case Migrate:
         case Ping:
         case ReplicaOf:

--- a/valkey_glide_core_common.h
+++ b/valkey_glide_core_common.h
@@ -105,7 +105,8 @@ typedef struct {
     zval*          raw_options; /* Raw PHP options array for complex parsing */
     size_t         key_len;
     core_options_t options;
-    core_arg_t     args[12]; /* Fixed arguments array - supports most commands */
+#define CORE_ARGS_FIXED_MAX 12
+    core_arg_t  args[CORE_ARGS_FIXED_MAX]; /* Fixed arguments array - supports most commands */
     core_arg_t* all_args; /* If non-NULL, use this dynamically allocated array instead of args[] */
     enum RequestType cmd_type;
     int              arg_count;

--- a/valkey_z_php_methods.c
+++ b/valkey_z_php_methods.c
@@ -859,6 +859,18 @@ MEMORY_PURGE_METHOD_IMPL(ValkeyGlide)
 MEMORY_STATS_METHOD_IMPL(ValkeyGlide)
 /* }}} */
 
+/* {{{ proto array ValkeyGlide::latencyHistory(string event) */
+LATENCY_HISTORY_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto array ValkeyGlide::latencyLatest() */
+LATENCY_LATEST_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto int ValkeyGlide::latencyReset(string ...events) */
+LATENCY_RESET_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
 /* {{{ proto bool ValkeyGlide::reset() */
 RESET_METHOD_IMPL(ValkeyGlide)
 /* }}} */


### PR DESCRIPTION
### Summary

Implement LATENCY HISTORY, LATENCY LATEST, and LATENCY RESET commands for both standalone and cluster clients.

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide-php/issues/236

### Features / Behaviour Changes

- latencyHistory(string $event): array|false — Returns latency spike time series for the specified event as an array of [timestamp, duration_ms] pairs. Returns 
empty array if event does not exist.
- latencyLatest(): array|false — Reports the latest latency events as an array of [event_name, timestamp, duration_ms, max_duration_ms] entries.
- latencyReset(string ...$events): int|false — Resets latency data for specified events (or all events if none specified). Returns the number of events reset.
- All three commands are available on both standalone (ValkeyGlide) and cluster (ValkeyGlideCluster) clients.

### Implementation

- Added execute_latency_history_command(), execute_latency_latest_command(), and execute_latency_reset_command() in valkey_glide_commands.c
- All use STANDARD_METHOD_IMPL macro pattern
- LatencyLatest registered as zero-arg operation, LatencyHistory/LatencyReset as message operations in valkey_glide_core_common.c
- Uses process_core_array_result for history/latest and process_core_int_result for reset
- Cluster stubs use @see only per review conventions

### Limitations

- PHPRedis does not have dedicated latency methods, so there is no PHPRedis signature to match. The API follows Valkey command semantics directly.
- Tests use rawCommand for CONFIG GET/SET to trigger latency spikes, as config() is not yet available on the cluster client. Issue link: https://github.com/valkey-io/valkey-glide-php/issues/284

### Testing

Tests run in both standalone and cluster mode (inherited).

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.