### PR TITLE
feat: Add lib_name and client_info_tag to client configuration

### DIFF
--- a/common.h
+++ b/common.h
@@ -4,11 +4,93 @@
 #ifndef VALKEY_GLIDE_COMMON_H
 #define VALKEY_GLIDE_COMMON_H
 
+/* Deliberately no <ctype.h>: isgraph()/isprint() are locale-dependent and would
+ * accept 0xA0-0xFF under a non-C LC_CTYPE, breaking the exact charset parity with
+ * glide-core that validate_printable_ascii() below depends on. Use explicit byte
+ * ranges instead. */
 #include <stdio.h>
 #include <zend_smart_str.h>
 
 #include "include/glide_bindings.h"
 #include "valkey_glide_address_resolver.h"
+
+/**
+ * Validate that a client metadata string (lib_name or client_info_tag) contains
+ * only the characters glide-core accepts inside a single metadata field:
+ * 0x21..0x27 and 0x2A..0x7E — printable ASCII excluding space, '(' and ')'.
+ *
+ * This is the per-field subset of the grammar enforced by glide-core's
+ * validate_effective_lib_name() on the *composed* name. Parentheses are
+ * excluded here because the binding itself introduces the only permitted pair
+ * when composing "<base>(<tag>)"; a field that carried its own parenthesis
+ * would compose into a name core rejects, so rejecting it early keeps this
+ * check from accepting values that would fail downstream.
+ *
+ * Empty is NOT handled here: callers treat an empty field as absent (matching
+ * core, where an empty effective name is treated as absent rather than an
+ * error), so this function is only invoked for non-empty values.
+ *
+ * Rejects embedded NUL bytes, control characters, space, DEL (0x7f), any
+ * non-ASCII (e.g. UTF-8) byte, and parentheses. Rejecting these before request
+ * composition also prevents an embedded NUL from silently truncating the value
+ * when it is later passed through strlen()/snprintf() during serialization.
+ *
+ * Returns 0 when every byte is acceptable, -1 otherwise.
+ */
+static inline int validate_printable_ascii(const char* s, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        unsigned char c = (unsigned char) s[i];
+        if (c < 0x21 || c > 0x7e || c == '(' || c == ')') {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/*
+ * Single source of truth for the PHP binding's default library name. Used by
+ * the lib-name resolver so the default identity is defined in exactly one place
+ * (no drift versus values hardcoded at composition sites).
+ */
+#define VALKEY_GLIDE_LIB_NAME "GlidePHP"
+
+/**
+ * Validate the client metadata fields (lib_name and client_info_tag) that a
+ * constructor received. This is a deliberate fail-early path in front of
+ * glide-core's validate_effective_lib_name(): core is the authority on the
+ * composed name, but validating per field here lets the error name the
+ * offending parameter, which core (seeing only the composed string) cannot do.
+ *
+ * An empty (zero-length) field is treated as ABSENT, not as an error, matching
+ * core's behaviour where an empty effective library name is treated as absent —
+ * so an empty client_info_tag yields no "(tag)" suffix rather than throwing.
+ *
+ * Non-empty fields must satisfy validate_printable_ascii, whose accepted set is
+ * the per-field subset of core's grammar (0x21-0x27, 0x2A-0x7E: printable ASCII
+ * excluding space, '(' and ')'). Keeping the two in step is what stops this
+ * check from accepting a value core would later reject.
+ *
+ * Returns NULL when both fields are acceptable, otherwise a ready-to-throw error
+ * message naming the offending field. Centralizing this here removes the
+ * copy-pasted validation block that previously lived at every constructor entry
+ * point (standalone, cluster, and both mock constructors).
+ */
+static inline const char* client_metadata_validation_error(const char* lib_name,
+                                                           size_t      lib_name_len,
+                                                           const char* client_info_tag,
+                                                           size_t      client_info_tag_len) {
+    if (lib_name != NULL && lib_name_len > 0 &&
+        validate_printable_ascii(lib_name, lib_name_len) != 0) {
+        return "lib_name must contain only printable ASCII characters from '!' through '~', "
+               "excluding spaces and parentheses";
+    }
+    if (client_info_tag != NULL && client_info_tag_len > 0 &&
+        validate_printable_ascii(client_info_tag, client_info_tag_len) != 0) {
+        return "client_info_tag must contain only printable ASCII characters from '!' through '~', "
+               "excluding spaces and parentheses";
+    }
+    return NULL;
+}
 
 /* ValkeyGlidePHP version */
 #define VALKEY_GLIDE_PHP_VERSION "1.1.2"
@@ -233,6 +315,8 @@ typedef struct {
     valkey_glide_backoff_strategy_t*                   reconnect_strategy; /* NULL if not set */
     char*                                              client_name;        /* NULL if not set */
     char*                                              client_az;          /* NULL if not set */
+    char*                                              lib_name;           /* NULL if not set */
+    char*                                              client_info_tag;    /* NULL if not set */
     valkey_glide_advanced_base_client_configuration_t* advanced_config;    /* NULL if not set */
     valkey_glide_compression_config_t*                 compression_config; /* NULL if not set */
     valkey_glide_client_side_cache_config_t*           client_side_cache;  /* NULL if not set */
@@ -276,8 +360,12 @@ typedef struct {
     zval*     circuit_breaker;   /* Circuit breaker configuration */
     char*     client_name;
     char*     client_az;
+    char*     lib_name;
+    char*     client_info_tag;
     size_t    client_name_len;
     size_t    client_az_len;
+    size_t    lib_name_len;
+    size_t    client_info_tag_len;
     zend_long read_from;           /* PRIMARY by default */
     zend_long node_discovery_mode; /* STANDARD by default */
     zend_long request_timeout;

--- a/src/client_constructor_mock.c
+++ b/src/client_constructor_mock.c
@@ -69,10 +69,22 @@ static zval* build_php_connection_request(uint8_t*                              
     add_next_index_string(&callable, "deserialize");
 
     zval* result = NULL;
-    if (call_user_function(NULL, NULL, &callable, &retval, 1, params) == SUCCESS) {
+    /* R2-M-1: require BOTH success and a defined retval. When the userland
+     * callable is missing, zend_call_function throws but still returns SUCCESS,
+     * leaving retval IS_UNDEF -- copying that handed back an IS_UNDEF zval with an
+     * exception pending. Guard on the exception too, so a thrown-but-SUCCESS call
+     * is treated as failure rather than producing a bogus value. */
+    if (call_user_function(NULL, NULL, &callable, &retval, 1, params) == SUCCESS &&
+        Z_TYPE(retval) != IS_UNDEF && !EG(exception)) {
         // Allocate return value
         result = emalloc(sizeof(zval));
         ZVAL_COPY(result, &retval);
+    } else if (!EG(exception)) {
+        /* Nothing was thrown (e.g. call_user_function itself failed), so the
+         * callers cannot rely on a pending exception. Throw here so the NULL
+         * return always carries a diagnosable error. */
+        const char* error_message = "Failed to invoke ConnectionRequestTest::deserialize.";
+        zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
     }
 
     zval_ptr_dtor(&callable);
@@ -92,7 +104,7 @@ PHP_METHOD(ClientConstructorMock, simulate_standalone_constructor) {
     valkey_glide_php_common_constructor_params_t common_params;
     valkey_glide_init_common_constructor_params(&common_params);
 
-    ZEND_PARSE_PARAMETERS_START(0, 17)
+    ZEND_PARSE_PARAMETERS_START(0, 19)
     Z_PARAM_OPTIONAL
     Z_PARAM_ARRAY_OR_NULL(common_params.addresses)
     Z_PARAM_BOOL(common_params.use_tls)
@@ -112,6 +124,8 @@ PHP_METHOD(ClientConstructorMock, simulate_standalone_constructor) {
     Z_PARAM_ZVAL_OR_NULL(common_params.address_resolver)
     Z_PARAM_ARRAY_OR_NULL(common_params.circuit_breaker)
     Z_PARAM_LONG(common_params.node_discovery_mode)
+    Z_PARAM_STRING_OR_NULL(common_params.lib_name, common_params.lib_name_len)
+    Z_PARAM_STRING_OR_NULL(common_params.client_info_tag, common_params.client_info_tag_len)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_THROWS());
 
     /* Validate database_id range before setting */
@@ -122,6 +136,22 @@ PHP_METHOD(ClientConstructorMock, simulate_standalone_constructor) {
         return;
     }
 
+    {
+        const char* metadata_error =
+            client_metadata_validation_error(common_params.lib_name,
+                                             common_params.lib_name_len,
+                                             common_params.client_info_tag,
+                                             common_params.client_info_tag_len);
+        if (metadata_error != NULL) {
+            /* L-3: no VALKEY_LOG_ERROR here. The real constructors
+             * (valkey_glide.c, valkey_glide_cluster.c) throw without logging, and
+             * the exception reaches the caller either way. Logging here made a
+             * green run emit ~40 spurious ERROR lines from the 4x10 invalid-value
+             * loops, so all four sites converge on the quieter behaviour. */
+            zend_throw_exception(get_valkey_glide_exception_ce(), metadata_error, 0);
+            return;
+        }
+    }
     bool addresses_allocated = _populate_addresses(&common_params.addresses);
 
     /* Build client configuration from individual parameters */
@@ -151,6 +181,14 @@ PHP_METHOD(ClientConstructorMock, simulate_standalone_constructor) {
         efree(common_params.addresses);
     }
 
+    /* M-4(b) / R2-M-1: build_php_connection_request returns NULL on its allocation
+     * guard, on a failed call, and when the callable threw. It guarantees an
+     * exception is pending on every NULL return, so surfacing it here is safe and
+     * never dereferences NULL. */
+    if (!php_request) {
+        RETURN_THROWS();
+    }
+
     RETURN_ZVAL(php_request, 1, 1);
 }
 
@@ -161,7 +199,7 @@ PHP_METHOD(ClientConstructorMock, simulate_cluster_constructor) {
     valkey_glide_php_common_constructor_params_t common_params;
     valkey_glide_init_common_constructor_params(&common_params);
 
-    ZEND_PARSE_PARAMETERS_START(0, 17)
+    ZEND_PARSE_PARAMETERS_START(0, 19)
     Z_PARAM_OPTIONAL
     Z_PARAM_ARRAY_OR_NULL(common_params.addresses)
     Z_PARAM_BOOL(common_params.use_tls)
@@ -181,6 +219,8 @@ PHP_METHOD(ClientConstructorMock, simulate_cluster_constructor) {
     Z_PARAM_ARRAY_OR_NULL(common_params.client_side_cache)
     Z_PARAM_ZVAL_OR_NULL(common_params.address_resolver)
     Z_PARAM_ARRAY_OR_NULL(common_params.circuit_breaker)
+    Z_PARAM_STRING_OR_NULL(common_params.lib_name, common_params.lib_name_len)
+    Z_PARAM_STRING_OR_NULL(common_params.client_info_tag, common_params.client_info_tag_len)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_THROWS());
 
     /* Validate database_id range before setting */
@@ -191,6 +231,22 @@ PHP_METHOD(ClientConstructorMock, simulate_cluster_constructor) {
         return;
     }
 
+    {
+        const char* metadata_error =
+            client_metadata_validation_error(common_params.lib_name,
+                                             common_params.lib_name_len,
+                                             common_params.client_info_tag,
+                                             common_params.client_info_tag_len);
+        if (metadata_error != NULL) {
+            /* L-3: no VALKEY_LOG_ERROR here. The real constructors
+             * (valkey_glide.c, valkey_glide_cluster.c) throw without logging, and
+             * the exception reaches the caller either way. Logging here made a
+             * green run emit ~40 spurious ERROR lines from the 4x10 invalid-value
+             * loops, so all four sites converge on the quieter behaviour. */
+            zend_throw_exception(get_valkey_glide_exception_ce(), metadata_error, 0);
+            return;
+        }
+    }
     bool addresses_allocated = _populate_addresses(&common_params.addresses);
 
     /* Build cluster client configuration from individual parameters */
@@ -240,6 +296,14 @@ PHP_METHOD(ClientConstructorMock, simulate_cluster_constructor) {
     if (addresses_allocated) {
         zval_ptr_dtor(common_params.addresses);
         efree(common_params.addresses);
+    }
+
+    /* M-4(b) / R2-M-1: build_php_connection_request returns NULL on its allocation
+     * guard, on a failed call, and when the callable threw. It guarantees an
+     * exception is pending on every NULL return, so surfacing it here is safe and
+     * never dereferences NULL. */
+    if (!php_request) {
+        RETURN_THROWS();
     }
 
     RETURN_ZVAL(php_request, 1, 1);

--- a/src/client_constructor_mock.stub.php
+++ b/src/client_constructor_mock.stub.php
@@ -105,6 +105,16 @@ class ClientConstructorMock
      *                                           ValkeyGlide::NODE_DISCOVERY_MODE_STANDARD,
      *                                           ValkeyGlide::NODE_DISCOVERY_MODE_STATIC, or
      *                                           ValkeyGlide::NODE_DISCOVERY_MODE_DISCOVER_ALL.
+     * @param callable|null $address_resolver    Custom address resolver callback.
+     * @param string|null $lib_name              Override the library name sent via CLIENT SETINFO LIB-NAME (default: "GlidePHP").
+     *                                           Empty is treated as UNSET. A non-empty value must contain only
+     *                                           printable ASCII, excluding space, '(' and ')'
+     *                                           (^[\x21-\x27\x2A-\x7E]+$). Parentheses are reserved for the
+     *                                           binding's own "(tag)" composition.
+     * @param string|null $client_info_tag       Tag appended to the resolved library name as "<resolved-lib-name>(tag)" for
+     *                                           framework attribution. Empty is treated as UNSET, so no "(tag)"
+     *                                           suffix is added. A non-empty value must contain only printable
+     *                                           ASCII, excluding space, '(' and ')' (^[\x21-\x27\x2A-\x7E]+$).
      */
     public static function simulate_standalone_constructor(
         ?array $addresses = null,
@@ -124,6 +134,8 @@ class ClientConstructorMock
         ?callable $address_resolver = null,
         ?array $circuit_breaker = null,
         int $node_discovery_mode = ValkeyGlide::NODE_DISCOVERY_MODE_STANDARD,
+        ?string $lib_name = null,
+        ?string $client_info_tag = null,
     ): \Connection_request\ConnectionRequest;
 
     /**
@@ -152,6 +164,17 @@ class ClientConstructorMock
      *                                                'compression_level' => 3, 'min_compression_size' => 256].
      * @param array|null $client_side_cache           Client-side cache configuration ['cache_id' => string, 'max_cache_kb' => int,
      *                                                'entry_ttl_ms' => int, 'eviction_policy' => ?int, 'enable_metrics' => bool].
+     * @param callable|null $address_resolver         Custom address resolver callback.
+     * @param string|null $lib_name                   Override the library name sent via CLIENT SETINFO LIB-NAME (default: "GlidePHP").
+     *                                                Empty is treated as UNSET. A non-empty value must contain
+     *                                                only printable ASCII, excluding space, '(' and ')'
+     *                                                (^[\x21-\x27\x2A-\x7E]+$). Parentheses are reserved for
+     *                                                the binding's own "(tag)" composition.
+     * @param string|null $client_info_tag            Tag appended to the resolved library name as "<resolved-lib-name>(tag)" for
+     *                                                framework attribution. Empty is treated as UNSET, so no
+     *                                                "(tag)" suffix is added. A non-empty value must contain only
+     *                                                printable ASCII, excluding space, '(' and ')'
+     *                                                (^[\x21-\x27\x2A-\x7E]+$).
      */
     public static function simulate_cluster_constructor(
         ?array $addresses = null,
@@ -171,5 +194,7 @@ class ClientConstructorMock
         ?array $client_side_cache = null,
         ?callable $address_resolver = null,
         ?array $circuit_breaker = null,
+        ?string $lib_name = null,
+        ?string $client_info_tag = null,
     ): \Connection_request\ConnectionRequest;
 }

--- a/tests/ClientInfoParsingTrait.php
+++ b/tests/ClientInfoParsingTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+defined('VALKEY_GLIDE_PHP_TESTRUN') or die("Use TestValkeyGlide.php to run tests!\n");
+
+/**
+ * Shared helpers for parsing `CLIENT INFO` responses in feature tests.
+ *
+ * Used by both ValkeyGlideFeaturesTest and ValkeyGlideClusterFeaturesTest so the
+ * field-extraction logic lives in exactly one place.
+ */
+trait ClientInfoParsingTrait
+{
+    /**
+     * Extract a single field value from a CLIENT INFO response line.
+     *
+     * CLIENT INFO returns space-separated key=value pairs. Accepted metadata
+     * values never contain whitespace, so the value runs up to the next space.
+     *
+     * @param string $info  The raw CLIENT INFO string.
+     * @param string $field The field name to extract (e.g. "lib-name").
+     * @return string|null The field value, or null when the field is absent.
+     */
+    protected function getClientInfoField(string $info, string $field): ?string
+    {
+        /* L-6: \S+ (not \S*) so a present-but-empty field is a parse miss rather
+         * than an empty string indistinguishable from absent, and so a value that
+         * wrongly leaked a space is not silently truncated to its prefix. */
+        if (preg_match('/(?:^| )' . preg_quote($field, '/') . '=(\S+)/', $info, $m)) {
+            return $m[1];
+        }
+        return null;
+    }
+}

--- a/tests/ConnectionRequestTest.php
+++ b/tests/ConnectionRequestTest.php
@@ -1180,6 +1180,233 @@ class ConnectionRequestTest extends \TestSuite
         $this->assertFalse($compression_config->getEnabled());
     }
 
+    // ---- lib_name and client_info_tag tests ----
+
+    public function testStandaloneLibNameOverride()
+    {
+        $request = ClientConstructorMock::simulate_standalone_constructor(lib_name: 'custom-lib');
+        $this->assertEquals('custom-lib', $request->getLibName());
+    }
+
+    public function testClusterLibNameOverride()
+    {
+        $request = ClientConstructorMock::simulate_cluster_constructor(lib_name: 'custom-lib');
+        $this->assertEquals('custom-lib', $request->getLibName());
+    }
+
+    public function testStandaloneClientInfoTag()
+    {
+        $request = ClientConstructorMock::simulate_standalone_constructor(client_info_tag: 'my-framework:1.0');
+        $this->assertEquals('GlidePHP(my-framework:1.0)', $request->getLibName());
+    }
+
+    public function testClusterClientInfoTag()
+    {
+        $request = ClientConstructorMock::simulate_cluster_constructor(client_info_tag: 'my-framework:1.0');
+        $this->assertEquals('GlidePHP(my-framework:1.0)', $request->getLibName());
+    }
+
+    public function testStandaloneLibNameWithTag()
+    {
+        $request = ClientConstructorMock::simulate_standalone_constructor(lib_name: 'custom', client_info_tag: 'tag:2.0');
+        $this->assertEquals('custom(tag:2.0)', $request->getLibName());
+    }
+
+    public function testClusterLibNameWithTag()
+    {
+        $request = ClientConstructorMock::simulate_cluster_constructor(lib_name: 'custom', client_info_tag: 'tag:2.0');
+        $this->assertEquals('custom(tag:2.0)', $request->getLibName());
+    }
+
+    public function testStandaloneLibNameDefault()
+    {
+        $request = ClientConstructorMock::simulate_standalone_constructor();
+        // When neither is set, the binding sends its own default identity.
+        $this->assertEquals('GlidePHP', $request->getLibName());
+    }
+
+    public function testClusterLibNameDefault()
+    {
+        $request = ClientConstructorMock::simulate_cluster_constructor();
+        // When neither is set, the binding sends its own default identity.
+        $this->assertEquals('GlidePHP', $request->getLibName());
+    }
+
+    /**
+     * An empty value is treated as absent rather than an error, matching
+     * glide-core's validate_effective_lib_name(). An empty client_info_tag must
+     * therefore produce no "()" suffix, and an empty lib_name must fall back to
+     * the binding default.
+     */
+    public function testStandaloneEmptyClientInfoTagTreatedAsAbsent()
+    {
+        $request = ClientConstructorMock::simulate_standalone_constructor(client_info_tag: '');
+        $this->assertEquals('GlidePHP', $request->getLibName());
+    }
+
+    public function testClusterEmptyClientInfoTagTreatedAsAbsent()
+    {
+        $request = ClientConstructorMock::simulate_cluster_constructor(client_info_tag: '');
+        $this->assertEquals('GlidePHP', $request->getLibName());
+    }
+
+    public function testStandaloneEmptyLibNameTreatedAsAbsent()
+    {
+        $request = ClientConstructorMock::simulate_standalone_constructor(lib_name: '');
+        $this->assertEquals('GlidePHP', $request->getLibName());
+    }
+
+    public function testClusterEmptyLibNameTreatedAsAbsent()
+    {
+        $request = ClientConstructorMock::simulate_cluster_constructor(lib_name: '');
+        $this->assertEquals('GlidePHP', $request->getLibName());
+    }
+
+    public function testStandaloneEmptyLibNameWithTagUsesDefaultBase()
+    {
+        $request = ClientConstructorMock::simulate_standalone_constructor(lib_name: '', client_info_tag: 'tag:2.0');
+        $this->assertEquals('GlidePHP(tag:2.0)', $request->getLibName());
+    }
+
+    /** L-9: cluster twin for the empty-lib_name-plus-tag composition. */
+    public function testClusterEmptyLibNameWithTagUsesDefaultBase()
+    {
+        $request = ClientConstructorMock::simulate_cluster_constructor(lib_name: '', client_info_tag: 'tag:2.0');
+        $this->assertEquals('GlidePHP(tag:2.0)', $request->getLibName());
+    }
+
+    /**
+     * M-3: guards the C validator's charset against glide-core's LIB_NAME_PATTERN
+     * character class [\x21-\x27\x2A-\x7E] (glide-core/src/client/mod.rs).
+     *
+     * The entire safety argument for keeping the binding's per-field validator is
+     * C-accept subset-of core-accept. That invariant spans a submodule boundary
+     * bumped independently of this code, so prose comments alone cannot hold it.
+     * If a core bump changes the grammar, this fails loudly here instead of
+     * silently deferring rejection to connect time.
+     *
+     * 0x00 is excluded: a NUL cannot survive PHP -> C marshalling as data.
+     */
+    public function testMetadataCharsetParityWithGlideCore()
+    {
+        foreach (['lib_name', 'client_info_tag'] as $field) {
+            for ($b = 0x01; $b <= 0xFF; $b++) {
+                $ch          = chr($b);
+                $coreAccepts = ($b >= 0x21 && $b <= 0x27) || ($b >= 0x2A && $b <= 0x7E);
+
+                $rejected = false;
+                try {
+                    if ($field === 'lib_name') {
+                        ClientConstructorMock::simulate_standalone_constructor(lib_name: $ch);
+                    } else {
+                        ClientConstructorMock::simulate_standalone_constructor(client_info_tag: $ch);
+                    }
+                } catch (ValkeyGlideException $e) {
+                    $rejected = true;
+                }
+
+                $this->assertTrue(
+                    $rejected === !$coreAccepts,
+                    sprintf(
+                        '%s byte 0x%02X: binding %s but core %s',
+                        $field,
+                        $b,
+                        $rejected ? 'rejects' : 'accepts',
+                        $coreAccepts ? 'accepts' : 'rejects'
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * Values that must be rejected for lib_name / client_info_tag.
+     *
+     * Note: the empty string is deliberately NOT listed here. An empty value is
+     * treated as absent (matching glide-core's validate_effective_lib_name),
+     * so it yields the default library name with no "(tag)" suffix rather than
+     * an error. See testStandaloneEmptyClientInfoTagTreatedAsAbsent.
+     *
+     * Parentheses are rejected per field because the binding introduces the only
+     * permitted "(tag)" pair when composing the effective name; a field carrying
+     * its own parenthesis would compose into a name core rejects.
+     */
+    private function invalidMetadataValues(): array
+    {
+        return [
+            'space'          => ['has space'],
+            'tab'            => ["has\ttab"],
+            'newline'        => ["has\nnewline"],
+            'embedded_nul'   => ["framework\0suffix"],
+            'control_bel'    => ["framework\x07"],
+            'del'            => ["framework\x7f"],
+            'non_ascii_utf8' => ['framework-é'],
+            'open_paren'     => ['framework('],
+            'close_paren'    => ['framework)'],
+            'wrapped_parens' => ['(framework)'],
+        ];
+    }
+
+    private function assertMetadataRejected(callable $construct, string $field, string $case = ''): void
+    {
+        $label = $case !== '' ? " (case '{$case}')" : '';
+        try {
+            $construct();
+            // M-5: name the offending case. Without this the leaked-invalid-value
+            // branch reported a bare "(false) !== (true)" with no case identity.
+            $this->assertTrue(false, "{$field}{$label} was accepted but must be rejected");
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains(
+                $field . " must contain only printable ASCII characters from '!' through '~'",
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function testStandaloneLibNameInvalidRejected()
+    {
+        foreach ($this->invalidMetadataValues() as $case => $value) {
+            $this->assertMetadataRejected(
+                fn() => ClientConstructorMock::simulate_standalone_constructor(lib_name: $value[0]),
+                'lib_name',
+                (string) $case
+            );
+        }
+    }
+
+    public function testClusterLibNameInvalidRejected()
+    {
+        foreach ($this->invalidMetadataValues() as $case => $value) {
+            $this->assertMetadataRejected(
+                fn() => ClientConstructorMock::simulate_cluster_constructor(lib_name: $value[0]),
+                'lib_name',
+                (string) $case
+            );
+        }
+    }
+
+    public function testStandaloneClientInfoTagInvalidRejected()
+    {
+        foreach ($this->invalidMetadataValues() as $case => $value) {
+            $this->assertMetadataRejected(
+                fn() => ClientConstructorMock::simulate_standalone_constructor(client_info_tag: $value[0]),
+                'client_info_tag',
+                (string) $case
+            );
+        }
+    }
+
+    public function testClusterClientInfoTagInvalidRejected()
+    {
+        foreach ($this->invalidMetadataValues() as $case => $value) {
+            $this->assertMetadataRejected(
+                fn() => ClientConstructorMock::simulate_cluster_constructor(client_info_tag: $value[0]),
+                'client_info_tag',
+                (string) $case
+            );
+        }
+    }
+
     // Helper methods
     // --------------
 

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -297,17 +297,32 @@ class TestSuite
         return false;
     }
 
-    protected function assertTrue($value): bool
+    protected function assertTrue($value, ?string $message = null): bool
     {
         if ($value === true) {
             return true;
         }
 
-        self::$errors [] = $this->assertionTrace(
-            "%s !== %s",
-            $this->printArg($value),
-            $this->printArg(true)
-        );
+        /* R2-H-1: the message MUST be a vsprintf ARGUMENT, never spliced into the
+         * format string. Callers legitimately pass messages containing '%' (e.g.
+         * "Success rate should be > 90%, got 95.2%"); splicing those in creates
+         * bogus conversion specs, and vsprintf then raises ValueError -- which
+         * extends Error, not Exception, so the runner's catch (Exception) does not
+         * catch it and the whole run dies with no summary. */
+        if ($message !== null) {
+            self::$errors [] = $this->assertionTrace(
+                "%s !== %s - %s",
+                $this->printArg($value),
+                $this->printArg(true),
+                $message
+            );
+        } else {
+            self::$errors [] = $this->assertionTrace(
+                "%s !== %s",
+                $this->printArg($value),
+                $this->printArg(true)
+            );
+        }
 
         return false;
     }
@@ -996,8 +1011,12 @@ class TestSuite
                     $failed++;
                     $failed_tests[] = $class_name . '::' . $name;
                 }
-            } catch (Exception $e) {
-                /* We may have simply skipped the test */
+            } catch (Throwable $e) {
+                /* R2-H-1: Throwable, not Exception. A PHP Error (e.g. ValueError
+                 * from a bad format string, or a TypeError) is not an Exception,
+                 * so catching only Exception let it escape and abort the entire
+                 * run -- losing the summary and every later test class. The
+                 * assertThrows helper below already catches Throwable. */
                 if ($e instanceof TestSkippedException) {
                     $result = self::makeWarning('SKIPPED');
                     $skipped++;

--- a/tests/ValkeyGlideClusterFeaturesTest.php
+++ b/tests/ValkeyGlideClusterFeaturesTest.php
@@ -3,6 +3,7 @@
 defined('VALKEY_GLIDE_PHP_TESTRUN') or die("Use TestValkeyGlide.php to run tests!\n");
 
 require_once __DIR__ . "/ValkeyGlideClusterBaseTest.php";
+require_once __DIR__ . "/ClientInfoParsingTrait.php";
 
 use ValkeyGlide\OpenTelemetry\OpenTelemetryConfig;
 use ValkeyGlide\OpenTelemetry\TracesConfig;
@@ -13,6 +14,8 @@ use ValkeyGlide\OpenTelemetry\TracesConfig;
  */
 class ValkeyGlideClusterFeaturesTest extends ValkeyGlideClusterBaseTest
 {
+    use ClientInfoParsingTrait;
+
     public function testBasicClusterConstructor()
     {
         // Test creating ValkeyGlideCluster with basic configuration
@@ -30,6 +33,14 @@ class ValkeyGlideClusterFeaturesTest extends ValkeyGlideClusterBaseTest
         $valkey_glide->close();
     }
 
+    /**
+     * R2-M-2: the lib-name assertion here is TAUTOLOGICAL and cannot fail. The
+     * binding's default (VALKEY_GLIDE_LIB_NAME) and the Rust core's compile-time
+     * GLIDE_NAME are both "GlidePHP", so this passes whether or not the binding
+     * populated lib_name at all. Falsifiable coverage that the binding really
+     * sends the field lives in testLibNameOverride (and testLibNameOverrideCluster),
+     * which assert a value GLIDE_NAME cannot produce. Kept for the lib-ver check.
+     */
     public function testClientLibNameAndVersion()
     {
         // Verify that CLIENT INFO reports the correct lib-name and lib-ver
@@ -39,9 +50,122 @@ class ValkeyGlideClusterFeaturesTest extends ValkeyGlideClusterBaseTest
             "INFO"
         );
         $this->assertIsString($info_str);
-        $this->assertTrue(str_contains($info_str, "lib-name=GlidePHP"));
+        $this->assertEquals("GlidePHP", $this->getClientInfoField($info_str, "lib-name"));
         $expected_version = phpversion('valkey_glide');
         $this->assertTrue(str_contains($info_str, "lib-ver=" . $expected_version));
+    }
+
+    public function testClientInfoTagAppendsToLibNameCluster()
+    {
+        // Verify that CLIENT INFO shows composed lib-name with tag for cluster client
+        $params = [
+            'addresses'       => [['host' => $this->getHost(), 'port' => $this->getPort()]],
+            'use_tls'         => $this->getTLS(),
+            'credentials'     => $this->getAuth(),
+            'read_from'       => ValkeyGlide::READ_FROM_PRIMARY,
+            'client_info_tag' => 'my-framework:1.0',
+        ];
+        if ($this->getTLS()) {
+            $params['advanced_config'] = ['tls_config' => ['use_insecure_tls' => true]];
+        }
+        $client = new ValkeyGlideCluster(...$params);
+        $info_str = $client->rawcommand(
+            ['type' => 'primarySlotKey', 'key' => 'test'],
+            "CLIENT",
+            "INFO"
+        );
+        $this->assertIsString($info_str);
+        $this->assertEquals("GlidePHP(my-framework:1.0)", $this->getClientInfoField($info_str, "lib-name"));
+        $client->close();
+    }
+
+    public function testLibNameWithClientInfoTagCluster()
+    {
+        // Verify that CLIENT INFO shows composed lib-name with custom lib_name and tag for cluster client
+        $params = [
+            'addresses'       => [['host' => $this->getHost(), 'port' => $this->getPort()]],
+            'use_tls'         => $this->getTLS(),
+            'credentials'     => $this->getAuth(),
+            'read_from'       => ValkeyGlide::READ_FROM_PRIMARY,
+            'lib_name'        => 'custom',
+            'client_info_tag' => 'tag:2.0',
+        ];
+        if ($this->getTLS()) {
+            $params['advanced_config'] = ['tls_config' => ['use_insecure_tls' => true]];
+        }
+        $client = new ValkeyGlideCluster(...$params);
+        $info_str = $client->rawcommand(
+            ['type' => 'primarySlotKey', 'key' => 'test'],
+            "CLIENT",
+            "INFO"
+        );
+        $this->assertIsString($info_str);
+        $this->assertEquals("custom(tag:2.0)", $this->getClientInfoField($info_str, "lib-name"));
+        $client->close();
+    }
+
+    /**
+     * M-2: exercises the REAL cluster validation gate at valkey_glide_cluster.c:264.
+     *
+     * Previously the cluster gate was only reachable through the mock's separate
+     * copy, so deleting or reordering the real gate left the suite green.
+     *
+     * R2-T-2: the constructor under test throws before
+     * valkey_glide_cluster_create_connection(), so the REJECTION ITSELF needs no
+     * reachable cluster -- but this class does: ValkeyGlideClusterBaseTest::setUp()
+     * builds a live client before every test method.
+     */
+    public function testClusterClientInfoTagWhitespaceRejected()
+    {
+        try {
+            new ValkeyGlideCluster(
+                addresses: [['host' => $this->getHost(), 'port' => $this->getPort()]],
+                client_info_tag: 'has space'
+            );
+            $this->assertTrue(false, 'Expected ValkeyGlideException for whitespace in client_info_tag');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains("client_info_tag must contain only printable ASCII characters from '!' through '~'", $e->getMessage());
+        }
+    }
+
+    public function testClusterLibNameNonPrintableRejected()
+    {
+        try {
+            new ValkeyGlideCluster(
+                addresses: [['host' => $this->getHost(), 'port' => $this->getPort()]],
+                lib_name: "bad\x7f"
+            );
+            $this->assertTrue(false, 'Expected ValkeyGlideException for non-printable byte in lib_name');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains("lib_name must contain only printable ASCII characters from '!' through '~'", $e->getMessage());
+        }
+    }
+
+    /**
+     * M-2: cluster twin for lib_name-only override, covering the have_tag == false
+     * estrdup branch in valkey_glide_resolve_lib_name.
+     */
+    public function testLibNameOverrideCluster()
+    {
+        $params = [
+            'addresses'   => [['host' => $this->getHost(), 'port' => $this->getPort()]],
+            'use_tls'     => $this->getTLS(),
+            'credentials' => $this->getAuth(),
+            'read_from'   => ValkeyGlide::READ_FROM_PRIMARY,
+            'lib_name'    => 'custom-lib',
+        ];
+        if ($this->getTLS()) {
+            $params['advanced_config'] = ['tls_config' => ['use_insecure_tls' => true]];
+        }
+        $client = new ValkeyGlideCluster(...$params);
+        $info_str = $client->rawcommand(
+            ['type' => 'primarySlotKey', 'key' => 'test'],
+            "CLIENT",
+            "INFO"
+        );
+        $this->assertIsString($info_str);
+        $this->assertEquals("custom-lib", $this->getClientInfoField($info_str, "lib-name"));
+        $client->close();
     }
 
     // ==============================================

--- a/tests/ValkeyGlideFeaturesTest.php
+++ b/tests/ValkeyGlideFeaturesTest.php
@@ -3,6 +3,7 @@
 defined('VALKEY_GLIDE_PHP_TESTRUN') or die("Use TestValkeyGlide.php to run tests!\n");
 
 require_once __DIR__ . "/ValkeyGlideBaseTest.php";
+require_once __DIR__ . "/ClientInfoParsingTrait.php";
 
 use ValkeyGlide\OpenTelemetry\OpenTelemetryConfig;
 use ValkeyGlide\OpenTelemetry\TracesConfig;
@@ -13,6 +14,8 @@ use ValkeyGlide\OpenTelemetry\TracesConfig;
  */
 class ValkeyGlideFeaturesTest extends ValkeyGlideBaseTest
 {
+    use ClientInfoParsingTrait;
+
     public function __construct($host, $port, $auth, $tls)
     {
         parent::__construct($host, $port, $auth, $tls);
@@ -37,14 +40,92 @@ class ValkeyGlideFeaturesTest extends ValkeyGlideBaseTest
         }
     }
 
+    /**
+     * R2-M-2: the lib-name assertion here is TAUTOLOGICAL and cannot fail. The
+     * binding's default (VALKEY_GLIDE_LIB_NAME) and the Rust core's compile-time
+     * GLIDE_NAME are both "GlidePHP", so this passes whether or not the binding
+     * populated lib_name at all. Falsifiable coverage that the binding really
+     * sends the field lives in testLibNameOverride (and testLibNameOverrideCluster),
+     * which assert a value GLIDE_NAME cannot produce. Kept for the lib-ver check.
+     */
     public function testClientLibNameAndVersion()
     {
         // Verify that CLIENT INFO reports the correct lib-name and lib-ver
         $info_str = $this->valkey_glide->rawcommand("CLIENT", "INFO");
         $this->assertIsString($info_str);
-        $this->assertTrue(str_contains($info_str, "lib-name=GlidePHP"));
+        $this->assertEquals("GlidePHP", $this->getClientInfoField($info_str, "lib-name"));
         $expected_version = phpversion('valkey_glide');
         $this->assertTrue(str_contains($info_str, "lib-ver=" . $expected_version));
+    }
+
+    public function testClientInfoTagAppendsToLibName()
+    {
+        $addresses = [['host' => $this->getHost(), 'port' => $this->getPort()]];
+        $client = new ValkeyGlide();
+        $connectParams = ['addresses' => $addresses, 'client_info_tag' => 'my-framework:1.0'];
+        if ($this->getTLS()) {
+            $connectParams['use_tls'] = true;
+            $connectParams['advanced_config'] = ['tls_config' => ['use_insecure_tls' => true]];
+        }
+        $client->connect(...$connectParams);
+        $info_str = $client->rawcommand("CLIENT", "INFO");
+        $this->assertIsString($info_str);
+        $this->assertEquals("GlidePHP(my-framework:1.0)", $this->getClientInfoField($info_str, "lib-name"));
+        $client->close();
+    }
+
+    public function testLibNameOverride()
+    {
+        $addresses = [['host' => $this->getHost(), 'port' => $this->getPort()]];
+        $client = new ValkeyGlide();
+        $connectParams = ['addresses' => $addresses, 'lib_name' => 'custom-lib'];
+        if ($this->getTLS()) {
+            $connectParams['use_tls'] = true;
+            $connectParams['advanced_config'] = ['tls_config' => ['use_insecure_tls' => true]];
+        }
+        $client->connect(...$connectParams);
+        $info_str = $client->rawcommand("CLIENT", "INFO");
+        $this->assertIsString($info_str);
+        $this->assertEquals("custom-lib", $this->getClientInfoField($info_str, "lib-name"));
+        $client->close();
+    }
+
+    public function testLibNameWithClientInfoTag()
+    {
+        $addresses = [['host' => $this->getHost(), 'port' => $this->getPort()]];
+        $client = new ValkeyGlide();
+        $connectParams = ['addresses' => $addresses, 'lib_name' => 'custom', 'client_info_tag' => 'tag:2.0'];
+        if ($this->getTLS()) {
+            $connectParams['use_tls'] = true;
+            $connectParams['advanced_config'] = ['tls_config' => ['use_insecure_tls' => true]];
+        }
+        $client->connect(...$connectParams);
+        $info_str = $client->rawcommand("CLIENT", "INFO");
+        $this->assertIsString($info_str);
+        $this->assertEquals("custom(tag:2.0)", $this->getClientInfoField($info_str, "lib-name"));
+        $client->close();
+    }
+
+    public function testClientInfoTagWhitespaceRejected()
+    {
+        $client = new ValkeyGlide();
+        try {
+            $client->connect(addresses: [['host' => $this->getHost(), 'port' => $this->getPort()]], client_info_tag: 'has space');
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains("client_info_tag must contain only printable ASCII characters from '!' through '~'", $e->getMessage());
+        }
+    }
+
+    public function testLibNameNonPrintableRejected()
+    {
+        $client = new ValkeyGlide();
+        try {
+            $client->connect(addresses: [['host' => $this->getHost(), 'port' => $this->getPort()]], lib_name: "bad\x7f");
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains("lib_name must contain only printable ASCII characters from '!' through '~'", $e->getMessage());
+        }
     }
 
     public function testConstructorWithSingleAddress()

--- a/tests/ValkeyGlideMonitorTest.php
+++ b/tests/ValkeyGlideMonitorTest.php
@@ -55,6 +55,77 @@ class ValkeyGlideMonitorTest extends ValkeyGlideBaseTest
     }
 
     /**
+     * A MONITOR connection must be attributable like any other client: the
+     * monitor path shares valkey_glide_build_client_config_base() and
+     * create_connection_request() with the standalone and cluster constructors,
+     * so lib_name / client_info_tag must resolve identically there.
+     */
+    public function testMonitorReportsComposedLibName()
+    {
+        $addresses = [['host' => $this->getHost(), 'port' => $this->getPort()]];
+
+        $cases = [
+            'default'  => [null, null, 'GlidePHP'],
+            'tag_only' => [null, 'framework:1.2', 'GlidePHP(framework:1.2)'],
+            'override' => ['custom-lib', null, 'custom-lib'],
+            'combined' => ['custom-lib', 'framework:1.2', 'custom-lib(framework:1.2)'],
+        ];
+
+        foreach ($cases as $case => [$lib, $tag, $expected]) {
+            $args = ['addresses' => $addresses];
+            if ($lib !== null) {
+                $args['lib_name'] = $lib;
+            }
+            if ($tag !== null) {
+                $args['client_info_tag'] = $tag;
+            }
+            $monitor = new ValkeyGlideMonitor(...$args);
+
+            $probe = new ValkeyGlide();
+            $probe->connect(addresses: $addresses);
+            $list = (string) $probe->rawcommand("CLIENT", "LIST");
+
+            $seen = [];
+            foreach (explode("\n", $list) as $line) {
+                if (strpos($line, 'cmd=monitor') !== false && preg_match('/lib-name=(\S+)/', $line, $m)) {
+                    $seen[$m[1]] = true;
+                }
+            }
+            $probe->close();
+            $monitor->close();
+
+            $this->assertTrue(
+                isset($seen[$expected]),
+                sprintf(
+                    'monitor case %s: expected lib-name=%s, saw [%s]',
+                    $case,
+                    $expected,
+                    implode(',', array_keys($seen))
+                )
+            );
+        }
+    }
+
+    public function testMonitorRejectsInvalidMetadata()
+    {
+        $addresses = [['host' => $this->getHost(), 'port' => $this->getPort()]];
+
+        try {
+            new ValkeyGlideMonitor(addresses: $addresses, client_info_tag: 'has space');
+            $this->assertTrue(false, 'Expected ValkeyGlideException for whitespace in client_info_tag');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains('client_info_tag', $e->getMessage());
+        }
+
+        try {
+            new ValkeyGlideMonitor(addresses: $addresses, lib_name: 'Glide(');
+            $this->assertTrue(false, 'Expected ValkeyGlideException for parenthesis in lib_name');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains('lib_name', $e->getMessage());
+        }
+    }
+
+    /**
      * Test that listen() requires a callable argument.
      */
     public function testMonitorRequiresCallable()

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -2711,3 +2711,36 @@
    ...
    fun:*glide_core*scope*register_client*
 }
+
+# glide-core LIB_NAME_PATTERN (client_info_tag / lib_name validation, see
+# validate_effective_lib_name) is a process-lifetime LazyLock<Regex>. Its
+# regex-automata lazy DFA cache grows its internal hashbrown table on first
+# use and is never freed before process exit by design; valgrind's heuristic
+# reports the pre-growth backing table as possibly lost. Two call sites hit
+# this: initial table insertion during cache init, and a later rehash during
+# a forward search on the same cache.
+{
+   glide_core_lib_name_pattern_dfa_cache_init
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:*hashbrown*raw*RawTable*reserve_rehash*
+   ...
+   fun:*regex_automata*hybrid*dfa*Lazy*init_cache*
+   ...
+   fun:*glide_core*client*validate_effective_lib_name*
+}
+
+{
+   glide_core_lib_name_pattern_dfa_cache_next_state
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:*hashbrown*raw*RawTable*reserve_rehash*
+   ...
+   fun:*regex_automata*hybrid*dfa*Lazy*cache_next_state*
+   ...
+   fun:*glide_core*client*validate_effective_lib_name*
+}

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -183,6 +183,10 @@ void valkey_glide_init_common_constructor_params(
     params->client_name_len         = 0;
     params->client_az               = NULL;
     params->client_az_len           = 0;
+    params->lib_name                = NULL;
+    params->lib_name_len            = 0;
+    params->client_info_tag         = NULL;
+    params->client_info_tag_len     = 0;
     params->advanced_config         = NULL;
     params->lazy_connect            = 0;
     params->lazy_connect_is_null    = 1;
@@ -202,6 +206,12 @@ int valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_pa
     config->request_timeout =
         params->request_timeout_is_null ? -1 : params->request_timeout; /* -1 means not set */
     config->client_name = params->client_name ? params->client_name : NULL;
+    /* L-7: length-aware, matching this feature's "empty means absent" semantics
+     * (and the adjacent client_az handling) rather than a no-op `p ? p : NULL`. */
+    config->lib_name = (params->lib_name && params->lib_name_len > 0) ? params->lib_name : NULL;
+    config->client_info_tag = (params->client_info_tag && params->client_info_tag_len > 0)
+                                  ? params->client_info_tag
+                                  : NULL;
 
     /* Set inflight requests limit to -1 (unset). A synchronous API does not need a request limit
        since it is effectively one-request-at-a-time. */
@@ -1026,6 +1036,10 @@ static int valkey_glide_create_connection(valkey_glide_object* valkey_glide,
                                           size_t               client_name_len,
                                           char*                client_az,
                                           size_t               client_az_len,
+                                          char*                lib_name,
+                                          size_t               lib_name_len,
+                                          char*                client_info_tag,
+                                          size_t               client_info_tag_len,
                                           zval*                advanced_config,
                                           zval*                lazy_connect_zval,
                                           zval*                context,
@@ -1066,11 +1080,15 @@ static int valkey_glide_create_connection(valkey_glide_object* valkey_glide,
         common_params.database_id_is_null = false;
     }
 
-    common_params.client_name     = client_name;
-    common_params.client_name_len = client_name_len;
-    common_params.client_az       = client_az;
-    common_params.client_az_len   = client_az_len;
-    common_params.advanced_config = advanced_config;
+    common_params.client_name         = client_name;
+    common_params.client_name_len     = client_name_len;
+    common_params.client_az           = client_az;
+    common_params.client_az_len       = client_az_len;
+    common_params.lib_name            = lib_name;
+    common_params.lib_name_len        = lib_name_len;
+    common_params.client_info_tag     = client_info_tag;
+    common_params.client_info_tag_len = client_info_tag_len;
+    common_params.advanced_config     = advanced_config;
 
     if (lazy_connect_zval != NULL && Z_TYPE_P(lazy_connect_zval) != IS_NULL) {
         common_params.lazy_connect         = Z_TYPE_P(lazy_connect_zval) == IS_TRUE;
@@ -1195,6 +1213,10 @@ PHP_METHOD(ValkeyGlide, connect) {
     size_t client_name_len          = 0;
     char*  client_az                = NULL;
     size_t client_az_len            = 0;
+    char*  lib_name                 = NULL;
+    size_t lib_name_len             = 0;
+    char*  client_info_tag          = NULL;
+    size_t client_info_tag_len      = 0;
     zval*  advanced_config          = NULL;
     zval*  lazy_connect_zval        = NULL;
     zval*  context                  = NULL;
@@ -1204,7 +1226,7 @@ PHP_METHOD(ValkeyGlide, connect) {
     zval*  circuit_breaker          = NULL;
     zval*  node_discovery_mode_zval = NULL;
 
-    ZEND_PARSE_PARAMETERS_START(0, 23)
+    ZEND_PARSE_PARAMETERS_START(0, 25)
     Z_PARAM_OPTIONAL
     Z_PARAM_STRING_OR_NULL(host, host_len)
     Z_PARAM_ZVAL_OR_NULL(port_zval)
@@ -1229,6 +1251,8 @@ PHP_METHOD(ValkeyGlide, connect) {
     Z_PARAM_ZVAL_OR_NULL(address_resolver)
     Z_PARAM_ARRAY_OR_NULL(circuit_breaker)
     Z_PARAM_ZVAL_OR_NULL(node_discovery_mode_zval)
+    Z_PARAM_STRING_OR_NULL(lib_name, lib_name_len)
+    Z_PARAM_STRING_OR_NULL(client_info_tag, client_info_tag_len)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_THROWS());
 
     /* Apply defaults for nullable parameters */
@@ -1280,6 +1304,15 @@ PHP_METHOD(ValkeyGlide, connect) {
         RETURN_FALSE;
     }
 
+    {
+        const char* metadata_error = client_metadata_validation_error(
+            lib_name, lib_name_len, client_info_tag, client_info_tag_len);
+        if (metadata_error != NULL) {
+            zend_throw_exception(get_valkey_glide_exception_ce(), metadata_error, 0);
+            RETURN_FALSE;
+        }
+    }
+
     /* Build addresses array host/port if provided */
     zval addresses_to_pass;
     if (host != NULL) {
@@ -1317,6 +1350,10 @@ PHP_METHOD(ValkeyGlide, connect) {
                                                 client_name_len,
                                                 client_az,
                                                 client_az_len,
+                                                lib_name,
+                                                lib_name_len,
+                                                client_info_tag,
+                                                client_info_tag_len,
                                                 advanced_config,
                                                 lazy_connect_zval,
                                                 context,

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -425,6 +425,7 @@ class ValkeyGlide
      * @param array|null $client_side_cache Client-side cache configuration array from ClientSideCache::toArray():
      *                                      ['cache_id' => string, 'max_cache_kb' => int, 'entry_ttl_ms' => int,
      *                                       'eviction_policy' => ?int, 'enable_metrics' => bool]
+     * @param callable|null $address_resolver Custom address resolver callback
      * @param array|null $circuit_breaker Circuit breaker configuration:
      *                                    ['window_size_ms' => int, 'failure_rate_threshold' => float,
      *                                     'min_errors' => int, 'open_timeout_ms' => int,
@@ -433,6 +434,15 @@ class ValkeyGlide
      *                                      NODE_DISCOVERY_MODE_STANDARD (default),
      *                                      NODE_DISCOVERY_MODE_STATIC, or
      *                                      NODE_DISCOVERY_MODE_DISCOVER_ALL
+     * @param string|null $lib_name Override the library name sent via CLIENT SETINFO LIB-NAME (default: "GlidePHP").
+     *      An empty string (or null) is treated as UNSET, yielding the default. A non-empty value
+     *      must contain only printable ASCII, excluding space, '(' and ')' (^[\x21-\x27\x2A-\x7E]+$).
+     *      Parentheses are reserved: the binding itself adds the single "(tag)" pair when composing
+     *      "<lib_name>(<client_info_tag>)". Use client_info_tag to get a parenthesised suffix.
+     * @param string|null $client_info_tag Tag appended to the resolved library name as "<resolved-lib-name>(tag)"
+     *      for framework attribution (e.g. "GlidePHP(tag)" by default, or "<lib_name>(tag)" when lib_name is set).
+     *      An empty string (or null) is treated as UNSET, so no "(tag)" suffix is added. A non-empty value
+     *      must contain only printable ASCII, excluding space, '(' and ')' (^[\x21-\x27\x2A-\x7E]+$).
      * @return bool True on successful connection, false on failure
      *
      * @throws ValkeyGlideException If conflicting parameters are specified or connection fails
@@ -469,6 +479,8 @@ class ValkeyGlide
         ?callable $address_resolver = null,
         ?array $circuit_breaker = null,
         ?int $node_discovery_mode = null,
+        ?string $lib_name = null,
+        ?string $client_info_tag = null,
     ): bool;
 
     public function __destruct();

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -176,6 +176,10 @@ PHP_METHOD(ValkeyGlideCluster, __construct) {
     zend_bool periodic_checks_is_null = 1;
     char*     client_az               = NULL;
     size_t    client_az_len           = 0;
+    char*     lib_name                = NULL;
+    size_t    lib_name_len            = 0;
+    char*     client_info_tag         = NULL;
+    size_t    client_info_tag_len     = 0;
     zval*     advanced_config         = NULL;
     zend_bool lazy_connect            = 0;
     zend_bool lazy_connect_is_null    = 1;
@@ -190,7 +194,7 @@ PHP_METHOD(ValkeyGlideCluster, __construct) {
     valkey_glide_init_common_constructor_params(&common_params);
     valkey_glide_object* valkey_glide;
 
-    ZEND_PARSE_PARAMETERS_START(0, 23)
+    ZEND_PARSE_PARAMETERS_START(0, 25)
     Z_PARAM_OPTIONAL
     Z_PARAM_STRING_OR_NULL(name, name_len)
     Z_PARAM_ARRAY_OR_NULL(seeds)
@@ -215,6 +219,8 @@ PHP_METHOD(ValkeyGlideCluster, __construct) {
     Z_PARAM_ARRAY_OR_NULL(client_side_cache)
     Z_PARAM_ZVAL_OR_NULL(address_resolver)
     Z_PARAM_ARRAY_OR_NULL(circuit_breaker)
+    Z_PARAM_STRING_OR_NULL(lib_name, lib_name_len)
+    Z_PARAM_STRING_OR_NULL(client_info_tag, client_info_tag_len)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_THROWS());
 
     valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, getThis());
@@ -255,6 +261,15 @@ PHP_METHOD(ValkeyGlideCluster, __construct) {
         common_params.context = phpredis_context;
     }
 
+    {
+        const char* metadata_error = client_metadata_validation_error(
+            lib_name, lib_name_len, client_info_tag, client_info_tag_len);
+        if (metadata_error != NULL) {
+            zend_throw_exception(get_valkey_glide_exception_ce(), metadata_error, 0);
+            return;
+        }
+    }
+
     /* Populate common_params */
     common_params.addresses               = addresses;
     common_params.use_tls                 = use_tls;
@@ -267,6 +282,10 @@ PHP_METHOD(ValkeyGlideCluster, __construct) {
     common_params.client_name_len         = client_name_len;
     common_params.client_az               = client_az;
     common_params.client_az_len           = client_az_len;
+    common_params.lib_name                = lib_name;
+    common_params.lib_name_len            = lib_name_len;
+    common_params.client_info_tag         = client_info_tag;
+    common_params.client_info_tag_len     = client_info_tag_len;
     common_params.advanced_config         = advanced_config;
     common_params.lazy_connect            = lazy_connect;
     common_params.lazy_connect_is_null    = lazy_connect_is_null;

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -272,10 +272,25 @@ class ValkeyGlideCluster
      * @param array|null $client_side_cache     Client-side cache configuration array from ClientSideCache::toArray():
      *                                          ['cache_id' => string, 'max_cache_kb' => int, 'entry_ttl_ms' => int,
      *                                          'eviction_policy' => ?int, 'enable_metrics' => bool]
+     * @param callable|null $address_resolver   Custom address resolver callback
      * @param array|null $circuit_breaker       Circuit breaker configuration:
      *                                          ['window_size_ms' => int, 'failure_rate_threshold' => float,
      *                                           'min_errors' => int, 'open_timeout_ms' => int,
      *                                           'count_timeouts' => bool, 'consecutive_successes' => int]
+     * @param string|null $lib_name             Override the library name sent via CLIENT SETINFO LIB-NAME (default: "GlidePHP").
+     *                                          An empty string (or null) is treated as UNSET, yielding the
+     *                                          default. A non-empty value must contain only printable ASCII,
+     *                                          excluding space, '(' and ')'
+     *                                          (^[\x21-\x27\x2A-\x7E]+$). Parentheses are reserved: the binding
+     *                                          itself adds the single "(tag)" pair when composing
+     *                                          "<lib_name>(<client_info_tag>)". Use client_info_tag for a
+     *                                          parenthesised suffix.
+     * @param string|null $client_info_tag      Tag appended to the resolved library name as "<resolved-lib-name>(tag)"
+     *                                          for framework attribution (e.g. "GlidePHP(tag)" by default, or
+     *                                          "<lib_name>(tag)" when lib_name is set). An empty string (or null)
+     *                                          is treated as UNSET, so no "(tag)" suffix is added. A non-empty
+     *                                          value must contain only printable ASCII, excluding space, '('
+     *                                          and ')' (^[\x21-\x27\x2A-\x7E]+$).
      *
      * Note: Cannot mix PHPRedis-style and ValkeyGlide-style parameters.
      */
@@ -303,6 +318,8 @@ class ValkeyGlideCluster
         ?array $client_side_cache = null,
         ?callable $address_resolver = null,
         ?array $circuit_breaker = null,
+        ?string $lib_name = null,
+        ?string $client_info_tag = null,
     ) {
     }
 

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -43,6 +43,37 @@ extern zend_class_entry* get_valkey_glide_exception_ce();
 extern char* long_to_string(long value, size_t* len);
 extern char* double_to_string(double value, size_t* len);
 
+/*
+ * Pure resolver for the library name reported to the server, given the
+ * (already validated) lib_name override and client_info_tag. Behaviour matrix:
+ *
+ *   lib_name   client_info_tag   result
+ *   --------   ---------------   ---------------------------
+ *   unset      unset             "GlidePHP"
+ *   set        unset             "<lib_name>"
+ *   unset      set               "GlidePHP(<tag>)"
+ *   set        set               "<lib_name>(<tag>)"
+ *
+ * The default identity comes solely from VALKEY_GLIDE_LIB_NAME (common.h) so
+ * there is a single source of truth and no value is hardcoded at the call site.
+ * The binding always sends its own default rather than relying on the Rust-core
+ * fallback, so the reported identity does not depend on core build configuration.
+ * The returned string is always heap-owned (emalloc) and must be freed by the
+ * caller with efree once the ConnectionRequest has been serialized.
+ */
+static char* valkey_glide_resolve_lib_name(const char* lib_name, const char* client_info_tag) {
+    bool        have_lib = (lib_name != NULL && lib_name[0] != '\0');
+    bool        have_tag = (client_info_tag != NULL && client_info_tag[0] != '\0');
+    const char* base     = have_lib ? lib_name : VALKEY_GLIDE_LIB_NAME;
+
+    if (have_tag) {
+        size_t composed_len = strlen(base) + strlen(client_info_tag) + 3; /* '(' ')' '\0' */
+        char*  composed     = emalloc(composed_len);
+        snprintf(composed, composed_len, "%s(%s)", base, client_info_tag);
+        return composed;
+    }
+    return estrdup(base);
+}
 
 /* Create a connection request in protobuf format. Made visible for testing. */
 uint8_t* create_connection_request(size_t*                                   len,
@@ -235,6 +266,14 @@ uint8_t* create_connection_request(size_t*                                   len
     /* Set client name */
     conn_req.client_name = config->client_name ? config->client_name : NULL;
 
+    /* Resolve lib_name via the pure resolver. Always returns a heap-owned,
+     * non-NULL string (defaults to VALKEY_GLIDE_LIB_NAME), so the binding
+     * always reports its own identity rather than relying on the core default.
+     * Freed after packing below. */
+    char* composed_lib_name =
+        valkey_glide_resolve_lib_name(config->lib_name, config->client_info_tag);
+    conn_req.lib_name = composed_lib_name;
+
     /* Set client AZ */
     if (config->client_az) {
         conn_req.client_az = config->client_az;
@@ -310,12 +349,20 @@ uint8_t* create_connection_request(size_t*                                   len
     /* Allocate memory for the serialized message */
     uint8_t* buffer = (uint8_t*) emalloc(*len);
     if (!buffer) {
+        efree(composed_lib_name);
         *len = 0;
         return NULL;
     }
 
     /* Serialize the message */
     connection_request__connection_request__pack(&conn_req, buffer);
+
+    /* Free the temporary composed lib_name. T-3: valkey_glide_resolve_lib_name
+     * cannot return NULL (emalloc/estrdup bail out on OOM and `base` is non-NULL
+     * by construction), so guarding here would advertise a nullable contract that
+     * does not exist -- and protobuf-c omits a NULL string field from the wire,
+     * which would be a silent identity regression. */
+    efree(composed_lib_name);
 
     return buffer;
 }

--- a/valkey_glide_monitor.c
+++ b/valkey_glide_monitor.c
@@ -117,15 +117,19 @@ void free_valkey_glide_monitor_object(zend_object* object) {
 /* ------------------------------------------------------------------ */
 
 PHP_METHOD(ValkeyGlideMonitor, __construct) {
-    zval*     addresses       = NULL;
-    zend_bool use_tls         = 0;
-    zval*     credentials     = NULL;
-    zval*     database_id_zv  = NULL;
-    char*     client_name     = NULL;
-    size_t    client_name_len = 0;
-    zval*     context         = NULL;
+    zval*     addresses           = NULL;
+    zend_bool use_tls             = 0;
+    zval*     credentials         = NULL;
+    zval*     database_id_zv      = NULL;
+    char*     client_name         = NULL;
+    size_t    client_name_len     = 0;
+    zval*     context             = NULL;
+    char*     lib_name            = NULL;
+    size_t    lib_name_len        = 0;
+    char*     client_info_tag     = NULL;
+    size_t    client_info_tag_len = 0;
 
-    ZEND_PARSE_PARAMETERS_START(0, 6)
+    ZEND_PARSE_PARAMETERS_START(0, 8)
     Z_PARAM_OPTIONAL
     Z_PARAM_ARRAY_OR_NULL(addresses)
     Z_PARAM_BOOL(use_tls)
@@ -133,6 +137,8 @@ PHP_METHOD(ValkeyGlideMonitor, __construct) {
     Z_PARAM_ZVAL_OR_NULL(database_id_zv)
     Z_PARAM_STRING_OR_NULL(client_name, client_name_len)
     Z_PARAM_ZVAL_OR_NULL(context)
+    Z_PARAM_STRING_OR_NULL(lib_name, lib_name_len)
+    Z_PARAM_STRING_OR_NULL(client_info_tag, client_info_tag_len)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_THROWS());
 
     valkey_glide_monitor_object* obj = VALKEY_GLIDE_MONITOR_ZVAL_GET_OBJECT(getThis());
@@ -148,9 +154,13 @@ PHP_METHOD(ValkeyGlideMonitor, __construct) {
         common_params.database_id         = Z_LVAL_P(database_id_zv);
         common_params.database_id_is_null = false;
     }
-    common_params.client_name     = client_name;
-    common_params.client_name_len = client_name_len;
-    common_params.context         = context;
+    common_params.client_name         = client_name;
+    common_params.client_name_len     = client_name_len;
+    common_params.context             = context;
+    common_params.lib_name            = lib_name;
+    common_params.lib_name_len        = lib_name_len;
+    common_params.client_info_tag     = client_info_tag;
+    common_params.client_info_tag_len = client_info_tag_len;
 
     /* Default to localhost:6379 when no addresses are supplied. */
     zval      addresses_array;
@@ -174,6 +184,23 @@ PHP_METHOD(ValkeyGlideMonitor, __construct) {
         if (created_addresses)
             zval_ptr_dtor(&addresses_array);
         RETURN_THROWS();
+    }
+
+    /* Validate lib_name and client_info_tag charset, as the standalone and cluster
+     * constructors do, so a monitor client reports the same effective library name
+     * and rejects the same values. */
+    {
+        const char* metadata_error =
+            client_metadata_validation_error(common_params.lib_name,
+                                             common_params.lib_name_len,
+                                             common_params.client_info_tag,
+                                             common_params.client_info_tag_len);
+        if (metadata_error != NULL) {
+            zend_throw_exception(get_valkey_glide_exception_ce(), metadata_error, 0);
+            if (created_addresses)
+                zval_ptr_dtor(&addresses_array);
+            RETURN_THROWS();
+        }
     }
 
     valkey_glide_base_client_configuration_t client_config;

--- a/valkey_glide_monitor.stub.php
+++ b/valkey_glide_monitor.stub.php
@@ -73,6 +73,14 @@ final class ValkeyGlideMonitor
      * @param int|null        $database_id  Database index to select.
      * @param string|null     $client_name  Client name reported to the server.
      * @param mixed           $context      Stream context for TLS.
+     * @param string|null     $lib_name     Override the library name sent via CLIENT SETINFO LIB-NAME
+     *                                      (default: "GlidePHP"). Empty is treated as UNSET. A non-empty
+     *                                      value must contain only printable ASCII, excluding space, '('
+     *                                      and ')' (^[\x21-\x27\x2A-\x7E]+$).
+     * @param string|null     $client_info_tag Tag appended to the resolved library name as
+     *                                      "<resolved-lib-name>(tag)" for framework attribution. Empty is
+     *                                      treated as UNSET, so no "(tag)" suffix is added. Same charset
+     *                                      restriction as $lib_name.
      *
      * @throws ValkeyGlideException If the connection cannot be established.
      */
@@ -82,7 +90,9 @@ final class ValkeyGlideMonitor
         ?array $credentials = null,
         ?int $database_id = null,
         ?string $client_name = null,
-        mixed $context = null
+        mixed $context = null,
+        ?string $lib_name = null,
+        ?string $client_info_tag = null
     ) {
     }
 

--- a/valkey_glide_pubsub_common.c
+++ b/valkey_glide_pubsub_common.c
@@ -63,8 +63,14 @@ void cond_wait(cond_t* c, mutex_t* m) {
 #endif
 }
 
-#define NSEC_PER_SEC 1000000000LL
-#define NSEC_PER_MSEC 1000000LL
+/* M-6: project-owned names. Previously these were NSEC_PER_SEC / NSEC_PER_MSEC
+ * behind #ifndef guards, which collided with macOS's mach/clock_types.h. The
+ * guards resolved the -Werror build failure but let the platform's definition win
+ * silently -- and the platform spells them `ull` where we mean `LL`, so the
+ * timeout arithmetic below would quietly convert to unsigned. Owning the names
+ * removes both the collision and the signedness ambiguity. */
+#define VALKEY_GLIDE_NSEC_PER_SEC 1000000000LL
+#define VALKEY_GLIDE_NSEC_PER_MSEC 1000000LL
 
 int cond_timedwait(cond_t* c, mutex_t* m, unsigned int timeout_ms) {
 #ifdef _WIN32
@@ -82,9 +88,10 @@ int cond_timedwait(cond_t* c, mutex_t* m, unsigned int timeout_ms) {
     // divide/modulo (pthread_cond_timedwait requires tv_nsec in [0, 1e9)).
     // e.g. a current tv_nsec of 800,000,000 plus a 300 ms timeout
     // (300,000,000 ns) totals 1,100,000,000 ns -> +1 s and 100,000,000 ns.
-    long long total_ns = (long long) ts.tv_nsec + (long long) timeout_ms * NSEC_PER_MSEC;
-    ts.tv_sec += total_ns / NSEC_PER_SEC;
-    ts.tv_nsec = total_ns % NSEC_PER_SEC;
+    long long total_ns =
+        (long long) ts.tv_nsec + (long long) timeout_ms * VALKEY_GLIDE_NSEC_PER_MSEC;
+    ts.tv_sec += total_ns / VALKEY_GLIDE_NSEC_PER_SEC;
+    ts.tv_nsec = total_ns % VALKEY_GLIDE_NSEC_PER_SEC;
     return pthread_cond_timedwait(c, m, &ts);
 #endif
 }


### PR DESCRIPTION
## Summary

Adds two new parameters to `ValkeyGlide::connect()` and `ValkeyGlideCluster::__construct()`:

1. **`lib_name`** — overrides the `CLIENT SETINFO LIB-NAME` value. When unset, Rust core default (`GlidePHP`) is preserved.
2. **`client_info_tag`** — appends a parenthesized tag to the resolved library name, e.g. `GlidePHP(my-framework:1.0)`. Follows the ioredis convention for framework attribution.

Closes tracking for PHP parity with valkey-io/valkey-glide#6389 (Python implementation).

## Behavior Matrix

| Config | Resulting `lib-name` |
|---|---|
| _(none)_ | `GlidePHP` (Rust core default) |
| `client_info_tag='fw:1.0'` | `GlidePHP(fw:1.0)` |
| `lib_name='custom'` | `custom` |
| `lib_name='custom'`, `client_info_tag='fw:1.0'` | `custom(fw:1.0)` |

## What Changed

- **`common.h`** — Added `lib_name` and `client_info_tag` fields to both the base client configuration struct and the common constructor params struct.
- **`valkey_glide.c`** — Parse new params in `connect()`, validate `client_info_tag` has no whitespace, pass to connection builder.
- **`valkey_glide_cluster.c`** — Same for cluster client.
- **`valkey_glide_core_commands.c`** — Compose `lib_name` from override and/or tag, set `conn_req.lib_name` (protobuf field 19).
- **`valkey_glide.stub.php`** / **`valkey_glide_cluster.stub.php`** — PHP-visible parameter documentation.
- **`src/client_constructor_mock.c`** / **`.stub.php`** — Mock support for unit testing.
- **`tests/ConnectionRequestTest.php`** — Unit tests for protobuf serialization.
- **`tests/ValkeyGlideFeaturesTest.php`** — Integration tests verifying CLIENT INFO output.

## Testing

- Unit tests via `ConnectionRequestTest` (protobuf field assertions, whitespace validation)
- Integration tests via `ValkeyGlideFeaturesTest` (real connection CLIENT INFO verification)

## Notes

- `lib_name` protobuf field 19 already exists in ConnectionRequest and is consumed by Rust core (Java and Python clients already set it).
- No proto or Rust-core changes required — this is a PHP binding-only change.