### PR TITLE
Implement MEMORY DOCTOR, MALLOC-STATS, PURGE, and STATS commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* Add `MEMORY DOCTOR`, `MEMORY MALLOC-STATS`, `MEMORY PURGE`, and `MEMORY STATS` commands for standalone and cluster clients ([#285](https://github.com/valkey-io/valkey-glide-php/pull/285))
 * Add `MIGRATE` command for standalone and cluster clients ([#276](https://github.com/valkey-io/valkey-glide-php/pull/276))
 * Add `CLIENT PAUSE` and `CLIENT UNPAUSE` commands for standalone and cluster clients ([#274](https://github.com/valkey-io/valkey-glide-php/pull/274))
 * Add `RESET` command for standalone and cluster clients ([#273](https://github.com/valkey-io/valkey-glide-php/pull/273))

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -863,6 +863,37 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         });
     }
 
+    public function testMemoryDoctorWithRoute()
+    {
+        // Random node returns a single string
+        $result = $this->valkey_glide->memoryDoctor('randomNode');
+        $this->assertIsString($result);
+        $this->assertGT(0, strlen($result));
+    }
+
+    public function testMemoryMallocStatsWithRoute()
+    {
+        // Random node returns a single string
+        $result = $this->valkey_glide->memoryMallocStats('randomNode');
+        $this->assertIsString($result);
+        $this->assertGT(0, strlen($result));
+    }
+
+    public function testMemoryPurgeWithRoute()
+    {
+        // Random node returns scalar true
+        $result = $this->valkey_glide->memoryPurge('randomNode');
+        $this->assertTrue($result);
+    }
+
+    public function testMemoryStatsWithRoute()
+    {
+        $result = $this->valkey_glide->memoryStats('randomNode');
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('peak.allocated', $result);
+        $this->assertGT(0, $result['peak.allocated']);
+    }
+
     public function testReset()
     {
         $key = '{reset_test}_' . uniqid();

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -822,20 +822,14 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     public function testMemoryPurge()
     {
         $result = $this->valkey_glide->memoryPurge();
-        // Cluster returns per-node array: {node_address => bool}
-        $this->assertIsArray($result);
-        $this->assertGT(0, count($result));
-        foreach ($result as $nodeAddress => $nodeResult) {
-            $this->assertIsString($nodeAddress);
-            $this->assertTrue($nodeResult);
-        }
+        $this->assertTrue($result);
     }
 
     public function testMemoryPurgeWithReplyLiteral()
     {
         $this->withOptReplyLiteralEnabled(function () {
             $result = $this->valkey_glide->memoryPurge();
-            // Cluster returns per-node array: {node_address => "OK"}
+            // Cluster with OPT_REPLY_LITERAL returns per-node array: {node_address => "OK"}
             $this->assertIsArray($result);
             $this->assertGT(0, count($result));
             foreach ($result as $nodeAddress => $nodeResult) {

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -819,6 +819,32 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->valkey_glide->del($key);
     }
 
+    public function testMemoryPurge()
+    {
+        $result = $this->valkey_glide->memoryPurge();
+        // Cluster returns per-node array: {node_address => bool}
+        $this->assertIsArray($result);
+        $this->assertGT(0, count($result));
+        foreach ($result as $nodeAddress => $nodeResult) {
+            $this->assertIsString($nodeAddress);
+            $this->assertTrue($nodeResult);
+        }
+    }
+
+    public function testMemoryPurgeWithReplyLiteral()
+    {
+        $this->withOptReplyLiteralEnabled(function () {
+            $result = $this->valkey_glide->memoryPurge();
+            // Cluster returns per-node array: {node_address => "OK"}
+            $this->assertIsArray($result);
+            $this->assertGT(0, count($result));
+            foreach ($result as $nodeAddress => $nodeResult) {
+                $this->assertIsString($nodeAddress);
+                $this->assertEquals('OK', $nodeResult);
+            }
+        });
+    }
+
     public function testReset()
     {
         $key = '{reset_test}_' . uniqid();

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -829,13 +829,7 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     {
         $this->withOptReplyLiteralEnabled(function () {
             $result = $this->valkey_glide->memoryPurge();
-            // Cluster with OPT_REPLY_LITERAL returns per-node array: {node_address => "OK"}
-            $this->assertIsArray($result);
-            $this->assertGT(0, count($result));
-            foreach ($result as $nodeAddress => $nodeResult) {
-                $this->assertIsString($nodeAddress);
-                $this->assertEquals('OK', $nodeResult);
-            }
+            $this->assertEquals('OK', $result);
         });
     }
 

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -774,6 +774,51 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->assertTrue($result[1]);
     }
 
+    public function testMemoryDoctor()
+    {
+        $result = $this->valkey_glide->memoryDoctor();
+        // Cluster returns per-node array: {node_address => report_string}
+        $this->assertIsArray($result);
+        $this->assertGT(0, count($result));
+        foreach ($result as $nodeAddress => $report) {
+            $this->assertIsString($nodeAddress);
+            $this->assertIsString($report);
+            $this->assertGT(0, strlen($report));
+        }
+    }
+
+    public function testMemoryMallocStats()
+    {
+        $result = $this->valkey_glide->memoryMallocStats();
+        // Cluster returns per-node array: {node_address => stats_string}
+        $this->assertIsArray($result);
+        $this->assertGT(0, count($result));
+        foreach ($result as $nodeAddress => $stats) {
+            $this->assertIsString($nodeAddress);
+            $this->assertIsString($stats);
+            $this->assertGT(0, strlen($stats));
+        }
+    }
+
+    public function testMemoryStats()
+    {
+        $key = '{memory_stats_test}_' . uniqid();
+        $this->valkey_glide->set($key, 'value');
+
+        $result = $this->valkey_glide->memoryStats();
+        // Cluster returns per-node array: {node_address => stats_array}
+        $this->assertIsArray($result);
+        $this->assertGT(0, count($result));
+        foreach ($result as $nodeAddress => $stats) {
+            $this->assertIsString($nodeAddress);
+            $this->assertIsArray($stats);
+            $this->assertGT(0, $stats['peak.allocated']);
+            $this->assertGT(0, $stats['total.allocated']);
+        }
+
+        $this->valkey_glide->del($key);
+    }
+
     public function testReset()
     {
         $key = '{reset_test}_' . uniqid();

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -3197,6 +3197,77 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         ];
     }
 
+
+    public function testMemoryDoctor()
+    {
+        $result = $this->valkey_glide->memoryDoctor();
+        $this->assertIsString($result);
+        $this->assertGT(0, strlen($result));
+    }
+
+    public function testMemoryMallocStats()
+    {
+        $result = $this->valkey_glide->memoryMallocStats();
+        $this->assertIsString($result);
+        $this->assertGT(0, strlen($result));
+    }
+
+    public function testMemoryPurge()
+    {
+        $result = $this->valkey_glide->memoryPurge();
+        $this->assertTrue($result);
+    }
+
+    public function testMemoryPurgeWithReplyLiteral()
+    {
+        $this->withOptReplyLiteralEnabled(function () {
+            $result = $this->valkey_glide->memoryPurge();
+            $this->assertEquals('OK', $result);
+        });
+    }
+
+    public function testMemoryStats()
+    {
+        // Write a key to ensure stats have data
+        $key = '{memory_stats_test}_' . $this->createRandomString();
+        $this->valkey_glide->set($key, 'value');
+
+        $stats = $this->valkey_glide->memoryStats();
+        $this->assertIsArray($stats);
+
+        // Verify key fields exist and have valid values
+        $this->assertGT(0, $stats['peak.allocated']);
+        $this->assertGT(0, $stats['total.allocated']);
+        $this->assertGT(0, $stats['startup.allocated']);
+        $this->assertGT(0, $stats['overhead.total']);
+        $this->assertGTE(0, $stats['keys.count']);
+        $this->assertGTE(0, $stats['dataset.bytes']);
+        $this->assertGTE(0, $stats['replication.backlog']);
+        $this->assertGTE(0, $stats['clients.normal']);
+
+        $this->valkey_glide->del($key);
+    }
+
+    public function testMemoryBatch()
+    {
+        if (!$this->havePipeline()) {
+            $this->markTestSkipped('Pipeline not supported');
+            return;
+        }
+
+        $this->valkey_glide->pipeline();
+        $this->valkey_glide->memoryDoctor();
+        $this->valkey_glide->memoryMallocStats();
+        $this->valkey_glide->memoryPurge();
+        $this->valkey_glide->memoryStats();
+        $result = $this->valkey_glide->exec();
+
+        $this->assertIsString($result[0]); // memoryDoctor
+        $this->assertIsString($result[1]); // memoryMallocStats
+        $this->assertTrue($result[2]);     // memoryPurge
+        $this->assertIsArray($result[3]);  // memoryStats
+    }
+
     public function testSave()
     {
         $this->waitForSaveNotInProgress();

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -3235,6 +3235,15 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->assertIsArray($stats);
 
         // Verify key fields exist and have valid values
+        $this->assertArrayHasKey('peak.allocated', $stats);
+        $this->assertArrayHasKey('total.allocated', $stats);
+        $this->assertArrayHasKey('startup.allocated', $stats);
+        $this->assertArrayHasKey('overhead.total', $stats);
+        $this->assertArrayHasKey('keys.count', $stats);
+        $this->assertArrayHasKey('dataset.bytes', $stats);
+        $this->assertArrayHasKey('replication.backlog', $stats);
+        $this->assertArrayHasKey('clients.normal', $stats);
+
         $this->assertGT(0, $stats['peak.allocated']);
         $this->assertGT(0, $stats['total.allocated']);
         $this->assertGT(0, $stats['startup.allocated']);

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -2457,7 +2457,7 @@ class ValkeyGlide
      * @see https://valkey.io/commands/memory-malloc-stats
      */
     public function memoryMallocStats(): ValkeyGlide|string|false;
-  
+
     /**
      * Makes the server a replica of the specified primary, or promotes it to a primary.
      *

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -2434,6 +2434,47 @@ class ValkeyGlide
     public function reset(): ValkeyGlide|bool|string;
 
     /**
+     * Returns a report about memory problems detected by the server.
+     *
+     * @return ValkeyGlide|string|false  Returns the memory diagnostic report string.
+     *                                   Returns false on failure.
+     *
+     * @see https://valkey.io/commands/memory-doctor
+     */
+    public function memoryDoctor(): ValkeyGlide|string|false;
+
+    /**
+     * Returns the internal statistics of the memory allocator.
+     *
+     * @return ValkeyGlide|string|false  Returns the memory allocator statistics string.
+     *                                   Returns false on failure.
+     *
+     * @see https://valkey.io/commands/memory-malloc-stats
+     */
+    public function memoryMallocStats(): ValkeyGlide|string|false;
+
+    /**
+     * Asks the server to reclaim memory from the allocator back to the operating system.
+     *
+     * @return ValkeyGlide|bool|string  Returns true on success, false on failure.
+     *                                  With OPT_REPLY_LITERAL enabled, returns "OK" on success,
+     *                                  false on failure.
+     *
+     * @see https://valkey.io/commands/memory-purge
+     */
+    public function memoryPurge(): ValkeyGlide|bool|string;
+
+    /**
+     * Returns detailed memory consumption statistics of the server.
+     *
+     * @return ValkeyGlide|array|false  Returns an associative array containing memory usage statistics.
+     *                                  Returns false on failure.
+     *
+     * @see https://valkey.io/commands/memory-stats
+     */
+    public function memoryStats(): ValkeyGlide|array|false;
+
+    /**
      * Enter into pipeline mode.
      *
      * Pipeline mode is the highest performance way to send many commands to ValkeyGlide

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -999,6 +999,22 @@ CLIENT_PAUSE_METHOD_IMPL(ValkeyGlideCluster)
 CLIENT_UNPAUSE_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
+/* {{{ proto string ValkeyGlideCluster::memoryDoctor() */
+MEMORY_DOCTOR_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto string ValkeyGlideCluster::memoryMallocStats() */
+MEMORY_MALLOC_STATS_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto bool ValkeyGlideCluster::memoryPurge() */
+MEMORY_PURGE_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
+/* {{{ proto array ValkeyGlideCluster::memoryStats() */
+MEMORY_STATS_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
 /* {{{ proto ValkeyGlideCluster::reset() */
 RESET_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1009,23 +1009,31 @@ class ValkeyGlideCluster
 
     /**
      * @see ValkeyGlide::memoryDoctor
+     *
+     * @param mixed $route Optional routing: 'allPrimaries', 'allNodes', 'randomNode', or a specific node address.
      */
-    public function memoryDoctor(): ValkeyGlideCluster|string|array|false;
+    public function memoryDoctor(mixed $route = null): ValkeyGlideCluster|string|array|false;
 
     /**
      * @see ValkeyGlide::memoryMallocStats
+     *
+     * @param mixed $route Optional routing: 'allPrimaries', 'allNodes', 'randomNode', or a specific node address.
      */
-    public function memoryMallocStats(): ValkeyGlideCluster|string|array|false;
+    public function memoryMallocStats(mixed $route = null): ValkeyGlideCluster|string|array|false;
 
     /**
      * @see ValkeyGlide::memoryPurge
+     *
+     * @param mixed $route Optional routing: 'allPrimaries', 'allNodes', 'randomNode', or a specific node address.
      */
-    public function memoryPurge(): ValkeyGlideCluster|bool|array|string;
+    public function memoryPurge(mixed $route = null): ValkeyGlideCluster|bool|array|string;
 
     /**
      * @see ValkeyGlide::memoryStats
+     *
+     * @param mixed $route Optional routing: 'allPrimaries', 'allNodes', 'randomNode', or a specific node address.
      */
-    public function memoryStats(): ValkeyGlideCluster|array|false;
+    public function memoryStats(mixed $route = null): ValkeyGlideCluster|array|false;
 
     /**
      * @see ValkeyGlide::psetex

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1003,6 +1003,26 @@ class ValkeyGlideCluster
     public function reset(): ValkeyGlideCluster|bool|string;
 
     /**
+     * @see ValkeyGlide::memoryDoctor
+     */
+    public function memoryDoctor(): ValkeyGlideCluster|string|false;
+
+    /**
+     * @see ValkeyGlide::memoryMallocStats
+     */
+    public function memoryMallocStats(): ValkeyGlideCluster|string|false;
+
+    /**
+     * @see ValkeyGlide::memoryPurge
+     */
+    public function memoryPurge(): ValkeyGlideCluster|bool|string;
+
+    /**
+     * @see ValkeyGlide::memoryStats
+     */
+    public function memoryStats(): ValkeyGlideCluster|array|false;
+
+    /**
      * @see ValkeyGlide::psetex
      */
     public function psetex(string $key, int $timeout, string $value): ValkeyGlideCluster|bool;

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1020,7 +1020,7 @@ class ValkeyGlideCluster
     /**
      * @see ValkeyGlide::memoryPurge
      */
-    public function memoryPurge(): ValkeyGlideCluster|bool|string;
+    public function memoryPurge(): ValkeyGlideCluster|bool|array|string;
 
     /**
      * @see ValkeyGlide::memoryStats

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1010,12 +1010,12 @@ class ValkeyGlideCluster
     /**
      * @see ValkeyGlide::memoryDoctor
      */
-    public function memoryDoctor(): ValkeyGlideCluster|string|false;
+    public function memoryDoctor(): ValkeyGlideCluster|string|array|false;
 
     /**
      * @see ValkeyGlide::memoryMallocStats
      */
-    public function memoryMallocStats(): ValkeyGlideCluster|string|false;
+    public function memoryMallocStats(): ValkeyGlideCluster|string|array|false;
 
     /**
      * @see ValkeyGlide::memoryPurge

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -644,7 +644,13 @@ int execute_memory_doctor_command(zval*             object,
             FAILURE) {
             return 0;
         }
-        if (args_count > 0) {
+        if (args_count > 1) {
+            zend_throw_exception(get_valkey_glide_exception_ce(),
+                                 "Expected at most 1 argument (route), got extra arguments",
+                                 0);
+            return 0;
+        }
+        if (args_count == 1) {
             core_args.has_route   = 1;
             core_args.route_param = &args[0];
         }
@@ -682,7 +688,13 @@ int execute_memory_malloc_stats_command(zval*             object,
             FAILURE) {
             return 0;
         }
-        if (args_count > 0) {
+        if (args_count > 1) {
+            zend_throw_exception(get_valkey_glide_exception_ce(),
+                                 "Expected at most 1 argument (route), got extra arguments",
+                                 0);
+            return 0;
+        }
+        if (args_count == 1) {
             core_args.has_route   = 1;
             core_args.route_param = &args[0];
         }
@@ -717,7 +729,13 @@ int execute_memory_purge_command(zval* object, int argc, zval* return_value, zen
             FAILURE) {
             return 0;
         }
-        if (args_count > 0) {
+        if (args_count > 1) {
+            zend_throw_exception(get_valkey_glide_exception_ce(),
+                                 "Expected at most 1 argument (route), got extra arguments",
+                                 0);
+            return 0;
+        }
+        if (args_count == 1) {
             core_args.has_route   = 1;
             core_args.route_param = &args[0];
         }
@@ -755,7 +773,13 @@ int execute_memory_stats_command(zval* object, int argc, zval* return_value, zen
             FAILURE) {
             return 0;
         }
-        if (args_count > 0) {
+        if (args_count > 1) {
+            zend_throw_exception(get_valkey_glide_exception_ce(),
+                                 "Expected at most 1 argument (route), got extra arguments",
+                                 0);
+            return 0;
+        }
+        if (args_count == 1) {
             core_args.has_route   = 1;
             core_args.route_param = &args[0];
         }

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -610,6 +610,16 @@ int execute_save_command(zval* object, int argc, zval* return_value, zend_class_
     return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
 }
 
+static int process_memory_stats_result(CommandResponse* response,
+                                       void*            output,
+                                       zval*            return_value) {
+    if (!response || !return_value) {
+        return 0;
+    }
+    return command_response_to_zval(
+        response, return_value, COMMAND_RESPONSE_ASSOSIATIVE_ARRAY_MAP, true);
+}
+
 int execute_memory_doctor_command(zval*             object,
                                   int               argc,
                                   zval*             return_value,
@@ -700,7 +710,7 @@ int execute_memory_stats_command(zval* object, int argc, zval* return_value, zen
     core_args.is_cluster          = (ce == get_valkey_glide_cluster_ce());
 
     return execute_and_handle_batch(
-        valkey_glide, &core_args, process_core_array_result, return_value, object);
+        valkey_glide, &core_args, process_memory_stats_result, return_value, object);
 }
 
 /* Execute a RESET command using the Valkey Glide client */

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -610,6 +610,99 @@ int execute_save_command(zval* object, int argc, zval* return_value, zend_class_
     return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
 }
 
+int execute_memory_doctor_command(zval*             object,
+                                  int               argc,
+                                  zval*             return_value,
+                                  zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
+        return 0;
+    }
+
+    core_command_args_t core_args = {0};
+    core_args.glide_client        = valkey_glide->glide_client;
+    core_args.cmd_type            = MemoryDoctor;
+    core_args.is_cluster          = (ce == get_valkey_glide_cluster_ce());
+
+    return execute_and_handle_batch(
+        valkey_glide, &core_args, process_core_string_result, return_value, object);
+}
+
+int execute_memory_malloc_stats_command(zval*             object,
+                                        int               argc,
+                                        zval*             return_value,
+                                        zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
+        return 0;
+    }
+
+    core_command_args_t core_args = {0};
+    core_args.glide_client        = valkey_glide->glide_client;
+    core_args.cmd_type            = MemoryMallocStats;
+    core_args.is_cluster          = (ce == get_valkey_glide_cluster_ce());
+
+    return execute_and_handle_batch(
+        valkey_glide, &core_args, process_core_string_result, return_value, object);
+}
+
+int execute_memory_purge_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
+        return 0;
+    }
+
+    core_command_args_t core_args = {0};
+    core_args.glide_client        = valkey_glide->glide_client;
+    core_args.cmd_type            = MemoryPurge;
+    core_args.is_cluster          = (ce == get_valkey_glide_cluster_ce());
+
+    z_result_processor_t processor = valkey_glide->opt_reply_literal
+                                         ? process_core_status_string_result
+                                         : process_core_status_bool_result;
+
+    return execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
+}
+
+int execute_memory_stats_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
+        return 0;
+    }
+
+    core_command_args_t core_args = {0};
+    core_args.glide_client        = valkey_glide->glide_client;
+    core_args.cmd_type            = MemoryStats;
+    core_args.is_cluster          = (ce == get_valkey_glide_cluster_ce());
+
+    return execute_and_handle_batch(
+        valkey_glide, &core_args, process_core_array_result, return_value, object);
+}
+
 /* Execute a RESET command using the Valkey Glide client */
 int execute_reset_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
     valkey_glide_object* valkey_glide;

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -625,20 +625,34 @@ int execute_memory_doctor_command(zval*             object,
                                   zval*             return_value,
                                   zend_class_entry* ce) {
     valkey_glide_object* valkey_glide;
+    zval*                args       = NULL;
+    int                  args_count = 0;
+    zend_bool            is_cluster = (ce == get_valkey_glide_cluster_ce());
 
     valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
     if (!valkey_glide || !valkey_glide->glide_client) {
         return 0;
     }
 
-    if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
-        return 0;
-    }
-
     core_command_args_t core_args = {0};
     core_args.glide_client        = valkey_glide->glide_client;
     core_args.cmd_type            = MemoryDoctor;
-    core_args.is_cluster          = (ce == get_valkey_glide_cluster_ce());
+    core_args.is_cluster          = is_cluster;
+
+    if (is_cluster) {
+        if (zend_parse_method_parameters(argc, object, "O*", &object, ce, &args, &args_count) ==
+            FAILURE) {
+            return 0;
+        }
+        if (args_count > 0) {
+            core_args.has_route   = 1;
+            core_args.route_param = &args[0];
+        }
+    } else {
+        if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
+            return 0;
+        }
+    }
 
     return execute_and_handle_batch(
         valkey_glide, &core_args, process_core_status_string_result, return_value, object);
@@ -649,20 +663,34 @@ int execute_memory_malloc_stats_command(zval*             object,
                                         zval*             return_value,
                                         zend_class_entry* ce) {
     valkey_glide_object* valkey_glide;
+    zval*                args       = NULL;
+    int                  args_count = 0;
+    zend_bool            is_cluster = (ce == get_valkey_glide_cluster_ce());
 
     valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
     if (!valkey_glide || !valkey_glide->glide_client) {
         return 0;
     }
 
-    if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
-        return 0;
-    }
-
     core_command_args_t core_args = {0};
     core_args.glide_client        = valkey_glide->glide_client;
     core_args.cmd_type            = MemoryMallocStats;
-    core_args.is_cluster          = (ce == get_valkey_glide_cluster_ce());
+    core_args.is_cluster          = is_cluster;
+
+    if (is_cluster) {
+        if (zend_parse_method_parameters(argc, object, "O*", &object, ce, &args, &args_count) ==
+            FAILURE) {
+            return 0;
+        }
+        if (args_count > 0) {
+            core_args.has_route   = 1;
+            core_args.route_param = &args[0];
+        }
+    } else {
+        if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
+            return 0;
+        }
+    }
 
     return execute_and_handle_batch(
         valkey_glide, &core_args, process_core_status_string_result, return_value, object);
@@ -670,20 +698,34 @@ int execute_memory_malloc_stats_command(zval*             object,
 
 int execute_memory_purge_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
     valkey_glide_object* valkey_glide;
+    zval*                args       = NULL;
+    int                  args_count = 0;
+    zend_bool            is_cluster = (ce == get_valkey_glide_cluster_ce());
 
     valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
     if (!valkey_glide || !valkey_glide->glide_client) {
         return 0;
     }
 
-    if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
-        return 0;
-    }
-
     core_command_args_t core_args = {0};
     core_args.glide_client        = valkey_glide->glide_client;
     core_args.cmd_type            = MemoryPurge;
-    core_args.is_cluster          = (ce == get_valkey_glide_cluster_ce());
+    core_args.is_cluster          = is_cluster;
+
+    if (is_cluster) {
+        if (zend_parse_method_parameters(argc, object, "O*", &object, ce, &args, &args_count) ==
+            FAILURE) {
+            return 0;
+        }
+        if (args_count > 0) {
+            core_args.has_route   = 1;
+            core_args.route_param = &args[0];
+        }
+    } else {
+        if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
+            return 0;
+        }
+    }
 
     z_result_processor_t processor = valkey_glide->opt_reply_literal
                                          ? process_core_status_string_result
