### PR TITLE
Add MUSL support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ to the GLIDE Core written in Rust using C FFI headers.
 **Supported Platforms:**
 
 - Linux: Ubuntu 20+, Amazon Linux 2/2023 (x86_64, aarch64)
+- Alpine Linux: 3.18+ (x86_64, aarch64) — uses musl libc
 - macOS: 13.7+ (x86_64), 14.7+ (aarch64)
-- **Note:** Alpine Linux/MUSL not supported
 
 **PHP Versions:** 8.2, 8.3
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ to the GLIDE Core written in Rust using C FFI headers.
 **Supported Platforms:**
 
 - Linux: Ubuntu 20+, Amazon Linux 2/2023 (x86_64, aarch64)
-- Alpine Linux: 3.18+ (x86_64, aarch64) — uses musl libc
+- Alpine Linux: 3.19+ (x86_64, aarch64) — uses musl libc
 - macOS: 13.7+ (x86_64), 14.7+ (aarch64)
 
 **PHP Versions:** 8.2, 8.3

--- a/Makefile.frag
+++ b/Makefile.frag
@@ -79,8 +79,17 @@ valkey-glide/ffi/target/release/libglide_ffi.a: ensure-submodules
 			export RUSTC_WRAPPER=sccache; \
 			echo "Using sccache for Rust compilation"; \
 		fi && \
+		EXTRA_RUSTFLAGS=""; \
+		if ldd --version 2>&1 | grep -q musl || test -f /etc/alpine-release; then \
+			echo "Detected musl/Alpine - setting target-feature=-crt-static"; \
+			EXTRA_RUSTFLAGS="-C target-feature=-crt-static"; \
+		fi && \
 		if [ -d valkey-glide/ffi ]; then \
-			cd valkey-glide/ffi && GLIDE_NAME=$(GLIDE_NAME) GLIDE_VERSION=$(GLIDE_VERSION) CARGO_BUILD_JOBS=$$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "4") cargo build --release && cd ../..; \
+			cd valkey-glide/ffi && \
+			GLIDE_NAME=$(GLIDE_NAME) GLIDE_VERSION=$(GLIDE_VERSION) \
+			RUSTFLAGS="$$EXTRA_RUSTFLAGS" \
+			CARGO_BUILD_JOBS=$$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "4") \
+			cargo build --release && cd ../..; \
 		fi; \
 	else \
 		echo "FFI library already exists, skipping cargo build"; \

--- a/Makefile.frag
+++ b/Makefile.frag
@@ -87,7 +87,7 @@ valkey-glide/ffi/target/release/libglide_ffi.a: ensure-submodules
 		if [ -d valkey-glide/ffi ]; then \
 			cd valkey-glide/ffi && \
 			GLIDE_NAME=$(GLIDE_NAME) GLIDE_VERSION=$(GLIDE_VERSION) \
-			RUSTFLAGS="$$EXTRA_RUSTFLAGS" \
+			RUSTFLAGS="$${RUSTFLAGS:+$$RUSTFLAGS }$$EXTRA_RUSTFLAGS" \
 			CARGO_BUILD_JOBS=$$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "4") \
 			cargo build --release && cd ../..; \
 		fi; \

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Linux:
 
 - Ubuntu 20 (x86_64/amd64 and arm64/aarch64)
 
-**Note: Currently Alpine Linux / MUSL is NOT supported.**
+Alpine Linux:
+
+- Alpine 3.18+ (x86_64/amd64 and arm64/aarch64) — uses musl libc
 
 macOS:
 
