### PR TITLE
Release 1.2.0

### DIFF
--- a/common.h
+++ b/common.h
@@ -11,7 +11,7 @@
 #include "valkey_glide_address_resolver.h"
 
 /* ValkeyGlidePHP version */
-#define VALKEY_GLIDE_PHP_VERSION "1.1.2"
+#define VALKEY_GLIDE_PHP_VERSION "1.2.0-rc1"
 
 #define VALKEY_GLIDE_PHP_GET_OBJECT(class_entry, o) \
     (class_entry*) ((char*) o - XtOffsetOf(class_entry, std))

--- a/package.xml
+++ b/package.xml
@@ -15,12 +15,12 @@ Note: After installation, add "extension=valkey_glide" to your php.ini file.</de
  <date>2025-01-26</date>
  <time>18:25:00</time>
  <version>
-  <release>1.1.2</release>
-  <api>1.1.2</api>
+  <release>1.2.0-rc1</release>
+  <api>1.2.0</api>
  </version>
  <stability>
-  <release>stable</release>
-  <api>stable</api>
+  <release>beta</release>
+  <api>beta</api>
  </stability>
  <license uri="https://www.apache.org/licenses/LICENSE-2.0">Apache-2.0</license>
  <notes>

--- a/package.xml
+++ b/package.xml
@@ -15,12 +15,12 @@ Note: After installation, add "extension=valkey_glide" to your php.ini file.</de
  <date>2025-01-26</date>
  <time>18:25:00</time>
  <version>
-  <release>1.2.0-rc1</release>
+  <release>1.2.0</release>
   <api>1.2.0</api>
  </version>
  <stability>
-  <release>beta</release>
-  <api>beta</api>
+  <release>stable</release>
+  <api>stable</api>
  </stability>
  <license uri="https://www.apache.org/licenses/LICENSE-2.0">Apache-2.0</license>
  <notes>

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@ Note: After installation, add "extension=valkey_glide" to your php.ini file.</de
   <email>noreply@valkey.io</email>
   <active>yes</active>
  </lead>
- <date>2025-01-26</date>
+ <date>2026-08-20</date>
  <time>18:25:00</time>
  <version>
   <release>1.2.0</release>


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!
-->

### Summary

Release branch `release-1.2` for the **v1.2.0** PHP client release. This PR cuts the first release candidate build (**rc1**).

Following the established release process, the RC marker lives only in `common.h`:
- `common.h`: `VALKEY_GLIDE_PHP_VERSION` → `1.2.0-rc1`
- `package.xml`: `<release>`/`<api>` → `1.2.0`, `<stability>` → `stable` (RC iterations bump only `common.h`; `package.xml` holds the final target version, consistent with prior releases and the `validate-version` RC skip logic)

### Issue link

This Pull Request is linked to issue (URL): _<add release tracking issue>_

### Implementation

Version bump for the 1.2.0 release candidate. Notable changes shipping in 1.2.0 since v1.1.2:

- **MUSL/Alpine Linux support** (#291)
- **MEMORY DOCTOR, MALLOC-STATS, PURGE, STATS commands** (#285)
- **LATENCY HISTORY, LATEST, RESET commands** (#283)
- **FAILOVER and REPLICAOF commands** (#282)
- **Circuit breaker configuration support** (#277)
- **MIGRATE command** (#276)
- **CLIENT PAUSE / UNPAUSE commands** (#274)
- **RESET command** (#273)
- **SAVE command** (#272)
- **BGREWRITEAOF command** (#271)
- **BGSAVE / BGSAVE SCHEDULE / BGSAVE CANCEL commands** (#237)
- **getLastError() / clearLastError() for PHPRedis compatibility** (#221, #220)
- **LOLWUT command** (#314)
- **LASTSAVE command** (#315)
- Version fix in workflow files (#260)

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