@@ -694,20 +736,34 @@ int execute_memory_purge_command(zval* object, int argc, zval* return_value, zen
 
 int execute_memory_stats_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
     valkey_glide_object* valkey_glide;
+    zval*                args       = NULL;
+    int                  args_count = 0;
+    zend_bool            is_cluster = (ce == get_valkey_glide_cluster_ce());
 
     valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
     if (!valkey_glide || !valkey_glide->glide_client) {
         return 0;
     }
 
-    if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
-        return 0;
-    }
-
     core_command_args_t core_args = {0};
     core_args.glide_client        = valkey_glide->glide_client;
     core_args.cmd_type            = MemoryStats;
-    core_args.is_cluster          = (ce == get_valkey_glide_cluster_ce());
+    core_args.is_cluster          = is_cluster;
+
+    if (is_cluster) {
+        if (zend_parse_method_parameters(argc, object, "O*", &object, ce, &args, &args_count) ==
+            FAILURE) {
+            return 0;
+        }
+        if (args_count > 0) {
+            core_args.has_route   = 1;
+            core_args.route_param = &args[0];
+        }
+    } else {
+        if (zend_parse_method_parameters(argc, object, "O", &object, ce) == FAILURE) {
+            return 0;
+        }
+    }
 
     return execute_and_handle_batch(
         valkey_glide, &core_args, process_memory_stats_result, return_value, object);

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -212,6 +212,13 @@ int execute_client_unpause_command(zval*             object,
                                    int               argc,
                                    zval*             return_value,
                                    zend_class_entry* ce);
