### PR TITLE
Update dependencies in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,11 @@ Before installing Valkey GLIDE PHP extension, ensure you have the following depe
 - Git
 - pkg-config
 - protoc (protobuf compiler) >= v3.20.0
+- protobuf-c library and compiler (`libprotobuf-c-dev`, `protobuf-c-compiler`)
+- libffi development headers (`libffi-dev`)
 - openssl and openssl-dev
 - rustup (Rust toolchain)
+- cbindgen (`cargo install cbindgen`)
 - php-bcmath (Protobuf PHP dependency, needed only for testing)
 
 #### Installing Dependencies
@@ -76,20 +79,24 @@ Before installing Valkey GLIDE PHP extension, ensure you have the following depe
 
 ```bash
 sudo apt update -y
-sudo apt install -y php-dev php-cli git gcc make autotools-dev pkg-config openssl libssl-dev unzip php-bcmath
+sudo apt install -y php-dev php-cli git gcc make autotools-dev pkg-config openssl libssl-dev unzip php-bcmath libprotobuf-c-dev protobuf-c-compiler libffi-dev
 # Install rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
+# Install cbindgen
+cargo install cbindgen
 ```
 
 **CentOS/RHEL:**
 
 ```bash
 sudo yum update -y
-sudo yum install -y php-devel php-cli git gcc make pkgconfig openssl openssl-devel unzip php-bcmath
+sudo yum install -y php-devel php-cli git gcc make pkgconfig openssl openssl-devel unzip php-bcmath protobuf-c-devel protobuf-c-compiler libffi-devel
 # Install rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
+# Install cbindgen
+cargo install cbindgen
 ```
 
 **macOS:**

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Before installing Valkey GLIDE PHP extension, ensure you have the following depe
 - Build tools (`gcc`, `make`, `autotools`)
 - Git
 - pkg-config
+- python3
 - protoc (protobuf compiler) >= v3.20.0
 - protobuf-c library and compiler (`libprotobuf-c-dev`, `protobuf-c-compiler`)
 - libffi development headers (`libffi-dev`)
@@ -79,7 +80,7 @@ Before installing Valkey GLIDE PHP extension, ensure you have the following depe
 
 ```bash
 sudo apt update -y
-sudo apt install -y php-dev php-cli git gcc make autotools-dev pkg-config openssl libssl-dev unzip php-bcmath libprotobuf-c-dev protobuf-c-compiler libffi-dev
+sudo apt install -y php-dev php-cli git gcc make autotools-dev pkg-config openssl libssl-dev unzip php-bcmath python3 libprotobuf-c-dev protobuf-c-compiler libffi-dev
 # Install rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
@@ -91,7 +92,7 @@ cargo install cbindgen
 
 ```bash
 sudo yum update -y
-sudo yum install -y php-devel php-cli git gcc make pkgconfig openssl openssl-devel unzip php-bcmath protobuf-c-devel protobuf-c-compiler libffi-devel
+sudo yum install -y php-devel php-cli git gcc make pkgconfig openssl openssl-devel unzip php-bcmath python3 protobuf-c-devel protobuf-c-compiler libffi-devel
 # Install rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

Update README.md to add missing build dependencies required for `pie install` on Ubuntu/Debian and CentOS/RHEL. Without these packages, `pie install valkey-io/valkey-glide-php` fails during the configure or make steps.

The following dependencies were missing:
- `libprotobuf-c-dev` / `protobuf-c-devel` — protobuf-c library for linking
- `protobuf-c-compiler` — provides the `protoc-c` binary for C protobuf code generation
- `libffi-dev` / `libffi-devel` — provides `ffi.h` required by `valkey_glide_address_resolver.c`
- `cbindgen` — generates C headers from the Rust FFI layer

### Issue link

N/A — discovered during testing of `pie install` on Ubuntu (Docker).

### Features / Behaviour Changes

Documentation-only change. No code changes.

### Implementation

- Added `libprotobuf-c-dev`, `protobuf-c-compiler`, and `libffi-dev` to the Ubuntu/Debian apt install command
- Added `protobuf-c-devel`, `protobuf-c-compiler`, and `libffi-devel` to the CentOS/RHEL yum install command
- Added `cargo install cbindgen` step to both Linux sections
- Updated the Prerequisites bullet list to include the new dependencies

### Limitations

None.

### Testing

Verified `pie install valkey-io/valkey-glide-php:1.1.2` succeeds in a clean Ubuntu 22.04 Docker container with the documented dependencies:

```bash
docker run --rm ubuntu:22.04 bash -c '
  export DEBIAN_FRONTEND=noninteractive
  apt-get update && apt-get install -y software-properties-common curl unzip
  add-apt-repository -y ppa:ondrej/php && apt-get update
  apt-get install -y php8.3-dev php8.3-cli git gcc make autotools-dev pkg-config \
    openssl libssl-dev libprotobuf-c-dev protobuf-c-compiler libffi-dev
  curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
  source "$HOME/.cargo/env"
  cargo install cbindgen
  curl -sLO https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/protoc-3.20.3-linux-x86_64.zip
  unzip -q protoc-3.20.3-linux-x86_64.zip -d $HOME/.local
  export PATH="$PATH:$HOME/.local/bin"
  curl -sL https://github.com/php/pie/releases/latest/download/pie.phar -o /usr/local/bin/pie
  chmod +x /usr/local/bin/pie
  pie install valkey-io/valkey-glide-php:1.1.2
'
```

Result: `✅ Extension is enabled and loaded`

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
