### PR TITLE
feat(php): Implement lolwut command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* Add `LOLWUT` command for standalone and cluster clients ([#314](https://github.com/valkey-io/valkey-glide-php/pull/314))
 * Add `CLIENT TRACKINGINFO` command for standalone and cluster clients ([#293](https://github.com/valkey-io/valkey-glide-php/pull/293))
 * Add `LATENCY HISTORY`, `LATENCY LATEST`, and `LATENCY RESET` commands for standalone and cluster clients ([#283](https://github.com/valkey-io/valkey-glide-php/pull/283))
 * Add `MEMORY DOCTOR`, `MEMORY MALLOC-STATS`, `MEMORY PURGE`, and `MEMORY STATS` commands for standalone and cluster clients ([#285](https://github.com/valkey-io/valkey-glide-php/pull/285))

--- a/tests/TestSuite.php
+++ b/tests/TestSuite.php
@@ -841,7 +841,7 @@ class TestSuite
         try {
             $callable();
             $this->fail('Expected exception of type ' . $exceptionClass . ' was not thrown.');
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             if ($e instanceof $exceptionClass) {
                 return;
             }

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -1399,6 +1399,36 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
         $this->assertEquals(strval(intval($usec)), strval($usec));
     }
 
+    public function testLolwut()
+    {
+        $this->assertLolwutResponse($this->valkey_glide->lolwut());
+        $this->assertLolwutResponse($this->valkey_glide->lolwut(null, [], 'randomNode'));
+        $this->assertLolwutResponse($this->valkey_glide->lolwut(5, null, 'randomNode'));
+        $this->assertLolwutResponse($this->valkey_glide->lolwut(6, [50, 20], 'randomNode'));
+
+        $all_nodes_responses = $this->valkey_glide->lolwut(null, [50, 20], 'allNodes');
+        $this->assertIsArray($all_nodes_responses);
+        foreach ($all_nodes_responses as $response) {
+            $this->assertLolwutResponse($response);
+        }
+
+        if ($this->is_valkey && $this->minVersionCheck('9.0.0')) {
+            $all_nodes_responses = $this->valkey_glide->lolwut(null, [30, 4], 'allNodes');
+            $this->assertIsArray($all_nodes_responses);
+            foreach ($all_nodes_responses as $response) {
+                $this->assertLolwutResponse($response);
+            }
+            $this->assertLolwutResponse(
+                $this->valkey_glide->lolwut(null, [40, 20, 1, 2], 'randomNode')
+            );
+        }
+    }
+
+    // Cluster batches cannot preserve LOLWUT routing; covered by standalone batch tests.
+    public function testLolwutBatch()
+    {
+    }
+
     public function testScan()
     {
         set_time_limit(getenv("VALGRIND_TEST") ? 300 : 10); // Enforce a 10-second limit on this test

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -1402,31 +1402,36 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
     public function testLolwut()
     {
         $this->assertLolwutResponse($this->valkey_glide->lolwut());
+        $this->assertLolwutResponse($this->valkey_glide->lolwut(null, null, null));
         $this->assertLolwutResponse($this->valkey_glide->lolwut(null, [], 'randomNode'));
         $this->assertLolwutResponse($this->valkey_glide->lolwut(5, null, 'randomNode'));
         $this->assertLolwutResponse($this->valkey_glide->lolwut(6, [50, 20], 'randomNode'));
 
-        $all_nodes_responses = $this->valkey_glide->lolwut(null, [50, 20], 'allNodes');
-        $this->assertIsArray($all_nodes_responses);
-        foreach ($all_nodes_responses as $response) {
-            $this->assertLolwutResponse($response);
-        }
+        $this->assertLolwutClusterResponses(
+            $this->valkey_glide->lolwut(null, [50, 20], 'allNodes')
+        );
+        $this->assertLolwutClusterResponses(
+            $this->valkey_glide->lolwut(null, [50, 20], 'allPrimaries')
+        );
 
         if ($this->is_valkey && $this->minVersionCheck('9.0.0')) {
-            $all_nodes_responses = $this->valkey_glide->lolwut(null, [30, 4], 'allNodes');
-            $this->assertIsArray($all_nodes_responses);
-            foreach ($all_nodes_responses as $response) {
-                $this->assertLolwutResponse($response);
-            }
+            $this->assertLolwutClusterResponses(
+                $this->valkey_glide->lolwut(null, [30, 4], 'allNodes')
+            );
             $this->assertLolwutResponse(
                 $this->valkey_glide->lolwut(null, [40, 20, 1, 2], 'randomNode')
             );
         }
     }
 
-    // Cluster batches cannot preserve LOLWUT routing; covered by standalone batch tests.
     public function testLolwutBatch()
     {
+        $this->valkey_glide->pipeline();
+        try {
+            $this->assertFalse($this->valkey_glide->lolwut());
+        } finally {
+            $this->assertTrue($this->valkey_glide->discard());
+        }
     }
 
     public function testScan()

--- a/tests/ValkeyGlideClusterTest.php
+++ b/tests/ValkeyGlideClusterTest.php
@@ -1426,9 +1426,26 @@ class ValkeyGlideClusterTest extends ValkeyGlideTest
 
     public function testLolwutBatch()
     {
+        if (!$this->havePipeline()) {
+            $this->markTestSkipped('Pipeline not supported');
+            return;
+        }
+
+        // Routeless LOLWUT can be queued in a cluster pipeline.
+        $responses = $this->valkey_glide->multi()
+            ->lolwut()
+            ->lolwut(6, [50, 20])
+            ->exec();
+
+        $this->assertIsArray($responses, 2);
+        foreach ($responses as $response) {
+            $this->assertLolwutResponse($response);
+        }
+
+        // A routed LOLWUT cannot be queued in cluster batch mode.
         $this->valkey_glide->pipeline();
         try {
-            $this->assertFalse($this->valkey_glide->lolwut());
+            $this->assertFalse($this->valkey_glide->lolwut(null, null, 'allNodes'));
         } finally {
             $this->assertTrue($this->valkey_glide->discard());
         }

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -6666,7 +6666,23 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
     {
         $this->assertIsString($response);
         if (is_string($response)) {
-            $this->assertStringContains('ver', strtolower($response));
+            $response = strtolower($response);
+            $this->assertStringContains('ver', $response);
+            $this->assertStringContains(strtolower($this->version), $response);
+        }
+    }
+
+    protected function assertLolwutClusterResponses($responses): void
+    {
+        $this->assertIsArray($responses);
+        if (!is_array($responses)) {
+            return;
+        }
+
+        $this->assertGT(0, count($responses));
+        foreach ($responses as $node_address => $response) {
+            $this->assertIsString($node_address);
+            $this->assertLolwutResponse($response);
         }
     }
 
@@ -6683,6 +6699,22 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
             $this->assertLolwutResponse($this->valkey_glide->lolwut(null, [30, 4]));
             $this->assertLolwutResponse($this->valkey_glide->lolwut(null, [40, 20, 1, 2]));
         }
+    }
+
+    public function testLolwutInvalidArguments()
+    {
+        $this->assertThrows(
+            ValkeyGlideException::class,
+            fn() => $this->valkey_glide->lolwut('6')
+        );
+        $this->assertThrows(
+            ValkeyGlideException::class,
+            fn() => $this->valkey_glide->lolwut(null, '50,20')
+        );
+        $this->assertThrows(
+            ValkeyGlideException::class,
+            fn() => $this->valkey_glide->lolwut(null, [50, '20'])
+        );
     }
 
     public function testLolwutBatch()

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -6662,6 +6662,43 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
 
 
 
+    protected function assertLolwutResponse($response): void
+    {
+        $this->assertIsString($response);
+        if (is_string($response)) {
+            $this->assertStringContains('ver', strtolower($response));
+        }
+    }
+
+    public function testLolwut()
+    {
+        $this->assertLolwutResponse($this->valkey_glide->lolwut());
+        $this->assertLolwutResponse($this->valkey_glide->lolwut(null, []));
+        $this->assertLolwutResponse($this->valkey_glide->lolwut(null, [50, 20]));
+        $this->assertLolwutResponse($this->valkey_glide->lolwut(5));
+        $this->assertLolwutResponse($this->valkey_glide->lolwut(5, [30, 4, 4]));
+        $this->assertLolwutResponse($this->valkey_glide->lolwut(6, [50, 20]));
+
+        if ($this->is_valkey && $this->minVersionCheck('9.0.0')) {
+            $this->assertLolwutResponse($this->valkey_glide->lolwut(null, [30, 4]));
+            $this->assertLolwutResponse($this->valkey_glide->lolwut(null, [40, 20, 1, 2]));
+        }
+    }
+
+    public function testLolwutBatch()
+    {
+        $responses = $this->valkey_glide->multi()
+            ->lolwut()
+            ->lolwut(5)
+            ->lolwut(6, [50, 20])
+            ->exec();
+
+        $this->assertIsArray($responses, 3);
+        foreach ($responses as $response) {
+            $this->assertLolwutResponse($response);
+        }
+    }
+
     /**
      * Scan and variants
      */

--- a/tests/ValkeyGlideTest.php
+++ b/tests/ValkeyGlideTest.php
@@ -6695,22 +6695,48 @@ class ValkeyGlideTest extends ValkeyGlideBaseTest
         $this->assertLolwutResponse($this->valkey_glide->lolwut(5, [30, 4, 4]));
         $this->assertLolwutResponse($this->valkey_glide->lolwut(6, [50, 20]));
 
+        // Scalar arguments are coerced like other integer arguments.
+        $this->assertLolwutResponse($this->valkey_glide->lolwut('6'));
+
+        // Parameters holding references are dereferenced before sending.
+        $width = 50;
+        $height = 20;
+        $this->assertLolwutResponse($this->valkey_glide->lolwut(null, [&$width, &$height]));
+
         if ($this->is_valkey && $this->minVersionCheck('9.0.0')) {
             $this->assertLolwutResponse($this->valkey_glide->lolwut(null, [30, 4]));
             $this->assertLolwutResponse($this->valkey_glide->lolwut(null, [40, 20, 1, 2]));
         }
     }
 
+    public function testLolwutParametersAffectOutput()
+    {
+        // The response size scales with the requested canvas, so a larger
+        // canvas must produce a longer reply. This proves the numeric
+        // parameters actually reach the server rather than being dropped.
+        $small = $this->valkey_glide->lolwut(null, [10, 2]);
+        $large = $this->valkey_glide->lolwut(null, [100, 20]);
+
+        $this->assertIsString($small);
+        $this->assertIsString($large);
+        if (is_string($small) && is_string($large)) {
+            $this->assertGT(strlen($small), strlen($large));
+        }
+    }
+
     public function testLolwutInvalidArguments()
     {
+        // A non-numeric version cannot be coerced to int -> TypeError.
         $this->assertThrows(
-            ValkeyGlideException::class,
-            fn() => $this->valkey_glide->lolwut('6')
+            TypeError::class,
+            fn() => $this->valkey_glide->lolwut('abc')
         );
+        // Parameters must be an array -> TypeError.
         $this->assertThrows(
-            ValkeyGlideException::class,
+            TypeError::class,
             fn() => $this->valkey_glide->lolwut(null, '50,20')
         );
+        // Non-integer parameter elements are rejected.
         $this->assertThrows(
             ValkeyGlideException::class,
             fn() => $this->valkey_glide->lolwut(null, [50, '20'])

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -3583,6 +3583,24 @@ class ValkeyGlide
     public function time(): ValkeyGlide|array;
 
     /**
+     * Returns Valkey's LOLWUT output.
+     *
+     * When provided, $version is sent as `VERSION <version>`. The optional $parameters
+     * are appended as the command's numeric parameters. Their supported count and meaning
+     * depend on the selected version and the server version.
+     *
+     * @param int|null   $version    Optional LOLWUT version.
+     * @param array|null $parameters Optional integer parameters.
+     *
+     * @return ValkeyGlide|string|false The LOLWUT output, or false on failure.
+     *
+     * @see https://valkey.io/commands/lolwut
+     *
+     * @example $valkey_glide->lolwut(6, [50, 20]);
+     */
+    public function lolwut(?int $version = null, ?array $parameters = null): ValkeyGlide|string|false;
+
+    /**
      * Get the amount of time a ValkeyGlide key has before it will expire, in seconds.
      *
      * @param string $key      The Key we want the TTL for.

--- a/valkey_glide_cluster.c
+++ b/valkey_glide_cluster.c
@@ -1116,6 +1116,11 @@ GEOSEARCHSTORE_METHOD_IMPL(ValkeyGlideCluster)
 TIME_METHOD_IMPL(ValkeyGlideCluster)
 /* }}} */
 
+/* {{{ proto string|array ValkeyGlideCluster::lolwut([int $version, array $parameters, mixed
+ * $route]) */
+LOLWUT_METHOD_IMPL(ValkeyGlideCluster)
+/* }}} */
+
 /* {{{ proto string ValkeyGlideCluster::randomkey(string key)
  *     proto string ValkeyGlideCluster::randomkey(array host_port) */
 RANDOMKEY_METHOD_IMPL(ValkeyGlideCluster)

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1328,6 +1328,13 @@ class ValkeyGlideCluster
     /**
      * @see ValkeyGlide::lolwut
      *
+     * When $route is omitted or null, the command is sent to a random node and returns a string.
+     * The 'allNodes' and 'allPrimaries' routes return an associative array mapping node addresses
+     * to strings. A specific node address route returns a string.
+     *
+     * This command cannot be queued in cluster batch or pipeline mode because those modes cannot
+     * preserve a per-command route; it returns false when called in either mode.
+     *
      * @param int|null   $version    Optional LOLWUT version.
      * @param array|null $parameters Optional integer parameters.
      * @param mixed      $route      Optional routing: 'allPrimaries', 'allNodes', 'randomNode',

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1326,6 +1326,23 @@ class ValkeyGlideCluster
     public function time(mixed $route): ValkeyGlideCluster|bool|array;
 
     /**
+     * @see ValkeyGlide::lolwut
+     *
+     * @param int|null   $version    Optional LOLWUT version.
+     * @param array|null $parameters Optional integer parameters.
+     * @param mixed      $route      Optional routing: 'allPrimaries', 'allNodes', 'randomNode',
+     *                               or a specific node address.
+     *
+     * @return ValkeyGlideCluster|string|array|false A string for a single-node route, an array
+     *                                                keyed by node for a multi-node route, or false on failure.
+     */
+    public function lolwut(
+        ?int $version = null,
+        ?array $parameters = null,
+        mixed $route = null
+    ): ValkeyGlideCluster|string|array|false;
+
+    /**
      * @see ValkeyGlide::ttl
      */
     public function ttl(string $key): ValkeyGlideCluster|int|false;

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -1342,39 +1342,46 @@ int execute_time_command(zval* object, int argc, zval* return_value, zend_class_
 /* Execute a LOLWUT command using the Valkey Glide client. */
 int execute_lolwut_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
     valkey_glide_object* valkey_glide;
-    zval*                version    = NULL;
-    zval*                parameters = NULL;
-    zval*                route      = NULL;
-    zend_bool            is_cluster = (ce == get_valkey_glide_cluster_ce());
+    zend_long            version_val     = 0;
+    zend_bool            version_is_null = 1;
+    zval*                parameters      = NULL;
+    zval*                route           = NULL;
+    zend_bool            is_cluster      = (ce == get_valkey_glide_cluster_ce());
 
     valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
     if (!valkey_glide || !valkey_glide->glide_client) {
         return 0;
     }
 
-    /* Cluster batches cannot preserve a per-command route. */
-    if (is_cluster && valkey_glide->is_in_batch_mode) {
-        return 0;
-    }
-
+    /* Parse arguments. Scalar types are coerced to match the declared stub
+     * signatures (e.g. lolwut('6') behaves like lolwut(6)), consistent with
+     * how other commands parse their `int`/`array` arguments. */
     if (is_cluster) {
-        if (zend_parse_method_parameters(
-                argc, object, "O|z!z!z!", &object, ce, &version, &parameters, &route) == FAILURE) {
+        if (zend_parse_method_parameters(argc,
+                                         object,
+                                         "O|l!a!z!",
+                                         &object,
+                                         ce,
+                                         &version_val,
+                                         &version_is_null,
+                                         &parameters,
+                                         &route) == FAILURE) {
             return 0;
         }
-    } else if (zend_parse_method_parameters(
-                   argc, object, "O|z!z!", &object, ce, &version, &parameters) == FAILURE) {
+    } else if (zend_parse_method_parameters(argc,
+                                            object,
+                                            "O|l!a!",
+                                            &object,
+                                            ce,
+                                            &version_val,
+                                            &version_is_null,
+                                            &parameters) == FAILURE) {
         return 0;
     }
 
-    if (version && Z_TYPE_P(version) != IS_NULL && Z_TYPE_P(version) != IS_LONG) {
-        zend_throw_exception(
-            get_valkey_glide_exception_ce(), "LOLWUT version must be an integer", 0);
-        return 0;
-    }
-    if (parameters && Z_TYPE_P(parameters) != IS_NULL && Z_TYPE_P(parameters) != IS_ARRAY) {
-        zend_throw_exception(
-            get_valkey_glide_exception_ce(), "LOLWUT parameters must be an array of integers", 0);
+    /* Cluster batches cannot preserve a per-command route, so reject only when
+     * an explicit route is supplied. Routeless calls queue and exec normally. */
+    if (is_cluster && valkey_glide->is_in_batch_mode && route && Z_TYPE_P(route) != IS_NULL) {
         return 0;
     }
 
@@ -1391,7 +1398,7 @@ int execute_lolwut_command(zval* object, int argc, zval* return_value, zend_clas
     uint32_t parameter_count = parameters && Z_TYPE_P(parameters) == IS_ARRAY
                                    ? zend_hash_num_elements(Z_ARRVAL_P(parameters))
                                    : 0;
-    uint32_t arg_count       = parameter_count + (version && Z_TYPE_P(version) == IS_LONG ? 2 : 0);
+    uint32_t arg_count       = parameter_count + (version_is_null ? 0 : 2);
 
     if (arg_count > 0) {
         core_args.all_args = ecalloc(arg_count, sizeof(core_arg_t));
@@ -1403,20 +1410,21 @@ int execute_lolwut_command(zval* object, int argc, zval* return_value, zend_clas
     }
 
     uint32_t arg_index = 0;
-    if (version && Z_TYPE_P(version) == IS_LONG) {
+    if (!version_is_null) {
         core_args.all_args[arg_index].type                  = CORE_ARG_TYPE_STRING;
         core_args.all_args[arg_index].data.string_arg.value = "VERSION";
         core_args.all_args[arg_index].data.string_arg.len   = sizeof("VERSION") - 1;
         arg_index++;
 
         core_args.all_args[arg_index].type                = CORE_ARG_TYPE_LONG;
-        core_args.all_args[arg_index].data.long_arg.value = Z_LVAL_P(version);
+        core_args.all_args[arg_index].data.long_arg.value = version_val;
         arg_index++;
     }
 
     if (parameters && Z_TYPE_P(parameters) == IS_ARRAY) {
         zval* parameter;
         ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(parameters), parameter) {
+            ZVAL_DEREF(parameter);
             if (Z_TYPE_P(parameter) != IS_LONG) {
                 efree(core_args.all_args);
                 zend_throw_exception(get_valkey_glide_exception_ce(),

--- a/valkey_glide_commands.c
+++ b/valkey_glide_commands.c
@@ -1339,6 +1339,110 @@ int execute_time_command(zval* object, int argc, zval* return_value, zend_class_
         valkey_glide, &core_args, process_core_array_result, return_value, object);
 }
 
+/* Execute a LOLWUT command using the Valkey Glide client. */
+int execute_lolwut_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
+    valkey_glide_object* valkey_glide;
+    zval*                version    = NULL;
+    zval*                parameters = NULL;
+    zval*                route      = NULL;
+    zend_bool            is_cluster = (ce == get_valkey_glide_cluster_ce());
+
+    valkey_glide = VALKEY_GLIDE_PHP_ZVAL_GET_OBJECT(valkey_glide_object, object);
+    if (!valkey_glide || !valkey_glide->glide_client) {
+        return 0;
+    }
+
+    /* Cluster batches cannot preserve a per-command route. */
+    if (is_cluster && valkey_glide->is_in_batch_mode) {
+        return 0;
+    }
+
+    if (is_cluster) {
+        if (zend_parse_method_parameters(
+                argc, object, "O|z!z!z!", &object, ce, &version, &parameters, &route) == FAILURE) {
+            return 0;
+        }
+    } else if (zend_parse_method_parameters(
+                   argc, object, "O|z!z!", &object, ce, &version, &parameters) == FAILURE) {
+        return 0;
+    }
+
+    if (version && Z_TYPE_P(version) != IS_NULL && Z_TYPE_P(version) != IS_LONG) {
+        zend_throw_exception(
+            get_valkey_glide_exception_ce(), "LOLWUT version must be an integer", 0);
+        return 0;
+    }
+    if (parameters && Z_TYPE_P(parameters) != IS_NULL && Z_TYPE_P(parameters) != IS_ARRAY) {
+        zend_throw_exception(
+            get_valkey_glide_exception_ce(), "LOLWUT parameters must be an array of integers", 0);
+        return 0;
+    }
+
+    core_command_args_t core_args = {0};
+    core_args.glide_client        = valkey_glide->glide_client;
+    core_args.cmd_type            = Lolwut;
+    core_args.is_cluster          = is_cluster;
+
+    if (is_cluster && route && Z_TYPE_P(route) != IS_NULL) {
+        core_args.has_route   = 1;
+        core_args.route_param = route;
+    }
+
+    uint32_t parameter_count = parameters && Z_TYPE_P(parameters) == IS_ARRAY
+                                   ? zend_hash_num_elements(Z_ARRVAL_P(parameters))
+                                   : 0;
+    uint32_t arg_count       = parameter_count + (version && Z_TYPE_P(version) == IS_LONG ? 2 : 0);
+
+    if (arg_count > 0) {
+        core_args.all_args = ecalloc(arg_count, sizeof(core_arg_t));
+        if (!core_args.all_args) {
+            zend_throw_exception(
+                get_valkey_glide_exception_ce(), "Unable to allocate LOLWUT command arguments", 0);
+            return 0;
+        }
+    }
+
+    uint32_t arg_index = 0;
+    if (version && Z_TYPE_P(version) == IS_LONG) {
+        core_args.all_args[arg_index].type                  = CORE_ARG_TYPE_STRING;
+        core_args.all_args[arg_index].data.string_arg.value = "VERSION";
+        core_args.all_args[arg_index].data.string_arg.len   = sizeof("VERSION") - 1;
+        arg_index++;
+
+        core_args.all_args[arg_index].type                = CORE_ARG_TYPE_LONG;
+        core_args.all_args[arg_index].data.long_arg.value = Z_LVAL_P(version);
+        arg_index++;
+    }
+
+    if (parameters && Z_TYPE_P(parameters) == IS_ARRAY) {
+        zval* parameter;
+        ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(parameters), parameter) {
+            if (Z_TYPE_P(parameter) != IS_LONG) {
+                efree(core_args.all_args);
+                zend_throw_exception(get_valkey_glide_exception_ce(),
+                                     "LOLWUT parameters must contain only integers",
+                                     0);
+                return 0;
+            }
+            core_args.all_args[arg_index].type                = CORE_ARG_TYPE_LONG;
+            core_args.all_args[arg_index].data.long_arg.value = Z_LVAL_P(parameter);
+            arg_index++;
+        }
+        ZEND_HASH_FOREACH_END();
+    }
+    core_args.arg_count = arg_index;
+
+    z_result_processor_t processor =
+        is_cluster ? process_core_status_string_result : process_core_string_result;
+    int result =
+        execute_and_handle_batch(valkey_glide, &core_args, processor, return_value, object);
+
+    if (core_args.all_args) {
+        efree(core_args.all_args);
+    }
+
+    return result;
+}
 /* Execute a WATCH command using the Valkey Glide client */
 int execute_watch_command(zval* object, int argc, zval* return_value, zend_class_entry* ce) {
     valkey_glide_object* valkey_glide;

--- a/valkey_glide_commands_common.h
+++ b/valkey_glide_commands_common.h
@@ -249,6 +249,7 @@ int execute_memory_stats_command(zval* object, int argc, zval* return_value, zen
 int execute_reset_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_save_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_time_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
+int execute_lolwut_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_scan_command(zval* object, int argc, zval* return_value, zend_class_entry* ce);
 int execute_cluster_scan_command(const void* glide_client,
                                  char**      cursor,
@@ -575,6 +576,9 @@ int execute_unlink_command(zval* object, int argc, zval* return_value, zend_clas
 #define SCAN_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, scan, execute_scan_command)
 
 #define TIME_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, time, execute_time_command)
+
+#define LOLWUT_METHOD_IMPL(class_name) \
+    STANDARD_METHOD_IMPL(class_name, lolwut, execute_lolwut_command)
 
 #define SSCAN_METHOD_IMPL(class_name) STANDARD_METHOD_IMPL(class_name, sscan, execute_sscan_command)
 

--- a/valkey_glide_core_common.c
+++ b/valkey_glide_core_common.c
@@ -325,6 +325,7 @@ int prepare_core_args(core_command_args_t* args,
         case FlushDB:
         case LatencyHistory:
         case LatencyReset:
+        case Lolwut:
         case Migrate:
         case Ping:
         case ReplicaOf:

--- a/valkey_z_php_methods.c
+++ b/valkey_z_php_methods.c
@@ -887,6 +887,10 @@ SAVE_METHOD_IMPL(ValkeyGlide)
 TIME_METHOD_IMPL(ValkeyGlide)
 /* }}} */
 
+/* {{{ proto string ValkeyGlide::lolwut([int $version, array $parameters]) */
+LOLWUT_METHOD_IMPL(ValkeyGlide)
+/* }}} */
+
 /* {{{ proto array ValkeyGlide::scan(long &iterator [, string pattern, long count]) */
 SCAN_METHOD_IMPL(ValkeyGlide)
 /* }}} */


### PR DESCRIPTION
### Summary

Implement the `LOLWUT` command for the PHP Valkey GLIDE extension, bringing the PHP client in line with the other GLIDE language clients.

### Issue link

This Pull Request is linked to issue: [Implement LOLWUT command](https://github.com/valkey-io/valkey-glide-php/issues/308)

Closes #308

### Features / Behaviour Changes

- Adds `ValkeyGlide::lolwut(?int $version = null, ?array $parameters = null)`.
- Adds `ValkeyGlideCluster::lolwut(?int $version = null, ?array $parameters = null, mixed $route = null)`.
- Supports bare `LOLWUT`, `LOLWUT VERSION <version>`, and optional integer parameters.
- Returns a string for single-node execution and a node-address-keyed array for multi-node cluster routes.

### Implementation

- Registers the command in the standalone and cluster Zend APIs and adds PHP stub documentation.
- Marshals the optional `VERSION` token and numeric parameters through the core command argument framework using the existing `Lolwut` request type.
- Validates that the optional version and every supplied parameter are integers; command-specific arity and value validation remain server-side, matching the other GLIDE clients.
- Uses string response processing for standalone requests and cluster-aware string response processing for routed cluster requests.

### Limitations

- LOLWUT is not supported in cluster batch mode because the current PHP batch mechanism cannot preserve a per-command cluster route.
- The meaning and supported count of numeric parameters depend on the LOLWUT version and the Valkey server version.

### Testing

- Added standalone coverage for bare, empty, parameter-only, version-only, version-with-parameters, and Valkey 9 parameter forms, plus standalone transaction batching.
- Added cluster coverage for default, random-node, all-node, and Valkey 9 routing scenarios.
- Built successfully with `make` and verified both public method signatures by loading the compiled extension and inspecting them with reflection.
- `make test` could not execute integration tests in this environment because `valkey-server` is not installed.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release.
- [x] Create merge commit if merging release branch into main, squash otherwise.