+int execute_memory_doctor_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_memory_malloc_stats_command(zval*             object,
+                                        int               argc,
+                                        zval*             return_value,
+                                        zend_class_entry* ce);
+int execute_memory_purge_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_memory_stats_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_reset_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_save_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_time_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
@@ -495,6 +502,18 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
     STANDARD_METHOD_IMPL(class_name, bgRewriteAof, execute_bgrewriteaof_command)
 
 #define SAVE_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, save, execute_save_command)
+
+#define MEMORY_DOCTOR_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, memoryDoctor, execute_memory_doctor_command)
+
+#define MEMORY_MALLOC_STATS_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, memoryMallocStats, execute_memory_malloc_stats_command)
+
+#define MEMORY_PURGE_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, memoryPurge, execute_memory_purge_command)
+
+#define MEMORY_STATS_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, memoryStats, execute_memory_stats_command)
 
 #define RESET_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, reset, execute_reset_command)
 

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -201,6 +201,10 @@ int prepare_core_args(core_command_args_t* args,
         case DBSize:
         case Discard:
         case Exec:
+        case MemoryDoctor:
+        case MemoryMallocStats:
+        case MemoryPurge:
+        case MemoryStats:
         case RandomKey:
         case Reset:
         case Role:

--- a/valkey_z_php_methods.c
+++ b/valkey_z_php_methods.c
@@ -835,6 +835,22 @@ CLIENT_PAUSE_METHOD_IMPL(ValkeyGlide)
 CLIENT_UNPAUSE_METHOD_IMPL(ValkeyGlide)
 /* }}} */
 
+/* {{{ proto string ValkeyGlide::memoryDoctor() */
+MEMORY_DOCTOR_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto string ValkeyGlide::memoryMallocStats() */
+MEMORY_MALLOC_STATS_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto bool ValkeyGlide::memoryPurge() */
+MEMORY_PURGE_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
+/* {{{ proto array ValkeyGlide::memoryStats() */
+MEMORY_STATS_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
 /* {{{ proto bool ValkeyGlide::reset() */
 RESET_METHOD_IMPL(ValkeyGlide)
 /* }}} */


### PR DESCRIPTION
### Summary

Implement the `MEMORY DOCTOR`, `MEMORY MALLOC-STATS`, `MEMORY PURGE`, and `MEMORY STATS` commands for standalone and cluster clients.

### Issue link

This Pull Request is linked to issue: #236

### Features / Behaviour Changes

Adds four new memory management commands:

| Method | Description | Return Type |
|--------|-------------|-------------|
| `memoryDoctor()` | Returns a report about memory problems detected by the server | `string\|false` |
| `memoryMallocStats()` | Returns internal statistics of the memory allocator | `string\|false` |
| `memoryPurge()` | Asks the server to reclaim memory from the allocator | `bool\|string` (OK with OPT_REPLY_LITERAL) |
| `memoryStats()` | Returns detailed memory consumption statistics | `array\|false` |

### Implementation

- Added command implementations in `valkey_glide_commands.c` following the established zero-arg command pattern
- Registered commands for both `ValkeyGlide` and `ValkeyGlideCluster` classes
- Added PHP stubs with documentation in `valkey_glide.stub.php` and `valkey_glide_cluster.stub.php`
- Added `MemoryDoctor`, `MemoryMallocStats`, `MemoryPurge`, `MemoryStats` to the zero-arg dispatch in `valkey_glide_core_common.c`

### Limitations

None.

### Testing

- Added unit tests for all four commands (standalone and cluster with per-node response overrides)
- Added `OPT_REPLY_LITERAL` test for `memoryPurge` (standalone and cluster)

### Checklist

Before submitting the PR make sure the following are checked:
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release