@@ -97,6 +99,18 @@ source "$HOME/.cargo/env"
 ```bash
 brew update
 brew install php git gcc make pkgconfig protobuf openssl
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+```
+
+**Alpine Linux:**
+
+```bash
+apk update
+apk add php83-dev php83-cli git gcc g++ make autoconf automake pkgconfig \
+  openssl-dev libffi-dev protobuf-c-dev protobuf-dev cmake perl \
+  linux-headers python3 bash curl tar
+# Install rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Linux:
 
 Alpine Linux:
 
-- Alpine 3.18+ (x86_64/amd64 and arm64/aarch64) — uses musl libc
+- Alpine 3.19+ (x86_64/amd64 and arm64/aarch64) — uses musl libc
 
 macOS:
 

--- a/config.m4
+++ b/config.m4
@@ -26,10 +26,14 @@ if test "$PHP_VALKEY_GLIDE" != "no"; then
   if test "$PHP_VALKEY_GLIDE_ASAN" = "yes"; then
     AC_MSG_CHECKING([for AddressSanitizer support])
     
-    dnl Detect platform to skip -fsanitize=address on macOS
+    dnl Detect platform to skip -fsanitize=address on macOS and musl
     UNAME_S=`uname -s`
     if test "$UNAME_S" = "Darwin"; then
       AC_MSG_RESULT([detected macOS, skipping -fsanitize=address])
+      ASAN_CFLAGS="-fno-omit-frame-pointer -g -O1"
+      ASAN_LDFLAGS=""
+    elif ldd --version 2>&1 | grep -q musl; then
+      AC_MSG_RESULT([detected musl libc, skipping -fsanitize=address (not supported)])
       ASAN_CFLAGS="-fno-omit-frame-pointer -g -O1"
       ASAN_LDFLAGS=""
     else
@@ -100,15 +104,16 @@ if test "$PHP_VALKEY_GLIDE" != "no"; then
     valkey_glide.c valkey_glide_cluster.c valkey_glide_pubsub_common.c valkey_glide_pubsub_introspection.c cluster_scan_cursor.c command_response.c logger.c valkey_glide_otel.c valkey_glide_commands.c valkey_glide_commands_2.c valkey_glide_commands_3.c valkey_glide_core_commands.c valkey_glide_core_common.c valkey_glide_expire_commands.c valkey_glide_ft_commands.c valkey_glide_ft_common.c valkey_glide_geo_commands.c valkey_glide_geo_common.c valkey_glide_hash_common.c valkey_glide_json_common.c valkey_glide_list_common.c valkey_glide_s_common.c valkey_glide_str_commands.c valkey_glide_x_commands.c valkey_glide_x_common.c valkey_glide_z.c valkey_glide_z_common.c valkey_z_php_methods.c valkey_glide_script_commands.c valkey_glide_function_commands.c valkey_glide_address_resolver.c src/command_request.pb-c.c src/connection_request.pb-c.c src/response.pb-c.c src/client_constructor_mock.c,
     $ext_shared,, $VALKEY_GLIDE_SHARED_LIBADD)
 
-  dnl Add FFI library only for macOS (keep Mac working as before)
+  dnl Add FFI library linking
   case $host_os in
     darwin*)
       VALKEY_GLIDE_SHARED_LIBADD="$VALKEY_GLIDE_SHARED_LIBADD \$(top_builddir)/valkey-glide/ffi/target/release/libglide_ffi.a -lresolv -lffi"
       LDFLAGS="$LDFLAGS -Wl,-undefined,dynamic_lookup"
       ;;
     *)
-      dnl Add Rust FFI library linking for Linux (like working commit)
-      VALKEY_GLIDE_SHARED_LIBADD="$VALKEY_GLIDE_SHARED_LIBADD \$(top_builddir)/valkey-glide/ffi/target/release/libglide_ffi.a -lresolv -lffi"
+      dnl Check if libresolv exists (it doesn't on musl/Alpine - resolver is in libc)
+      AC_CHECK_LIB([resolv], [res_query], [RESOLV_LIB="-lresolv"], [RESOLV_LIB=""])
+      VALKEY_GLIDE_SHARED_LIBADD="$VALKEY_GLIDE_SHARED_LIBADD \$(top_builddir)/valkey-glide/ffi/target/release/libglide_ffi.a $RESOLV_LIB -lffi"
       ;;
   esac
 

--- a/config.m4
+++ b/config.m4
@@ -32,7 +32,7 @@ if test "$PHP_VALKEY_GLIDE" != "no"; then
       AC_MSG_RESULT([detected macOS, skipping -fsanitize=address])
       ASAN_CFLAGS="-fno-omit-frame-pointer -g -O1"
       ASAN_LDFLAGS=""
-    elif ldd --version 2>&1 | grep -q musl; then
+    elif ldd --version 2>&1 | grep -q musl || test -f /etc/alpine-release; then
       AC_MSG_RESULT([detected musl libc, skipping -fsanitize=address (not supported)])
       ASAN_CFLAGS="-fno-omit-frame-pointer -g -O1"
       ASAN_LDFLAGS=""
@@ -443,7 +443,11 @@ if test "$PHP_VALKEY_GLIDE" != "no"; then
       fi
       
       GLIDE_PHP_VERSION=$(grep -o '#define VALKEY_GLIDE_PHP_VERSION "[^"]*"' common.h | sed 's/.*"\([^"]*\)"/\1/' 2>/dev/null || echo "unknown")
-      cd valkey-glide/ffi && GLIDE_NAME=GlidePHP GLIDE_VERSION="$GLIDE_PHP_VERSION" CARGO_HOME="$CARGO_HOME_DIR" PATH="$CARGO_DIR:$PATH" CARGO_BUILD_JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "4") ../../cargo build --release && CARGO_HOME="$CARGO_HOME_DIR" PATH="$CARGO_DIR:$PATH" ../../cbindgen --output ../../include/glide_bindings.h && cd ../.. || AC_MSG_ERROR([Rust build or header generation failed])
+      MUSL_RUSTFLAGS=""
+      if ldd --version 2>&1 | grep -q musl || test -f /etc/alpine-release; then
+        MUSL_RUSTFLAGS="-C target-feature=-crt-static"
+      fi
+      cd valkey-glide/ffi && GLIDE_NAME=GlidePHP GLIDE_VERSION="$GLIDE_PHP_VERSION" CARGO_HOME="$CARGO_HOME_DIR" PATH="$CARGO_DIR:$PATH" RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }$MUSL_RUSTFLAGS" CARGO_BUILD_JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "4") ../../cargo build --release && CARGO_HOME="$CARGO_HOME_DIR" PATH="$CARGO_DIR:$PATH" ../../cbindgen --output ../../include/glide_bindings.h && cd ../.. || AC_MSG_ERROR([Rust build or header generation failed])
       
       dnl Add include guards to the generated header immediately
       if test -f "include/glide_bindings.h"; then


### PR DESCRIPTION
### Summary

Enable the PHP extension to build and run on Alpine Linux (musl libc), supporting both x86_64 and aarch64 architectures.

### Issue link

This Pull Request is linked to issue: [MUSL support for PHP](https://github.com/valkey-io/valkey-glide-php/issues/279)
Closes #279

### Features / Behaviour Changes

- The PHP extension can now be built and loaded on Alpine Linux (musl libc 1.2.3+, Alpine 3.19+)
- Supports both x86_64 and aarch64 architectures on Alpine
- No behavioral changes for existing glibc-based Linux or macOS builds

### Implementation

Three targeted changes to the build system:

1. **`config.m4` — Conditional `-lresolv` linking:** On musl, `libresolv` does not exist as a separate library (resolver functions are in libc). Replaced hardcoded `-lresolv` with `AC_CHECK_LIB([resolv], [res_query], ...)` which probes at configure time. On glibc it finds and links libresolv; on musl it omits it.

2. **`config.m4` — ASAN musl detection:** musl's gcc does not support `-fsanitize=address`. Added musl detection (`ldd --version 2>&1 | grep -q musl`) alongside the existing macOS check to skip ASAN flags on Alpine.

3. **`Makefile.frag` — RUSTFLAGS for musl:** On musl targets, Rust defaults to statically linking the C runtime (`-crt-static`). This conflicts with the PHP extension which is a dynamically-linked `.so`. Added musl detection that sets `RUSTFLAGS="-C target-feature=-crt-static"` before `cargo build`, matching the approach used by the Java GLIDE client.

No C source code changes were needed — the existing code is already portable across glibc and musl.

### Limitations

- AddressSanitizer (ASAN) is not available on musl. Valgrind can be used as an alternative for memory analysis.
- The `aws-lc-sys` crate (transitive dependency via rustls) requires additional build tools on Alpine (`cmake`, `g++`, `perl`, `linux-headers`), adding build time.
- musl has minimal locale support (should not affect Valkey operations which use binary-safe strings).

### Testing

- **Build verification:** Extension builds successfully on Alpine (`php:8.3-cli-alpine` Docker image)
- **Extension loading:** `php -m | grep valkey_glide` confirms the extension loads without missing symbols
- **Regression:** Verified glibc-based builds (Ubuntu) are unaffected by the `AC_CHECK_LIB` change
- **Configure output validation:**
  - Alpine: `checking for res_query in -lresolv... no` (correct — skipped)
  - Ubuntu: `checking for res_query in -lresolv... yes` (correct — included)

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.