### PR TITLE
feat(config): add mTLS (mutual TLS) client certificate support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-* Add mutual TLS (mTLS) support via `client_cert`/`client_key` (inline PEM bytes) or `client_cert_path`/`client_key_path` (file paths) in `advanced_config['tls_config']` for standalone and cluster clients ([#321](https://github.com/valkey-io/valkey-glide-php/pull/321))
+* Add mutual TLS (mTLS) support for standalone and cluster clients via `advanced_config['tls_config']` — byte-based (`client_cert`/`client_key`) or path-based with automatic certificate reload (`client_cert_path`/`client_key_path` + optional `cert_reload_interval_seconds`) ([#321](https://github.com/valkey-io/valkey-glide-php/pull/321))
 * Add `CONFIG` command for cluster client ([#284](https://github.com/valkey-io/valkey-glide-php/issues/284))
 * Add `MONITOR` command for standalone client ([#309](https://github.com/valkey-io/valkey-glide-php/pull/309))
 * Add `LOLWUT` command for standalone and cluster clients ([#314](https://github.com/valkey-io/valkey-glide-php/pull/314))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* Add mutual TLS (mTLS) support via `client_cert`/`client_key` (inline PEM bytes) or `client_cert_path`/`client_key_path` (file paths) in `advanced_config['tls_config']` for standalone and cluster clients ([#288](https://github.com/valkey-io/valkey-glide-php/issues/288))
 * Add `MONITOR` command for standalone client ([#309](https://github.com/valkey-io/valkey-glide-php/pull/309))
 * Add `LOLWUT` command for standalone and cluster clients ([#314](https://github.com/valkey-io/valkey-glide-php/pull/314))
 * Add `LASTSAVE` command for standalone and cluster clients ([#315](https://github.com/valkey-io/valkey-glide-php/pull/315))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-* Add mutual TLS (mTLS) support via `client_cert`/`client_key` (inline PEM bytes) or `client_cert_path`/`client_key_path` (file paths) in `advanced_config['tls_config']` for standalone and cluster clients ([#288](https://github.com/valkey-io/valkey-glide-php/issues/288))
+* Add mutual TLS (mTLS) support via `client_cert`/`client_key` (inline PEM bytes) or `client_cert_path`/`client_key_path` (file paths) in `advanced_config['tls_config']` for standalone and cluster clients ([#321](https://github.com/valkey-io/valkey-glide-php/pull/321))
 * Add `MONITOR` command for standalone client ([#309](https://github.com/valkey-io/valkey-glide-php/pull/309))
 * Add `LOLWUT` command for standalone and cluster clients ([#314](https://github.com/valkey-io/valkey-glide-php/pull/314))
 * Add `LASTSAVE` command for standalone and cluster clients ([#315](https://github.com/valkey-io/valkey-glide-php/pull/315))

--- a/README.md
+++ b/README.md
@@ -401,9 +401,10 @@ $client->set('key', 'value');
 $client->close();
 ```
 
-Alternatively, the client certificate and key can be loaded directly from files by
-providing their paths. Use either the inline byte form above or the path form below
-for a given item, but not both:
+Alternatively, use path-based mTLS by providing file paths instead of inline bytes.
+With path-based mTLS the core reads the files and periodically reloads them, so a rotated
+certificate is adopted on the next reconnect. Byte-based and path-based mTLS are mutually
+exclusive — provide one mode or the other, and each requires both of its fields:
 
 ```php
 $client = new ValkeyGlide();
@@ -415,6 +416,8 @@ $client->connect(
             'root_certs'       => file_get_contents('ca-cert.pem'),
             'client_cert_path' => 'client-cert.pem',  // Path to PEM client certificate file
             'client_key_path'  => 'client-key.pem',   // Path to PEM client private key file
+            // Optional: override the automatic reload cadence (path-based mTLS only).
+            'cert_reload_interval_seconds' => 300,
         ]
     ]
 );

--- a/README.md
+++ b/README.md
@@ -379,6 +379,50 @@ $client->connect(
 )
 ```
 
+### With Mutual TLS (mTLS)
+
+```php
+// Create ValkeyGlide client with mutual TLS (client certificate authentication).
+// Both a client certificate and a client key are required for mTLS.
+$client = new ValkeyGlide();
+$client->connect(
+    addresses: [['host' => 'localhost', 'port' => 6379]],
+    use_tls: true,  // REQUIRED for mTLS
+    advanced_config: [
+        'tls_config' => [
+            'root_certs'  => file_get_contents('ca-cert.pem'),      // PEM CA certificate(s)
+            'client_cert' => file_get_contents('client-cert.pem'),  // PEM client certificate bytes
+            'client_key'  => file_get_contents('client-key.pem'),   // PEM client private key bytes
+        ]
+    ]
+);
+
+$client->set('key', 'value');
+$client->close();
+```
+
+Alternatively, the client certificate and key can be loaded directly from files by
+providing their paths. Use either the inline byte form above or the path form below
+for a given item, but not both:
+
+```php
+$client = new ValkeyGlide();
+$client->connect(
+    addresses: [['host' => 'localhost', 'port' => 6379]],
+    use_tls: true,
+    advanced_config: [
+        'tls_config' => [
+            'root_certs'       => file_get_contents('ca-cert.pem'),
+            'client_cert_path' => 'client-cert.pem',  // Path to PEM client certificate file
+            'client_key_path'  => 'client-key.pem',   // Path to PEM client private key file
+        ]
+    ]
+);
+
+$client->set('key', 'value');
+$client->close();
+```
+
 ### Cluster Valkey
 
 ```php

--- a/README.md
+++ b/README.md
@@ -423,6 +423,10 @@ $client->set('key', 'value');
 $client->close();
 ```
 
+> **Note:** mTLS is only supported through the `advanced_config['tls_config']` path shown above.
+> Client certificates/keys supplied via a stream context (`context: stream_context_create([...])`)
+> are not used for mutual TLS.
+
 ### Cluster Valkey
 
 ```php

--- a/common.h
+++ b/common.h
@@ -199,16 +199,16 @@ typedef struct {
 } valkey_glide_backoff_strategy_t;
 
 typedef struct {
-    uint8_t* root_certs;       /* Certificate data bytes */
-    size_t   root_certs_len;   /* Length of certificate data */
-    uint8_t* client_cert;      /* Client certificate data bytes (byte-based mTLS) */
-    size_t   client_cert_len;  /* Length of client certificate data */
-    uint8_t* client_key;       /* Client private key data bytes (byte-based mTLS) */
-    size_t   client_key_len;   /* Length of client private key data */
-    char*    client_cert_path; /* Path to client certificate file (path-based mTLS); NULL if unset */
-    char*    client_key_path;  /* Path to client private key file (path-based mTLS); NULL if unset */
-    int64_t  cert_reload_interval; /* Reload cadence in seconds; -1 = unset (core default) */
-    bool     use_insecure_tls; /* Whether to use insecure TLS (skips certificate verification) */
+    uint8_t* root_certs;      /* Certificate data bytes */
+    size_t   root_certs_len;  /* Length of certificate data */
+    uint8_t* client_cert;     /* Client certificate data bytes (byte-based mTLS) */
+    size_t   client_cert_len; /* Length of client certificate data */
+    uint8_t* client_key;      /* Client private key data bytes (byte-based mTLS) */
+    size_t   client_key_len;  /* Length of client private key data */
+    char*   client_cert_path; /* Path to client certificate file (path-based mTLS); NULL if unset */
+    char*   client_key_path;  /* Path to client private key file (path-based mTLS); NULL if unset */
+    int64_t cert_reload_interval; /* Reload cadence in seconds; -1 = unset (core default) */
+    bool    use_insecure_tls;     /* Whether to use insecure TLS (skips certificate verification) */
 } valkey_glide_tls_advanced_configuration_t;
 
 typedef struct {

--- a/common.h
+++ b/common.h
@@ -121,6 +121,15 @@ typedef struct {
 #define VALKEY_GLIDE_TLS_CONFIG "tls_config"
 #define VALKEY_GLIDE_USE_INSECURE_TLS "use_insecure_tls"
 #define VALKEY_GLIDE_ROOT_CERTS "root_certs"
+#define VALKEY_GLIDE_CLIENT_CERT "client_cert"
+#define VALKEY_GLIDE_CLIENT_KEY "client_key"
+#define VALKEY_GLIDE_CLIENT_CERT_PATH "client_cert_path"
+#define VALKEY_GLIDE_CLIENT_KEY_PATH "client_key_path"
+
+/* Maximum allowed size (in bytes) for a single certificate or private key.
+ * Acts as a safeguard against accidentally loading oversized/incorrect files.
+ * Matches the C# client's ConnectionConfiguration.CertificateMaxSize (10 MiB). */
+#define VALKEY_GLIDE_CERTIFICATE_MAX_SIZE (10 * 1024 * 1024) /* 10 MiB */
 
 /* Compression Constants */
 #define VALKEY_GLIDE_COMPRESSION "compression"
@@ -191,6 +200,10 @@ typedef struct {
 typedef struct {
     uint8_t* root_certs;       /* Certificate data bytes */
     size_t   root_certs_len;   /* Length of certificate data */
+    uint8_t* client_cert;      /* Client certificate data bytes (mTLS) */
+    size_t   client_cert_len;  /* Length of client certificate data */
+    uint8_t* client_key;       /* Client private key data bytes (mTLS) */
+    size_t   client_key_len;   /* Length of client private key data */
     bool     use_insecure_tls; /* Whether to use insecure TLS (skips certificate verification) */
 } valkey_glide_tls_advanced_configuration_t;
 

--- a/common.h
+++ b/common.h
@@ -125,6 +125,7 @@ typedef struct {
 #define VALKEY_GLIDE_CLIENT_KEY "client_key"
 #define VALKEY_GLIDE_CLIENT_CERT_PATH "client_cert_path"
 #define VALKEY_GLIDE_CLIENT_KEY_PATH "client_key_path"
+#define VALKEY_GLIDE_CERT_RELOAD_INTERVAL "cert_reload_interval_seconds"
 
 /* Maximum allowed size (in bytes) for a single certificate or private key.
  * Acts as a safeguard against accidentally loading oversized/incorrect files.
@@ -200,10 +201,13 @@ typedef struct {
 typedef struct {
     uint8_t* root_certs;       /* Certificate data bytes */
     size_t   root_certs_len;   /* Length of certificate data */
-    uint8_t* client_cert;      /* Client certificate data bytes (mTLS) */
+    uint8_t* client_cert;      /* Client certificate data bytes (byte-based mTLS) */
     size_t   client_cert_len;  /* Length of client certificate data */
-    uint8_t* client_key;       /* Client private key data bytes (mTLS) */
+    uint8_t* client_key;       /* Client private key data bytes (byte-based mTLS) */
     size_t   client_key_len;   /* Length of client private key data */
+    char*    client_cert_path; /* Path to client certificate file (path-based mTLS); NULL if unset */
+    char*    client_key_path;  /* Path to client private key file (path-based mTLS); NULL if unset */
+    int64_t  cert_reload_interval; /* Reload cadence in seconds; -1 = unset (core default) */
     bool     use_insecure_tls; /* Whether to use insecure TLS (skips certificate verification) */
 } valkey_glide_tls_advanced_configuration_t;
 

--- a/tests/ConnectionRequestTest.php
+++ b/tests/ConnectionRequestTest.php
@@ -618,10 +618,291 @@ class ConnectionRequestTest extends \TestSuite
         }
     }
 
+    // mTLS (client cert/key) Tests
+    // -----------------------------
+
+    private const CLIENT_CERT_DATA = "CLIENT_CERT_DATA";
+    private const CLIENT_KEY_DATA  = "CLIENT_KEY_DATA";
+
+    public function testClientAuthTlsDefault()
+    {
+        $request = ClientConstructorMock::simulate_standalone_constructor(use_tls: true);
+        $this->assertEquals('', $request->getClientCert());
+        $this->assertEquals('', $request->getClientKey());
+
+        $request = ClientConstructorMock::simulate_cluster_constructor(use_tls: true);
+        $this->assertEquals('', $request->getClientCert());
+        $this->assertEquals('', $request->getClientKey());
+    }
+
+    public function testClientAuthTlsAdvancedConfig()
+    {
+        $advanced_config = ['tls_config' => [
+            'client_cert' => self::CLIENT_CERT_DATA,
+            'client_key'  => self::CLIENT_KEY_DATA,
+        ]];
+
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            use_tls: true,
+            advanced_config: $advanced_config
+        );
+        $this->assertEquals(self::CLIENT_CERT_DATA, $request->getClientCert());
+        $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
+
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            use_tls: true,
+            advanced_config: $advanced_config
+        );
+        $this->assertEquals(self::CLIENT_CERT_DATA, $request->getClientCert());
+        $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
+    }
+
+    public function testClientAuthTlsWithRootCerts()
+    {
+        $advanced_config = ['tls_config' => [
+            'root_certs'  => self::CERTIFICATE_DATA,
+            'client_cert' => self::CLIENT_CERT_DATA,
+            'client_key'  => self::CLIENT_KEY_DATA,
+        ]];
+
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            use_tls: true,
+            advanced_config: $advanced_config
+        );
+
+        $root_certs = $request->getRootCerts();
+        $this->assertEquals(1, $root_certs->count());
+        $this->assertEquals(self::CERTIFICATE_DATA, $root_certs[0]);
+        $this->assertEquals(self::CLIENT_CERT_DATA, $request->getClientCert());
+        $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
+
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            use_tls: true,
+            advanced_config: $advanced_config
+        );
+
+        $root_certs = $request->getRootCerts();
+        $this->assertEquals(1, $root_certs->count());
+        $this->assertEquals(self::CERTIFICATE_DATA, $root_certs[0]);
+        $this->assertEquals(self::CLIENT_CERT_DATA, $request->getClientCert());
+        $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
+    }
+
+    public function testClientAuthTlsCertWithoutKey()
+    {
+        $advanced_config = ['tls_config' => ['client_cert' => self::CLIENT_CERT_DATA]];
+        $expected_msg = 'client_cert is provided but client_key not provided. mTLS requires both.';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertEquals($expected_msg, $e->getMessage());
+        }
+
+        try {
+            ClientConstructorMock::simulate_cluster_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertEquals($expected_msg, $e->getMessage());
+        }
+    }
+
+    public function testClientAuthTlsKeyWithoutCert()
+    {
+        $advanced_config = ['tls_config' => ['client_key' => self::CLIENT_KEY_DATA]];
+        $expected_msg = 'client_key is provided but client_cert not provided. mTLS requires both.';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertEquals($expected_msg, $e->getMessage());
+        }
+
+        try {
+            ClientConstructorMock::simulate_cluster_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertEquals($expected_msg, $e->getMessage());
+        }
+    }
+
+    public function testClientAuthTlsEmptyCert()
+    {
+        $advanced_config = ['tls_config' => [
+            'client_cert' => '',
+            'client_key'  => self::CLIENT_KEY_DATA,
+        ]];
+        $expected_msg = 'client_cert cannot be an empty string';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
+    public function testClientAuthTlsEmptyKey()
+    {
+        $advanced_config = ['tls_config' => [
+            'client_cert' => self::CLIENT_CERT_DATA,
+            'client_key'  => '',
+        ]];
+        $expected_msg = 'client_key cannot be an empty string';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
+    public function testClientAuthTlsOversizedCert()
+    {
+        // 10 MiB + 1 byte exceeds the maximum allowed certificate size.
+        $oversized = str_repeat('A', (10 * 1024 * 1024) + 1);
+        $advanced_config = ['tls_config' => [
+            'client_cert' => $oversized,
+            'client_key'  => self::CLIENT_KEY_DATA,
+        ]];
+        $expected_msg = 'client_cert exceeds the maximum allowed size';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
+    public function testClientAuthTlsOversizedKey()
+    {
+        $oversized = str_repeat('A', (10 * 1024 * 1024) + 1);
+        $advanced_config = ['tls_config' => [
+            'client_cert' => self::CLIENT_CERT_DATA,
+            'client_key'  => $oversized,
+        ]];
+        $expected_msg = 'client_key exceeds the maximum allowed size';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
+    public function testClientAuthTlsFromFilePath()
+    {
+        // Write cert and key to temporary files and load them via *_path options.
+        $cert_handle = tmpfile();
+        fwrite($cert_handle, self::CLIENT_CERT_DATA);
+        $cert_path = stream_get_meta_data($cert_handle)['uri'];
+
+        $key_handle = tmpfile();
+        fwrite($key_handle, self::CLIENT_KEY_DATA);
+        $key_path = stream_get_meta_data($key_handle)['uri'];
+
+        $advanced_config = ['tls_config' => [
+            'client_cert_path' => $cert_path,
+            'client_key_path'  => $key_path,
+        ]];
+
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            use_tls: true,
+            advanced_config: $advanced_config
+        );
+        $this->assertEquals(self::CLIENT_CERT_DATA, $request->getClientCert());
+        $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
+
+        $request = ClientConstructorMock::simulate_cluster_constructor(
+            use_tls: true,
+            advanced_config: $advanced_config
+        );
+        $this->assertEquals(self::CLIENT_CERT_DATA, $request->getClientCert());
+        $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
+
+        fclose($cert_handle);
+        fclose($key_handle);
+    }
+
+    public function testClientAuthTlsMixedInlineAndPath()
+    {
+        $key_handle = tmpfile();
+        fwrite($key_handle, self::CLIENT_KEY_DATA);
+        $key_path = stream_get_meta_data($key_handle)['uri'];
+
+        // Inline cert bytes with key loaded from file path.
+        $advanced_config = ['tls_config' => [
+            'client_cert'     => self::CLIENT_CERT_DATA,
+            'client_key_path' => $key_path,
+        ]];
+
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            use_tls: true,
+            advanced_config: $advanced_config
+        );
+        $this->assertEquals(self::CLIENT_CERT_DATA, $request->getClientCert());
+        $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
+
+        fclose($key_handle);
+    }
+
+    public function testClientAuthTlsPathNotFound()
+    {
+        $advanced_config = ['tls_config' => [
+            'client_cert_path' => '/invalid/client-cert.pem',
+            'client_key'       => self::CLIENT_KEY_DATA,
+        ]];
+        $expected_msg = 'Failed to load client_cert from file';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
+    public function testClientAuthTlsEmptyPath()
+    {
+        $advanced_config = ['tls_config' => [
+            'client_cert_path' => '',
+            'client_key'       => self::CLIENT_KEY_DATA,
+        ]];
+        $expected_msg = 'client_cert_path cannot be an empty string';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
+    public function testClientAuthTlsInlineAndPathConflict()
+    {
+        $advanced_config = ['tls_config' => [
+            'client_cert'      => self::CLIENT_CERT_DATA,
+            'client_cert_path' => '/some/path.pem',
+            'client_key'       => self::CLIENT_KEY_DATA,
+        ]];
+        $expected_msg = 'Cannot specify both client_cert and client_cert_path';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
     // ================================================================
     // Compression Tests
     // ================================================================
-
     public function testCompressionStandaloneZstdDefault()
     {
         $request = ClientConstructorMock::simulate_standalone_constructor(

--- a/tests/ConnectionRequestTest.php
+++ b/tests/ConnectionRequestTest.php
@@ -897,7 +897,8 @@ class ConnectionRequestTest extends \TestSuite
             'client_cert_path' => '',
             'client_key'       => self::CLIENT_KEY_DATA,
         ]];
-        $expected_msg = 'client_cert_path cannot be an empty string';
+        // An empty path is rejected by the file loader (fopen fails).
+        $expected_msg = 'Failed to load client_cert from file';
 
         try {
             ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
@@ -970,7 +971,8 @@ class ConnectionRequestTest extends \TestSuite
             'client_cert'     => self::CLIENT_CERT_DATA,
             'client_key_path' => '',
         ]];
-        $expected_msg = 'client_key_path cannot be an empty string';
+        // An empty path is rejected by the file loader (fopen fails).
+        $expected_msg = 'Failed to load client_key from file';
 
         try {
             ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);

--- a/tests/ConnectionRequestTest.php
+++ b/tests/ConnectionRequestTest.php
@@ -900,6 +900,30 @@ class ConnectionRequestTest extends \TestSuite
         }
     }
 
+    public function testClientAuthTlsWithTlsDisabled()
+    {
+        $advanced_config = ['tls_config' => [
+            'client_cert' => self::CLIENT_CERT_DATA,
+            'client_key'  => self::CLIENT_KEY_DATA,
+        ]];
+        $expected_msg = 'Cannot configure mTLS client certificate when TLS is disabled.';
+
+        // use_tls defaults to false; providing mTLS credentials must be rejected.
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertEquals($expected_msg, $e->getMessage());
+        }
+
+        try {
+            ClientConstructorMock::simulate_cluster_constructor(advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertEquals($expected_msg, $e->getMessage());
+        }
+    }
+
     // ================================================================
     // Compression Tests
     // ================================================================

--- a/tests/ConnectionRequestTest.php
+++ b/tests/ConnectionRequestTest.php
@@ -78,6 +78,7 @@ require_once __DIR__ . "/Connection_request/AuthenticationInfo.php";
 require_once __DIR__ . "/Connection_request/ClientCircuitBreakerConfig.php";
 require_once __DIR__ . "/Connection_request/CompressionBackend.php";
 require_once __DIR__ . "/Connection_request/CompressionConfig.php";
+require_once __DIR__ . "/Connection_request/ClientCertReloadConfig.php";
 require_once __DIR__ . "/Connection_request/ConnectionRequest.php";
 require_once __DIR__ . "/Connection_request/ConnectionRetryStrategy.php";
 require_once __DIR__ . "/Connection_request/NodeAddress.php";
@@ -629,35 +630,37 @@ class ConnectionRequestTest extends \TestSuite
         $request = ClientConstructorMock::simulate_standalone_constructor(use_tls: true);
         $this->assertEquals('', $request->getClientCert());
         $this->assertEquals('', $request->getClientKey());
+        $this->assertEquals('', $request->getClientCertPath());
+        $this->assertEquals('', $request->getClientKeyPath());
+        $this->assertNull($request->getCertReload());
 
         $request = ClientConstructorMock::simulate_cluster_constructor(use_tls: true);
         $this->assertEquals('', $request->getClientCert());
         $this->assertEquals('', $request->getClientKey());
     }
 
-    public function testClientAuthTlsAdvancedConfig()
+    // Byte-based mTLS (client_cert / client_key inline PEM bytes)
+    // ----------------------------------------------------------
+
+    public function testClientAuthTlsByteMode()
     {
         $advanced_config = ['tls_config' => [
             'client_cert' => self::CLIENT_CERT_DATA,
             'client_key'  => self::CLIENT_KEY_DATA,
         ]];
 
-        $request = ClientConstructorMock::simulate_standalone_constructor(
-            use_tls: true,
-            advanced_config: $advanced_config
-        );
-        $this->assertEquals(self::CLIENT_CERT_DATA, $request->getClientCert());
-        $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
-
-        $request = ClientConstructorMock::simulate_cluster_constructor(
-            use_tls: true,
-            advanced_config: $advanced_config
-        );
-        $this->assertEquals(self::CLIENT_CERT_DATA, $request->getClientCert());
-        $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
+        foreach (['simulate_standalone_constructor', 'simulate_cluster_constructor'] as $ctor) {
+            $request = ClientConstructorMock::$ctor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertEquals(self::CLIENT_CERT_DATA, $request->getClientCert());
+            $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
+            // Byte mode must not set path/reload fields.
+            $this->assertEquals('', $request->getClientCertPath());
+            $this->assertEquals('', $request->getClientKeyPath());
+            $this->assertNull($request->getCertReload());
+        }
     }
 
-    public function testClientAuthTlsWithRootCerts()
+    public function testClientAuthTlsByteModeWithRootCerts()
     {
         $advanced_config = ['tls_config' => [
             'root_certs'  => self::CERTIFICATE_DATA,
@@ -669,18 +672,6 @@ class ConnectionRequestTest extends \TestSuite
             use_tls: true,
             advanced_config: $advanced_config
         );
-
-        $root_certs = $request->getRootCerts();
-        $this->assertEquals(1, $root_certs->count());
-        $this->assertEquals(self::CERTIFICATE_DATA, $root_certs[0]);
-        $this->assertEquals(self::CLIENT_CERT_DATA, $request->getClientCert());
-        $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
-
-        $request = ClientConstructorMock::simulate_cluster_constructor(
-            use_tls: true,
-            advanced_config: $advanced_config
-        );
-
         $root_certs = $request->getRootCerts();
         $this->assertEquals(1, $root_certs->count());
         $this->assertEquals(self::CERTIFICATE_DATA, $root_certs[0]);
@@ -688,53 +679,41 @@ class ConnectionRequestTest extends \TestSuite
         $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
     }
 
-    public function testClientAuthTlsCertWithoutKey()
+    public function testClientAuthTlsByteCertWithoutKey()
     {
         $advanced_config = ['tls_config' => ['client_cert' => self::CLIENT_CERT_DATA]];
-        $expected_msg = 'client_cert is provided but client_key not provided. mTLS requires both.';
+        $expected_msg = 'client_cert and client_key must be provided together';
 
-        try {
-            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
-            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
-        } catch (ValkeyGlideException $e) {
-            $this->assertEquals($expected_msg, $e->getMessage());
-        }
-
-        try {
-            ClientConstructorMock::simulate_cluster_constructor(use_tls: true, advanced_config: $advanced_config);
-            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
-        } catch (ValkeyGlideException $e) {
-            $this->assertEquals($expected_msg, $e->getMessage());
+        foreach (['simulate_standalone_constructor', 'simulate_cluster_constructor'] as $ctor) {
+            try {
+                ClientConstructorMock::$ctor(use_tls: true, advanced_config: $advanced_config);
+                $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+            } catch (ValkeyGlideException $e) {
+                $this->assertStringContains($expected_msg, $e->getMessage());
+            }
         }
     }
 
-    public function testClientAuthTlsKeyWithoutCert()
+    public function testClientAuthTlsByteKeyWithoutCert()
     {
         $advanced_config = ['tls_config' => ['client_key' => self::CLIENT_KEY_DATA]];
-        $expected_msg = 'client_key is provided but client_cert not provided. mTLS requires both.';
+        $expected_msg = 'client_cert and client_key must be provided together';
 
         try {
             ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
             $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
         } catch (ValkeyGlideException $e) {
-            $this->assertEquals($expected_msg, $e->getMessage());
-        }
-
-        try {
-            ClientConstructorMock::simulate_cluster_constructor(use_tls: true, advanced_config: $advanced_config);
-            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
-        } catch (ValkeyGlideException $e) {
-            $this->assertEquals($expected_msg, $e->getMessage());
+            $this->assertStringContains($expected_msg, $e->getMessage());
         }
     }
 
-    public function testClientAuthTlsEmptyCert()
+    public function testClientAuthTlsByteEmpty()
     {
         $advanced_config = ['tls_config' => [
             'client_cert' => '',
             'client_key'  => self::CLIENT_KEY_DATA,
         ]];
-        $expected_msg = 'client_cert cannot be an empty string';
+        $expected_msg = 'must not be empty';
 
         try {
             ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
@@ -744,31 +723,14 @@ class ConnectionRequestTest extends \TestSuite
         }
     }
 
-    public function testClientAuthTlsEmptyKey()
+    public function testClientAuthTlsByteOversized()
     {
-        $advanced_config = ['tls_config' => [
-            'client_cert' => self::CLIENT_CERT_DATA,
-            'client_key'  => '',
-        ]];
-        $expected_msg = 'client_key cannot be an empty string';
-
-        try {
-            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
-            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
-        } catch (ValkeyGlideException $e) {
-            $this->assertStringContains($expected_msg, $e->getMessage());
-        }
-    }
-
-    public function testClientAuthTlsOversizedCert()
-    {
-        // 10 MiB + 1 byte exceeds the maximum allowed certificate size.
         $oversized = str_repeat('A', (10 * 1024 * 1024) + 1);
         $advanced_config = ['tls_config' => [
             'client_cert' => $oversized,
             'client_key'  => self::CLIENT_KEY_DATA,
         ]];
-        $expected_msg = 'client_cert exceeds the maximum allowed size';
+        $expected_msg = 'exceeds the maximum allowed size';
 
         try {
             ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
@@ -778,86 +740,54 @@ class ConnectionRequestTest extends \TestSuite
         }
     }
 
-    public function testClientAuthTlsOversizedKey()
+    // Path-based mTLS (client_cert_path / client_key_path, native core reload)
+    // -----------------------------------------------------------------------
+
+    public function testClientAuthTlsPathMode()
     {
-        $oversized = str_repeat('A', (10 * 1024 * 1024) + 1);
+        // Paths are passed through unread; the core reads and reloads them.
         $advanced_config = ['tls_config' => [
-            'client_cert' => self::CLIENT_CERT_DATA,
-            'client_key'  => $oversized,
+            'client_cert_path' => '/etc/mtls/client-cert.pem',
+            'client_key_path'  => '/etc/mtls/client-key.pem',
         ]];
-        $expected_msg = 'client_key exceeds the maximum allowed size';
 
-        try {
-            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
-            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
-        } catch (ValkeyGlideException $e) {
-            $this->assertStringContains($expected_msg, $e->getMessage());
+        foreach (['simulate_standalone_constructor', 'simulate_cluster_constructor'] as $ctor) {
+            $request = ClientConstructorMock::$ctor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertEquals('/etc/mtls/client-cert.pem', $request->getClientCertPath());
+            $this->assertEquals('/etc/mtls/client-key.pem', $request->getClientKeyPath());
+            // Path mode must not set the inline byte fields.
+            $this->assertEquals('', $request->getClientCert());
+            $this->assertEquals('', $request->getClientKey());
+            // cert_reload is enabled by default in path mode, with no explicit interval.
+            $reload = $request->getCertReload();
+            $this->assertNotNull($reload);
+            $this->assertTrue($reload->getEnabled());
+            $this->assertEquals(0, $reload->getIntervalSeconds());
         }
     }
 
-    public function testClientAuthTlsFromFilePath()
+    public function testClientAuthTlsPathModeWithInterval()
     {
-        // Write cert and key to temporary files and load them via *_path options.
-        $cert_handle = tmpfile();
-        fwrite($cert_handle, self::CLIENT_CERT_DATA);
-        $cert_path = stream_get_meta_data($cert_handle)['uri'];
-
-        $key_handle = tmpfile();
-        fwrite($key_handle, self::CLIENT_KEY_DATA);
-        $key_path = stream_get_meta_data($key_handle)['uri'];
-
         $advanced_config = ['tls_config' => [
-            'client_cert_path' => $cert_path,
-            'client_key_path'  => $key_path,
+            'client_cert_path'            => '/etc/mtls/client-cert.pem',
+            'client_key_path'             => '/etc/mtls/client-key.pem',
+            'cert_reload_interval_seconds' => 60,
         ]];
 
         $request = ClientConstructorMock::simulate_standalone_constructor(
             use_tls: true,
             advanced_config: $advanced_config
         );
-        $this->assertEquals(self::CLIENT_CERT_DATA, $request->getClientCert());
-        $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
-
-        $request = ClientConstructorMock::simulate_cluster_constructor(
-            use_tls: true,
-            advanced_config: $advanced_config
-        );
-        $this->assertEquals(self::CLIENT_CERT_DATA, $request->getClientCert());
-        $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
-
-        fclose($cert_handle);
-        fclose($key_handle);
+        $reload = $request->getCertReload();
+        $this->assertNotNull($reload);
+        $this->assertTrue($reload->getEnabled());
+        $this->assertEquals(60, $reload->getIntervalSeconds());
     }
 
-    public function testClientAuthTlsMixedInlineAndPath()
+    public function testClientAuthTlsPathCertWithoutKey()
     {
-        $key_handle = tmpfile();
-        fwrite($key_handle, self::CLIENT_KEY_DATA);
-        $key_path = stream_get_meta_data($key_handle)['uri'];
-
-        // Inline cert bytes with key loaded from file path.
-        $advanced_config = ['tls_config' => [
-            'client_cert'     => self::CLIENT_CERT_DATA,
-            'client_key_path' => $key_path,
-        ]];
-
-        $request = ClientConstructorMock::simulate_standalone_constructor(
-            use_tls: true,
-            advanced_config: $advanced_config
-        );
-        $this->assertEquals(self::CLIENT_CERT_DATA, $request->getClientCert());
-        $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
-
-        fclose($key_handle);
-    }
-
-    public function testClientAuthTlsPathNotFound()
-    {
-        $advanced_config = ['tls_config' => [
-            'client_cert_path' => '/invalid/client-cert.pem',
-            'client_key'       => self::CLIENT_KEY_DATA,
-        ]];
-        $expected_msg = 'Failed to load client_cert from file';
+        $advanced_config = ['tls_config' => ['client_cert_path' => '/etc/mtls/client-cert.pem']];
+        $expected_msg = 'client_cert_path and client_key_path must be provided together';
 
         try {
             ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
@@ -867,38 +797,13 @@ class ConnectionRequestTest extends \TestSuite
         }
     }
 
-    public function testClientAuthTlsOversizedCertFromPath()
-    {
-        // Write a file larger than the 10 MiB maximum and load it via client_cert_path.
-        // The bounded loader must reject it (before allocating the whole file).
-        $cert_handle = tmpfile();
-        fwrite($cert_handle, str_repeat('A', (10 * 1024 * 1024) + 1));
-        $cert_path = stream_get_meta_data($cert_handle)['uri'];
-
-        $advanced_config = ['tls_config' => [
-            'client_cert_path' => $cert_path,
-            'client_key'       => self::CLIENT_KEY_DATA,
-        ]];
-        $expected_msg = 'Failed to load client_cert from file';
-
-        try {
-            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
-            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
-        } catch (ValkeyGlideException $e) {
-            $this->assertStringContains($expected_msg, $e->getMessage());
-        } finally {
-            fclose($cert_handle);
-        }
-    }
-
-    public function testClientAuthTlsEmptyPath()
+    public function testClientAuthTlsPathEmpty()
     {
         $advanced_config = ['tls_config' => [
             'client_cert_path' => '',
-            'client_key'       => self::CLIENT_KEY_DATA,
+            'client_key_path'  => '/etc/mtls/client-key.pem',
         ]];
-        // An empty path is rejected by the file loader (fopen fails).
-        $expected_msg = 'Failed to load client_cert from file';
+        $expected_msg = 'must not be empty';
 
         try {
             ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
@@ -908,14 +813,18 @@ class ConnectionRequestTest extends \TestSuite
         }
     }
 
-    public function testClientAuthTlsInlineAndPathConflict()
+    // Mode exclusivity and interval validation
+    // -----------------------------------------
+
+    public function testClientAuthTlsPathAndByteMutuallyExclusive()
     {
         $advanced_config = ['tls_config' => [
             'client_cert'      => self::CLIENT_CERT_DATA,
-            'client_cert_path' => '/some/path.pem',
             'client_key'       => self::CLIENT_KEY_DATA,
+            'client_cert_path' => '/etc/mtls/client-cert.pem',
+            'client_key_path'  => '/etc/mtls/client-key.pem',
         ]];
-        $expected_msg = 'Cannot specify both client_cert and client_cert_path';
+        $expected_msg = 'mutually exclusive';
 
         try {
             ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
@@ -925,54 +834,14 @@ class ConnectionRequestTest extends \TestSuite
         }
     }
 
-    public function testClientAuthTlsBoundarySizeAccepted()
-    {
-        // Exactly the maximum allowed size (10 MiB) must be accepted (cap is `> MAX`).
-        $maxSized = str_repeat('A', 10 * 1024 * 1024);
-        $advanced_config = ['tls_config' => [
-            'client_cert' => $maxSized,
-            'client_key'  => self::CLIENT_KEY_DATA,
-        ]];
-
-        $request = ClientConstructorMock::simulate_standalone_constructor(
-            use_tls: true,
-            advanced_config: $advanced_config
-        );
-        $this->assertEquals($maxSized, $request->getClientCert());
-        $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
-    }
-
-    public function testClientAuthTlsOversizedKeyFromPath()
-    {
-        // A key file larger than 10 MiB must be rejected by the bounded loader.
-        $key_handle = tmpfile();
-        fwrite($key_handle, str_repeat('A', (10 * 1024 * 1024) + 1));
-        $key_path = stream_get_meta_data($key_handle)['uri'];
-
-        $advanced_config = ['tls_config' => [
-            'client_cert' => self::CLIENT_CERT_DATA,
-            'client_key_path' => $key_path,
-        ]];
-        $expected_msg = 'Failed to load client_key from file';
-
-        try {
-            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
-            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
-        } catch (ValkeyGlideException $e) {
-            $this->assertStringContains($expected_msg, $e->getMessage());
-        } finally {
-            fclose($key_handle);
-        }
-    }
-
-    public function testClientAuthTlsEmptyKeyPath()
+    public function testClientAuthTlsIntervalWithoutPathMode()
     {
         $advanced_config = ['tls_config' => [
-            'client_cert'     => self::CLIENT_CERT_DATA,
-            'client_key_path' => '',
+            'client_cert'                  => self::CLIENT_CERT_DATA,
+            'client_key'                   => self::CLIENT_KEY_DATA,
+            'cert_reload_interval_seconds' => 60,
         ]];
-        // An empty path is rejected by the file loader (fopen fails).
-        $expected_msg = 'Failed to load client_key from file';
+        $expected_msg = 'cert_reload_interval_seconds may only be set when path-based mTLS';
 
         try {
             ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
@@ -982,14 +851,14 @@ class ConnectionRequestTest extends \TestSuite
         }
     }
 
-    public function testClientAuthTlsKeyInlineAndPathConflict()
+    public function testClientAuthTlsIntervalNotPositive()
     {
         $advanced_config = ['tls_config' => [
-            'client_cert'     => self::CLIENT_CERT_DATA,
-            'client_key'      => self::CLIENT_KEY_DATA,
-            'client_key_path' => '/some/key.pem',
+            'client_cert_path'            => '/etc/mtls/client-cert.pem',
+            'client_key_path'             => '/etc/mtls/client-key.pem',
+            'cert_reload_interval_seconds' => 0,
         ]];
-        $expected_msg = 'Cannot specify both client_key and client_key_path';
+        $expected_msg = 'cert_reload_interval_seconds must be positive';
 
         try {
             ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
@@ -1001,22 +870,29 @@ class ConnectionRequestTest extends \TestSuite
 
     public function testClientAuthTlsWithTlsDisabled()
     {
-        $advanced_config = ['tls_config' => [
+        $expected_msg = 'Cannot configure mTLS client certificate when TLS is disabled.';
+
+        // Byte mode with TLS disabled.
+        $byte_config = ['tls_config' => [
             'client_cert' => self::CLIENT_CERT_DATA,
             'client_key'  => self::CLIENT_KEY_DATA,
         ]];
-        $expected_msg = 'Cannot configure mTLS client certificate when TLS is disabled.';
-
-        // use_tls defaults to false; providing mTLS credentials must be rejected.
-        try {
-            ClientConstructorMock::simulate_standalone_constructor(advanced_config: $advanced_config);
-            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
-        } catch (ValkeyGlideException $e) {
-            $this->assertEquals($expected_msg, $e->getMessage());
+        foreach (['simulate_standalone_constructor', 'simulate_cluster_constructor'] as $ctor) {
+            try {
+                ClientConstructorMock::$ctor(advanced_config: $byte_config);
+                $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+            } catch (ValkeyGlideException $e) {
+                $this->assertEquals($expected_msg, $e->getMessage());
+            }
         }
 
+        // Path mode with TLS disabled.
+        $path_config = ['tls_config' => [
+            'client_cert_path' => '/etc/mtls/client-cert.pem',
+            'client_key_path'  => '/etc/mtls/client-key.pem',
+        ]];
         try {
-            ClientConstructorMock::simulate_cluster_constructor(advanced_config: $advanced_config);
+            ClientConstructorMock::simulate_standalone_constructor(advanced_config: $path_config);
             $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
         } catch (ValkeyGlideException $e) {
             $this->assertEquals($expected_msg, $e->getMessage());

--- a/tests/ConnectionRequestTest.php
+++ b/tests/ConnectionRequestTest.php
@@ -867,6 +867,30 @@ class ConnectionRequestTest extends \TestSuite
         }
     }
 
+    public function testClientAuthTlsOversizedCertFromPath()
+    {
+        // Write a file larger than the 10 MiB maximum and load it via client_cert_path.
+        // The bounded loader must reject it (before allocating the whole file).
+        $cert_handle = tmpfile();
+        fwrite($cert_handle, str_repeat('A', (10 * 1024 * 1024) + 1));
+        $cert_path = stream_get_meta_data($cert_handle)['uri'];
+
+        $advanced_config = ['tls_config' => [
+            'client_cert_path' => $cert_path,
+            'client_key'       => self::CLIENT_KEY_DATA,
+        ]];
+        $expected_msg = 'Failed to load client_cert from file';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        } finally {
+            fclose($cert_handle);
+        }
+    }
+
     public function testClientAuthTlsEmptyPath()
     {
         $advanced_config = ['tls_config' => [

--- a/tests/ConnectionRequestTest.php
+++ b/tests/ConnectionRequestTest.php
@@ -996,6 +996,41 @@ class ConnectionRequestTest extends \TestSuite
         }
     }
 
+    public function testClientAuthTlsWrongTypedCredential()
+    {
+        // A non-string credential value must be rejected, not silently ignored.
+        $advanced_config = ['tls_config' => [
+            'client_cert' => 123,
+            'client_key'  => self::CLIENT_KEY_DATA,
+        ]];
+        $expected_msg = 'must be strings';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
+    public function testClientAuthTlsWrongTypedInterval()
+    {
+        // A non-integer cert_reload_interval_seconds must be rejected, not coerced.
+        $advanced_config = ['tls_config' => [
+            'client_cert_path'             => '/etc/mtls/client-cert.pem',
+            'client_key_path'              => '/etc/mtls/client-key.pem',
+            'cert_reload_interval_seconds' => '60',
+        ]];
+        $expected_msg = 'must be an integer';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
     // ================================================================
     // Compression Tests
     // ================================================================

--- a/tests/ConnectionRequestTest.php
+++ b/tests/ConnectionRequestTest.php
@@ -723,12 +723,45 @@ class ConnectionRequestTest extends \TestSuite
         }
     }
 
+    public function testClientAuthTlsByteEmptyKey()
+    {
+        $advanced_config = ['tls_config' => [
+            'client_cert' => self::CLIENT_CERT_DATA,
+            'client_key'  => '',
+        ]];
+        $expected_msg = 'must not be empty';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
     public function testClientAuthTlsByteOversized()
     {
         $oversized = str_repeat('A', (10 * 1024 * 1024) + 1);
         $advanced_config = ['tls_config' => [
             'client_cert' => $oversized,
             'client_key'  => self::CLIENT_KEY_DATA,
+        ]];
+        $expected_msg = 'exceeds the maximum allowed size';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
+    public function testClientAuthTlsByteOversizedKey()
+    {
+        $oversized = str_repeat('A', (10 * 1024 * 1024) + 1);
+        $advanced_config = ['tls_config' => [
+            'client_cert' => self::CLIENT_CERT_DATA,
+            'client_key'  => $oversized,
         ]];
         $expected_msg = 'exceeds the maximum allowed size';
 
@@ -797,11 +830,40 @@ class ConnectionRequestTest extends \TestSuite
         }
     }
 
+    public function testClientAuthTlsPathKeyWithoutCert()
+    {
+        $advanced_config = ['tls_config' => ['client_key_path' => '/etc/mtls/client-key.pem']];
+        $expected_msg = 'client_cert_path and client_key_path must be provided together';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
     public function testClientAuthTlsPathEmpty()
     {
         $advanced_config = ['tls_config' => [
             'client_cert_path' => '',
             'client_key_path'  => '/etc/mtls/client-key.pem',
+        ]];
+        $expected_msg = 'must not be empty';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
+    public function testClientAuthTlsPathEmptyKey()
+    {
+        $advanced_config = ['tls_config' => [
+            'client_cert_path' => '/etc/mtls/client-cert.pem',
+            'client_key_path'  => '',
         ]];
         $expected_msg = 'must not be empty';
 
@@ -859,6 +921,41 @@ class ConnectionRequestTest extends \TestSuite
             'cert_reload_interval_seconds' => 0,
         ]];
         $expected_msg = 'cert_reload_interval_seconds must be positive';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
+    public function testClientAuthTlsIntervalNegative()
+    {
+        $advanced_config = ['tls_config' => [
+            'client_cert_path'            => '/etc/mtls/client-cert.pem',
+            'client_key_path'             => '/etc/mtls/client-key.pem',
+            'cert_reload_interval_seconds' => -1,
+        ]];
+        $expected_msg = 'cert_reload_interval_seconds must be positive';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
+    public function testClientAuthTlsIntervalOverflow()
+    {
+        // Exceeds uint32 max (4294967295).
+        $advanced_config = ['tls_config' => [
+            'client_cert_path'            => '/etc/mtls/client-cert.pem',
+            'client_key_path'             => '/etc/mtls/client-key.pem',
+            'cert_reload_interval_seconds' => 4294967296,
+        ]];
+        $expected_msg = 'no greater than';
 
         try {
             ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);

--- a/tests/ConnectionRequestTest.php
+++ b/tests/ConnectionRequestTest.php
@@ -924,6 +924,79 @@ class ConnectionRequestTest extends \TestSuite
         }
     }
 
+    public function testClientAuthTlsBoundarySizeAccepted()
+    {
+        // Exactly the maximum allowed size (10 MiB) must be accepted (cap is `> MAX`).
+        $maxSized = str_repeat('A', 10 * 1024 * 1024);
+        $advanced_config = ['tls_config' => [
+            'client_cert' => $maxSized,
+            'client_key'  => self::CLIENT_KEY_DATA,
+        ]];
+
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            use_tls: true,
+            advanced_config: $advanced_config
+        );
+        $this->assertEquals($maxSized, $request->getClientCert());
+        $this->assertEquals(self::CLIENT_KEY_DATA, $request->getClientKey());
+    }
+
+    public function testClientAuthTlsOversizedKeyFromPath()
+    {
+        // A key file larger than 10 MiB must be rejected by the bounded loader.
+        $key_handle = tmpfile();
+        fwrite($key_handle, str_repeat('A', (10 * 1024 * 1024) + 1));
+        $key_path = stream_get_meta_data($key_handle)['uri'];
+
+        $advanced_config = ['tls_config' => [
+            'client_cert' => self::CLIENT_CERT_DATA,
+            'client_key_path' => $key_path,
+        ]];
+        $expected_msg = 'Failed to load client_key from file';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        } finally {
+            fclose($key_handle);
+        }
+    }
+
+    public function testClientAuthTlsEmptyKeyPath()
+    {
+        $advanced_config = ['tls_config' => [
+            'client_cert'     => self::CLIENT_CERT_DATA,
+            'client_key_path' => '',
+        ]];
+        $expected_msg = 'client_key_path cannot be an empty string';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
+    public function testClientAuthTlsKeyInlineAndPathConflict()
+    {
+        $advanced_config = ['tls_config' => [
+            'client_cert'     => self::CLIENT_CERT_DATA,
+            'client_key'      => self::CLIENT_KEY_DATA,
+            'client_key_path' => '/some/key.pem',
+        ]];
+        $expected_msg = 'Cannot specify both client_key and client_key_path';
+
+        try {
+            ClientConstructorMock::simulate_standalone_constructor(use_tls: true, advanced_config: $advanced_config);
+            $this->assertTrue(false, 'Expected ValkeyGlideException was not thrown');
+        } catch (ValkeyGlideException $e) {
+            $this->assertStringContains($expected_msg, $e->getMessage());
+        }
+    }
+
     public function testClientAuthTlsWithTlsDisabled()
     {
         $advanced_config = ['tls_config' => [

--- a/tests/ValkeyGlideBaseTest.php
+++ b/tests/ValkeyGlideBaseTest.php
@@ -117,6 +117,17 @@ abstract class ValkeyGlideBaseTest extends TestSuite
 
     protected const TLS_CERTIFICATE_PATH   = __DIR__ . '/../valkey-glide/utils/tls_crts/ca.crt';
 
+    // mTLS (client-cert-verifying) standalone server.
+    // The generated server cert/key are signed by the same CA, so they double as
+    // valid client credentials for the mTLS handshake.
+    protected const MTLS_PORT_STANDALONE = 6405;
+    protected const MTLS_ADDRESS_STANDALONE = [
+        'host' => 'localhost',
+        'port' => self::MTLS_PORT_STANDALONE
+    ];
+    protected const TLS_CLIENT_CERT_PATH = __DIR__ . '/../valkey-glide/utils/tls_crts/server.crt';
+    protected const TLS_CLIENT_KEY_PATH  = __DIR__ . '/../valkey-glide/utils/tls_crts/server.key';
+
     protected function getNilValue()
     {
         return false;

--- a/tests/ValkeyGlideBaseTest.php
+++ b/tests/ValkeyGlideBaseTest.php
@@ -125,6 +125,11 @@ abstract class ValkeyGlideBaseTest extends TestSuite
         'host' => 'localhost',
         'port' => self::MTLS_PORT_STANDALONE
     ];
+    protected const MTLS_PORT_CLUSTER = 8101;
+    protected const MTLS_ADDRESS_CLUSTER = [
+        'host' => 'localhost',
+        'port' => self::MTLS_PORT_CLUSTER
+    ];
     protected const TLS_CLIENT_CERT_PATH = __DIR__ . '/../valkey-glide/utils/tls_crts/server.crt';
     protected const TLS_CLIENT_KEY_PATH  = __DIR__ . '/../valkey-glide/utils/tls_crts/server.key';
 

--- a/tests/ValkeyGlideBaseTest.php
+++ b/tests/ValkeyGlideBaseTest.php
@@ -313,6 +313,24 @@ abstract class ValkeyGlideBaseTest extends TestSuite
     }
 
     /**
+     * Marks the current test as skipped if TLS is disabled or the mTLS
+     * (client-cert-verifying) server on $port is not reachable.
+     *
+     * The mTLS servers are started with graceful failure in the test harness,
+     * so skip rather than fail when the server did not come up (e.g. port in use).
+     */
+    protected function skipIfMtlsUnavailable(int $port): void
+    {
+        $this->skipIfTlsDisabled();
+
+        $conn = @fsockopen('127.0.0.1', $port, $errno, $errstr, 1.0);
+        if ($conn === false) {
+            $this->markTestSkipped("mTLS server on port {$port} is not available");
+        }
+        fclose($conn);
+    }
+
+    /**
      * Marks the current test as skipped if TLS is enabled.
      */
     protected function skipIfTlsEnabled(): void

--- a/tests/ValkeyGlideClusterTlsTest.php
+++ b/tests/ValkeyGlideClusterTlsTest.php
@@ -245,18 +245,21 @@ class ValkeyGlideClusterTlsTest extends ValkeyGlideClusterBaseTest
     {
         $this->skipIfTlsDisabled();
 
-        $certData = $this->getCaCertificate();
+        $ca   = file_get_contents(self::TLS_CERTIFICATE_PATH);
+        $cert = file_get_contents(self::TLS_CLIENT_CERT_PATH);
+        $key  = file_get_contents(self::TLS_CLIENT_KEY_PATH);
 
-        $this->assertThrows(ValkeyGlideException::class, function () use ($certData) {
+        $this->assertThrows(ValkeyGlideException::class, function () use ($ca, $cert, $key) {
             new ValkeyGlideCluster(
                 addresses: [self::TLS_ADDRESS_CLUSTER],
                 use_tls: true,
                 advanced_config: [
                     'tls_config' => [
-                        'client_cert'      => $certData,
-                        'client_key'       => $certData,
-                        'client_cert_path' => self::TLS_CERTIFICATE_PATH,
-                        'client_key_path'  => self::TLS_CERTIFICATE_PATH,
+                        'root_certs'       => $ca,
+                        'client_cert'      => $cert,
+                        'client_key'       => $key,
+                        'client_cert_path' => self::TLS_CLIENT_CERT_PATH,
+                        'client_key_path'  => self::TLS_CLIENT_KEY_PATH,
                     ]
                 ]
             );
@@ -272,7 +275,7 @@ class ValkeyGlideClusterTlsTest extends ValkeyGlideClusterBaseTest
      */
     public function testMtlsHandshakeWithByteCredentials()
     {
-        $this->skipIfTlsDisabled();
+        $this->skipIfMtlsUnavailable(self::MTLS_PORT_CLUSTER);
 
         $client = new ValkeyGlideCluster(
             addresses: [self::MTLS_ADDRESS_CLUSTER],
@@ -295,7 +298,7 @@ class ValkeyGlideClusterTlsTest extends ValkeyGlideClusterBaseTest
      */
     public function testMtlsHandshakeWithPathCredentials()
     {
-        $this->skipIfTlsDisabled();
+        $this->skipIfMtlsUnavailable(self::MTLS_PORT_CLUSTER);
 
         $client = new ValkeyGlideCluster(
             addresses: [self::MTLS_ADDRESS_CLUSTER],
@@ -318,7 +321,7 @@ class ValkeyGlideClusterTlsTest extends ValkeyGlideClusterBaseTest
      */
     public function testMtlsHandshakeWithoutClientCertFails()
     {
-        $this->skipIfTlsDisabled();
+        $this->skipIfMtlsUnavailable(self::MTLS_PORT_CLUSTER);
 
         $this->assertThrows(ValkeyGlideException::class, function () {
             new ValkeyGlideCluster(

--- a/tests/ValkeyGlideClusterTlsTest.php
+++ b/tests/ValkeyGlideClusterTlsTest.php
@@ -162,4 +162,126 @@ class ValkeyGlideClusterTlsTest extends ValkeyGlideClusterBaseTest
         $this->assertConnected($client);
         $client->close();
     }
+
+    // ================================================================
+    // mTLS (mutual TLS) tests
+    // ================================================================
+
+    /**
+     * mTLS requires both the client certificate and the client key.
+     * Providing only the client certificate must fail.
+     */
+    public function testMtlsClientCertWithoutKeyThrows()
+    {
+        $this->skipIfTlsDisabled();
+
+        $certData = $this->getCaCertificate();
+
+        $this->assertThrows(ValkeyGlideException::class, function () use ($certData) {
+            new ValkeyGlideCluster(
+                addresses: [self::TLS_ADDRESS_CLUSTER],
+                use_tls: true,
+                advanced_config: [
+                    'tls_config' => [
+                        'root_certs'  => $certData,
+                        'client_cert' => $certData,
+                    ]
+                ]
+            );
+        });
+    }
+
+    /**
+     * mTLS requires both the client certificate and the client key.
+     * Providing only the client key must fail.
+     */
+    public function testMtlsClientKeyWithoutCertThrows()
+    {
+        $this->skipIfTlsDisabled();
+
+        $certData = $this->getCaCertificate();
+
+        $this->assertThrows(ValkeyGlideException::class, function () use ($certData) {
+            new ValkeyGlideCluster(
+                addresses: [self::TLS_ADDRESS_CLUSTER],
+                use_tls: true,
+                advanced_config: [
+                    'tls_config' => [
+                        'root_certs' => $certData,
+                        'client_key' => $certData,
+                    ]
+                ]
+            );
+        });
+    }
+
+    /**
+     * An empty client certificate string must be rejected.
+     */
+    public function testMtlsEmptyClientCertThrows()
+    {
+        $this->skipIfTlsDisabled();
+
+        $certData = $this->getCaCertificate();
+
+        $this->assertThrows(ValkeyGlideException::class, function () use ($certData) {
+            new ValkeyGlideCluster(
+                addresses: [self::TLS_ADDRESS_CLUSTER],
+                use_tls: true,
+                advanced_config: [
+                    'tls_config' => [
+                        'client_cert' => '',
+                        'client_key'  => $certData,
+                    ]
+                ]
+            );
+        });
+    }
+
+    /**
+     * A non-existent client certificate file path must be rejected.
+     */
+    public function testMtlsClientCertPathNotFoundThrows()
+    {
+        $this->skipIfTlsDisabled();
+
+        $certData = $this->getCaCertificate();
+
+        $this->assertThrows(ValkeyGlideException::class, function () use ($certData) {
+            new ValkeyGlideCluster(
+                addresses: [self::TLS_ADDRESS_CLUSTER],
+                use_tls: true,
+                advanced_config: [
+                    'tls_config' => [
+                        'client_cert_path' => '/invalid/client-cert.pem',
+                        'client_key'       => $certData,
+                    ]
+                ]
+            );
+        });
+    }
+
+    /**
+     * Specifying both inline bytes and a file path for the same item must be rejected.
+     */
+    public function testMtlsInlineAndPathConflictThrows()
+    {
+        $this->skipIfTlsDisabled();
+
+        $certData = $this->getCaCertificate();
+
+        $this->assertThrows(ValkeyGlideException::class, function () use ($certData) {
+            new ValkeyGlideCluster(
+                addresses: [self::TLS_ADDRESS_CLUSTER],
+                use_tls: true,
+                advanced_config: [
+                    'tls_config' => [
+                        'client_cert'      => $certData,
+                        'client_cert_path' => self::TLS_CERTIFICATE_PATH,
+                        'client_key'       => $certData,
+                    ]
+                ]
+            );
+        });
+    }
 }

--- a/tests/ValkeyGlideClusterTlsTest.php
+++ b/tests/ValkeyGlideClusterTlsTest.php
@@ -262,4 +262,74 @@ class ValkeyGlideClusterTlsTest extends ValkeyGlideClusterBaseTest
             );
         });
     }
+
+    // ================================================================
+    // mTLS handshake tests (against a client-cert-verifying cluster)
+    // ================================================================
+
+    /**
+     * A successful mTLS handshake using byte-based client certificate/key.
+     */
+    public function testMtlsHandshakeWithByteCredentials()
+    {
+        $this->skipIfTlsDisabled();
+
+        $client = new ValkeyGlideCluster(
+            addresses: [self::MTLS_ADDRESS_CLUSTER],
+            use_tls: true,
+            advanced_config: [
+                'tls_config' => [
+                    'root_certs'  => file_get_contents(self::TLS_CERTIFICATE_PATH),
+                    'client_cert' => file_get_contents(self::TLS_CLIENT_CERT_PATH),
+                    'client_key'  => file_get_contents(self::TLS_CLIENT_KEY_PATH),
+                ]
+            ]
+        );
+
+        $this->assertConnected($client);
+        $client->close();
+    }
+
+    /**
+     * A successful mTLS handshake using path-based client certificate/key.
+     */
+    public function testMtlsHandshakeWithPathCredentials()
+    {
+        $this->skipIfTlsDisabled();
+
+        $client = new ValkeyGlideCluster(
+            addresses: [self::MTLS_ADDRESS_CLUSTER],
+            use_tls: true,
+            advanced_config: [
+                'tls_config' => [
+                    'root_certs'       => file_get_contents(self::TLS_CERTIFICATE_PATH),
+                    'client_cert_path' => self::TLS_CLIENT_CERT_PATH,
+                    'client_key_path'  => self::TLS_CLIENT_KEY_PATH,
+                ]
+            ]
+        );
+
+        $this->assertConnected($client);
+        $client->close();
+    }
+
+    /**
+     * Connecting to a client-cert-verifying cluster without a client certificate must fail.
+     */
+    public function testMtlsHandshakeWithoutClientCertFails()
+    {
+        $this->skipIfTlsDisabled();
+
+        $this->assertThrows(ValkeyGlideException::class, function () {
+            new ValkeyGlideCluster(
+                addresses: [self::MTLS_ADDRESS_CLUSTER],
+                use_tls: true,
+                advanced_config: [
+                    'tls_config' => [
+                        'root_certs' => file_get_contents(self::TLS_CERTIFICATE_PATH),
+                    ]
+                ]
+            );
+        });
+    }
 }

--- a/tests/ValkeyGlideClusterTlsTest.php
+++ b/tests/ValkeyGlideClusterTlsTest.php
@@ -239,30 +239,7 @@ class ValkeyGlideClusterTlsTest extends ValkeyGlideClusterBaseTest
     }
 
     /**
-     * A non-existent client certificate file path must be rejected.
-     */
-    public function testMtlsClientCertPathNotFoundThrows()
-    {
-        $this->skipIfTlsDisabled();
-
-        $certData = $this->getCaCertificate();
-
-        $this->assertThrows(ValkeyGlideException::class, function () use ($certData) {
-            new ValkeyGlideCluster(
-                addresses: [self::TLS_ADDRESS_CLUSTER],
-                use_tls: true,
-                advanced_config: [
-                    'tls_config' => [
-                        'client_cert_path' => '/invalid/client-cert.pem',
-                        'client_key'       => $certData,
-                    ]
-                ]
-            );
-        });
-    }
-
-    /**
-     * Specifying both inline bytes and a file path for the same item must be rejected.
+     * Path-based and byte-based mTLS are mutually exclusive.
      */
     public function testMtlsInlineAndPathConflictThrows()
     {
@@ -277,8 +254,9 @@ class ValkeyGlideClusterTlsTest extends ValkeyGlideClusterBaseTest
                 advanced_config: [
                     'tls_config' => [
                         'client_cert'      => $certData,
-                        'client_cert_path' => self::TLS_CERTIFICATE_PATH,
                         'client_key'       => $certData,
+                        'client_cert_path' => self::TLS_CERTIFICATE_PATH,
+                        'client_key_path'  => self::TLS_CERTIFICATE_PATH,
                     ]
                 ]
             );

--- a/tests/ValkeyGlideTlsTest.php
+++ b/tests/ValkeyGlideTlsTest.php
@@ -265,4 +265,131 @@ class ValkeyGlideTlsTest extends ValkeyGlideBaseTest
         $this->assertConnected($client);
         $client->close();
     }
+
+    // ================================================================
+    // mTLS (mutual TLS) tests
+    // ================================================================
+
+    /**
+     * mTLS requires both the client certificate and the client key.
+     * Providing only the client certificate must fail.
+     */
+    public function testMtlsClientCertWithoutKeyThrows()
+    {
+        $this->skipIfTlsDisabled();
+
+        $certData = $this->getCaCertificate();
+
+        $this->assertThrows(ValkeyGlideException::class, function () use ($certData) {
+            $client = new ValkeyGlide();
+            $client->connect(
+                addresses: [self::TLS_ADDRESS_STANDALONE],
+                use_tls: true,
+                advanced_config: [
+                    'tls_config' => [
+                        'root_certs'  => $certData,
+                        'client_cert' => $certData,
+                    ]
+                ]
+            );
+        });
+    }
+
+    /**
+     * mTLS requires both the client certificate and the client key.
+     * Providing only the client key must fail.
+     */
+    public function testMtlsClientKeyWithoutCertThrows()
+    {
+        $this->skipIfTlsDisabled();
+
+        $certData = $this->getCaCertificate();
+
+        $this->assertThrows(ValkeyGlideException::class, function () use ($certData) {
+            $client = new ValkeyGlide();
+            $client->connect(
+                addresses: [self::TLS_ADDRESS_STANDALONE],
+                use_tls: true,
+                advanced_config: [
+                    'tls_config' => [
+                        'root_certs' => $certData,
+                        'client_key' => $certData,
+                    ]
+                ]
+            );
+        });
+    }
+
+    /**
+     * An empty client certificate string must be rejected.
+     */
+    public function testMtlsEmptyClientCertThrows()
+    {
+        $this->skipIfTlsDisabled();
+
+        $certData = $this->getCaCertificate();
+
+        $this->assertThrows(ValkeyGlideException::class, function () use ($certData) {
+            $client = new ValkeyGlide();
+            $client->connect(
+                addresses: [self::TLS_ADDRESS_STANDALONE],
+                use_tls: true,
+                advanced_config: [
+                    'tls_config' => [
+                        'client_cert' => '',
+                        'client_key'  => $certData,
+                    ]
+                ]
+            );
+        });
+    }
+
+    /**
+     * A non-existent client certificate file path must be rejected.
+     */
+    public function testMtlsClientCertPathNotFoundThrows()
+    {
+        $this->skipIfTlsDisabled();
+
+        $certData = $this->getCaCertificate();
+
+        $this->assertThrows(ValkeyGlideException::class, function () use ($certData) {
+            $client = new ValkeyGlide();
+            $client->connect(
+                addresses: [self::TLS_ADDRESS_STANDALONE],
+                use_tls: true,
+                advanced_config: [
+                    'tls_config' => [
+                        'client_cert_path' => '/invalid/client-cert.pem',
+                        'client_key'       => $certData,
+                    ]
+                ]
+            );
+        });
+    }
+
+    /**
+     * Specifying both inline bytes and a file path for the same item must be rejected.
+     */
+    public function testMtlsInlineAndPathConflictThrows()
+    {
+        $this->skipIfTlsDisabled();
+
+        $certData = $this->getCaCertificate();
+
+        $this->assertThrows(ValkeyGlideException::class, function () use ($certData) {
+            $client = new ValkeyGlide();
+            $client->connect(
+                addresses: [self::TLS_ADDRESS_STANDALONE],
+                use_tls: true,
+                advanced_config: [
+                    'tls_config' => [
+                        'client_cert'      => $certData,
+                        'client_cert_path' => self::TLS_CERTIFICATE_PATH,
+                        'client_key'       => $certData,
+                    ]
+                ]
+            );
+        });
+    }
 }

--- a/tests/ValkeyGlideTlsTest.php
+++ b/tests/ValkeyGlideTlsTest.php
@@ -351,19 +351,22 @@ class ValkeyGlideTlsTest extends ValkeyGlideBaseTest
     {
         $this->skipIfTlsDisabled();
 
-        $certData = $this->getCaCertificate();
+        $ca   = file_get_contents(self::TLS_CERTIFICATE_PATH);
+        $cert = file_get_contents(self::TLS_CLIENT_CERT_PATH);
+        $key  = file_get_contents(self::TLS_CLIENT_KEY_PATH);
 
-        $this->assertThrows(ValkeyGlideException::class, function () use ($certData) {
+        $this->assertThrows(ValkeyGlideException::class, function () use ($ca, $cert, $key) {
             $client = new ValkeyGlide();
             $client->connect(
                 addresses: [self::TLS_ADDRESS_STANDALONE],
                 use_tls: true,
                 advanced_config: [
                     'tls_config' => [
-                        'client_cert'      => $certData,
-                        'client_key'       => $certData,
-                        'client_cert_path' => self::TLS_CERTIFICATE_PATH,
-                        'client_key_path'  => self::TLS_CERTIFICATE_PATH,
+                        'root_certs'       => $ca,
+                        'client_cert'      => $cert,
+                        'client_key'       => $key,
+                        'client_cert_path' => self::TLS_CLIENT_CERT_PATH,
+                        'client_key_path'  => self::TLS_CLIENT_KEY_PATH,
                     ]
                 ]
             );
@@ -379,7 +382,7 @@ class ValkeyGlideTlsTest extends ValkeyGlideBaseTest
      */
     public function testMtlsHandshakeWithByteCredentials()
     {
-        $this->skipIfTlsDisabled();
+        $this->skipIfMtlsUnavailable(self::MTLS_PORT_STANDALONE);
 
         $client = new ValkeyGlide();
         $client->connect(
@@ -403,7 +406,7 @@ class ValkeyGlideTlsTest extends ValkeyGlideBaseTest
      */
     public function testMtlsHandshakeWithPathCredentials()
     {
-        $this->skipIfTlsDisabled();
+        $this->skipIfMtlsUnavailable(self::MTLS_PORT_STANDALONE);
 
         $client = new ValkeyGlide();
         $client->connect(
@@ -427,7 +430,7 @@ class ValkeyGlideTlsTest extends ValkeyGlideBaseTest
      */
     public function testMtlsHandshakeWithoutClientCertFails()
     {
-        $this->skipIfTlsDisabled();
+        $this->skipIfMtlsUnavailable(self::MTLS_PORT_STANDALONE);
 
         $this->assertThrows(ValkeyGlideException::class, function () {
             $client = new ValkeyGlide();

--- a/tests/ValkeyGlideTlsTest.php
+++ b/tests/ValkeyGlideTlsTest.php
@@ -345,31 +345,7 @@ class ValkeyGlideTlsTest extends ValkeyGlideBaseTest
     }
 
     /**
-     * A non-existent client certificate file path must be rejected.
-     */
-    public function testMtlsClientCertPathNotFoundThrows()
-    {
-        $this->skipIfTlsDisabled();
-
-        $certData = $this->getCaCertificate();
-
-        $this->assertThrows(ValkeyGlideException::class, function () use ($certData) {
-            $client = new ValkeyGlide();
-            $client->connect(
-                addresses: [self::TLS_ADDRESS_STANDALONE],
-                use_tls: true,
-                advanced_config: [
-                    'tls_config' => [
-                        'client_cert_path' => '/invalid/client-cert.pem',
-                        'client_key'       => $certData,
-                    ]
-                ]
-            );
-        });
-    }
-
-    /**
-     * Specifying both inline bytes and a file path for the same item must be rejected.
+     * Path-based and byte-based mTLS are mutually exclusive.
      */
     public function testMtlsInlineAndPathConflictThrows()
     {
@@ -385,8 +361,9 @@ class ValkeyGlideTlsTest extends ValkeyGlideBaseTest
                 advanced_config: [
                     'tls_config' => [
                         'client_cert'      => $certData,
-                        'client_cert_path' => self::TLS_CERTIFICATE_PATH,
                         'client_key'       => $certData,
+                        'client_cert_path' => self::TLS_CERTIFICATE_PATH,
+                        'client_key_path'  => self::TLS_CERTIFICATE_PATH,
                     ]
                 ]
             );

--- a/tests/ValkeyGlideTlsTest.php
+++ b/tests/ValkeyGlideTlsTest.php
@@ -369,4 +369,79 @@ class ValkeyGlideTlsTest extends ValkeyGlideBaseTest
             );
         });
     }
+
+    // ================================================================
+    // mTLS handshake tests (against a client-cert-verifying server)
+    // ================================================================
+
+    /**
+     * A successful mTLS handshake using byte-based client certificate/key.
+     */
+    public function testMtlsHandshakeWithByteCredentials()
+    {
+        $this->skipIfTlsDisabled();
+
+        $client = new ValkeyGlide();
+        $client->connect(
+            addresses: [self::MTLS_ADDRESS_STANDALONE],
+            use_tls: true,
+            advanced_config: [
+                'tls_config' => [
+                    'root_certs'  => file_get_contents(self::TLS_CERTIFICATE_PATH),
+                    'client_cert' => file_get_contents(self::TLS_CLIENT_CERT_PATH),
+                    'client_key'  => file_get_contents(self::TLS_CLIENT_KEY_PATH),
+                ]
+            ]
+        );
+
+        $this->assertConnected($client);
+        $client->close();
+    }
+
+    /**
+     * A successful mTLS handshake using path-based client certificate/key.
+     */
+    public function testMtlsHandshakeWithPathCredentials()
+    {
+        $this->skipIfTlsDisabled();
+
+        $client = new ValkeyGlide();
+        $client->connect(
+            addresses: [self::MTLS_ADDRESS_STANDALONE],
+            use_tls: true,
+            advanced_config: [
+                'tls_config' => [
+                    'root_certs'       => file_get_contents(self::TLS_CERTIFICATE_PATH),
+                    'client_cert_path' => self::TLS_CLIENT_CERT_PATH,
+                    'client_key_path'  => self::TLS_CLIENT_KEY_PATH,
+                ]
+            ]
+        );
+
+        $this->assertConnected($client);
+        $client->close();
+    }
+
+    /**
+     * Connecting to a client-cert-verifying server without a client certificate must fail.
+     */
+    public function testMtlsHandshakeWithoutClientCertFails()
+    {
+        $this->skipIfTlsDisabled();
+
+        $this->assertThrows(ValkeyGlideException::class, function () {
+            $client = new ValkeyGlide();
+            $client->connect(
+                addresses: [self::MTLS_ADDRESS_STANDALONE],
+                use_tls: true,
+                advanced_config: [
+                    'tls_config' => [
+                        'root_certs' => file_get_contents(self::TLS_CERTIFICATE_PATH),
+                    ]
+                ]
+            );
+            // Force a round-trip in case the connection is established lazily.
+            $client->ping();
+        });
+    }
 }

--- a/tests/create-valkey-cluster.sh
+++ b/tests/create-valkey-cluster.sh
@@ -79,9 +79,9 @@ fi
 # 5b. Create an mTLS cluster (client-certificate verification) for mTLS handshake tests
 echo "Setting up mTLS cluster (client-cert verification)..."
 if ../valkey-glide/utils/cluster_manager.py --tls start --tls-auth-clients --prefix mtls-cluster --cluster-mode -p 8101 8102 8103 8104 8105 8106; then
-    echo "✅ mTLS cluster started on ports 8101-8106"
+    echo "mTLS cluster started on ports 8101-8106"
 else
-    echo "⚠️  WARNING: mTLS cluster setup failed (ports 8101-8106 may be in use), continuing without mTLS cluster..."
+    echo "WARNING: mTLS cluster setup failed (ports 8101-8106 may be in use), continuing without mTLS cluster..."
 fi
 
 # 6. Test multi-database support if Valkey 9+

--- a/tests/create-valkey-cluster.sh
+++ b/tests/create-valkey-cluster.sh
@@ -76,6 +76,14 @@ else
     echo "⚠️  WARNING: TLS cluster setup failed (ports 8001-8006 may be in use), continuing without TLS cluster..."
 fi
 
+# 5b. Create an mTLS cluster (client-certificate verification) for mTLS handshake tests
+echo "Setting up mTLS cluster (client-cert verification)..."
+if ../valkey-glide/utils/cluster_manager.py --tls start --tls-auth-clients --prefix mtls-cluster --cluster-mode -p 8101 8102 8103 8104 8105 8106; then
+    echo "✅ mTLS cluster started on ports 8101-8106"
+else
+    echo "⚠️  WARNING: mTLS cluster setup failed (ports 8101-8106 may be in use), continuing without mTLS cluster..."
+fi
+
 # 6. Test multi-database support if Valkey 9+
 if [ "$MAJOR_VERSION" -ge 9 ]; then
     echo "Testing multi-database support in cluster..."

--- a/tests/start_valkey_with_replicas.sh
+++ b/tests/start_valkey_with_replicas.sh
@@ -72,6 +72,14 @@ else
     echo "⚠️  WARNING: TLS standalone setup failed (port 6400 may be in use), continuing without TLS..."
 fi
 
+# Handle mTLS setup (client-certificate verification) with graceful failure
+echo "Setting up mTLS standalone server (client-cert verification)..."
+if ../valkey-glide/utils/cluster_manager.py --tls start --tls-auth-clients --prefix mtls-standalone -p 6405 -r 0; then
+    echo "✅ mTLS standalone server started on port 6405"
+else
+    echo "⚠️  WARNING: mTLS standalone setup failed (port 6405 may be in use), continuing without mTLS..."
+fi
+
 # Wait a moment for servers to start
 sleep 2
 

--- a/tests/start_valkey_with_replicas.sh
+++ b/tests/start_valkey_with_replicas.sh
@@ -75,9 +75,9 @@ fi
 # Handle mTLS setup (client-certificate verification) with graceful failure
 echo "Setting up mTLS standalone server (client-cert verification)..."
 if ../valkey-glide/utils/cluster_manager.py --tls start --tls-auth-clients --prefix mtls-standalone -p 6405 -r 0; then
-    echo "✅ mTLS standalone server started on port 6405"
+    echo "mTLS standalone server started on port 6405"
 else
-    echo "⚠️  WARNING: mTLS standalone setup failed (port 6405 may be in use), continuing without mTLS..."
+    echo "WARNING: mTLS standalone setup failed (port 6405 may be in use), continuing without mTLS..."
 fi
 
 # Wait a moment for servers to start

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -2681,3 +2681,33 @@
    fun:*redis*connection*create_rustls_config*
    ...
 }
+
+# OpenTelemetry resource value clone during one-time tracer-provider init.
+# The existing opentelemetry_resource_from_detectors suppression only matches the
+# hashbrown-insert path; this covers the Value::clone (Box<[u8]>) path into
+# Resource::from_detectors, which is a process-lifetime global initialised once.
+{
+   opentelemetry_resource_value_clone_from_detectors
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:*opentelemetry*common*Value*clone*
+   ...
+   fun:*opentelemetry_sdk*resource*Resource*from_detectors*
+}
+
+# glide-core global client registry (DashMap<u64, Client>) rehash on client
+# creation. Reached via the normal connect() path for both standalone and
+# cluster clients. The registry is a process-lifetime global freed at teardown;
+# valgrind reports the pre-rehash backing table as possibly lost.
+{
+   glide_core_scope_register_client_dashmap_rehash
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:*hashbrown*raw*RawTable*reserve_rehash*
+   ...
+   fun:*glide_core*scope*register_client*
+}

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -167,7 +167,7 @@ static valkey_glide_advanced_base_client_configuration_t* _build_advanced_config
 
 static void _initialize_open_telemetry(valkey_glide_php_common_constructor_params_t* params,
                                        bool                                          is_cluster);
-static bool _load_data_from_file(const char* path, uint8_t** data, size_t* length);
+static bool _load_data_from_file(const char* path, uint8_t** data, size_t* length, size_t max_size);
 
 void valkey_glide_init_common_constructor_params(
     valkey_glide_php_common_constructor_params_t* params) {
@@ -1945,24 +1945,14 @@ static bool _resolve_mtls_material(HashTable*  advanced_tls_ht,
 
         uint8_t* file_data;
         size_t   file_len;
-        if (!_load_data_from_file(path, &file_data, &file_len)) {
-            char error_message[192];
+        /* Bound the read at the maximum certificate size so an oversized/incorrect
+         * file is rejected before being loaded entirely into memory. */
+        if (!_load_data_from_file(path, &file_data, &file_len, VALKEY_GLIDE_CERTIFICATE_MAX_SIZE)) {
+            char error_message[224];
             snprintf(error_message,
                      sizeof(error_message),
-                     "Failed to load %s from file: %s",
-                     label,
-                     path);
-            VALKEY_LOG_ERROR("tls_config_mtls", error_message);
-            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
-            return false;
-        }
-
-        if (file_len > VALKEY_GLIDE_CERTIFICATE_MAX_SIZE) {
-            efree(file_data);
-            char error_message[192];
-            snprintf(error_message,
-                     sizeof(error_message),
-                     "%s file exceeds the maximum allowed size of %d bytes: %s",
+                     "Failed to load %s from file (file may be missing, empty, or larger than the "
+                     "maximum allowed size of %d bytes): %s",
                      label,
                      VALKEY_GLIDE_CERTIFICATE_MAX_SIZE,
                      path);
@@ -2027,7 +2017,8 @@ static valkey_glide_tls_advanced_configuration_t* _build_advanced_tls_config(
             uint8_t*    cert_data;
             size_t      cert_len;
 
-            if (_load_data_from_file(cafile_path, &cert_data, &cert_len)) {
+            if (_load_data_from_file(
+                    cafile_path, &cert_data, &cert_len, VALKEY_GLIDE_CERTIFICATE_MAX_SIZE)) {
                 tls_advanced_config->root_certs     = cert_data;
                 tls_advanced_config->root_certs_len = cert_len;
             } else {
@@ -2184,7 +2175,10 @@ static void _initialize_open_telemetry(valkey_glide_php_common_constructor_param
  * @param length Pointer to store the data length
  * @return       true if successful, false otherwise
  */
-static bool _load_data_from_file(const char* path, uint8_t** data, size_t* length) {
+static bool _load_data_from_file(const char* path,
+                                 uint8_t**   data,
+                                 size_t*     length,
+                                 size_t      max_size) {
     /* Open the file */
     FILE* f = fopen(path, "rb");
     if (!f)
@@ -2193,6 +2187,13 @@ static bool _load_data_from_file(const char* path, uint8_t** data, size_t* lengt
     /* Get file size using fstat */
     struct stat st;
     if (fstat(fileno(f), &st) != 0 || st.st_size <= 0) {
+        fclose(f);
+        return false;
+    }
+
+    /* Reject files larger than max_size (0 means no limit) before allocating,
+     * so an oversized/incorrect file is not read entirely into memory. */
+    if (max_size > 0 && (size_t) st.st_size > max_size) {
         fclose(f);
         return false;
     }

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -1903,6 +1903,21 @@ static bool _parse_mtls_config(HashTable*                                 advanc
                                            VALKEY_GLIDE_CERT_RELOAD_INTERVAL,
                                            sizeof(VALKEY_GLIDE_CERT_RELOAD_INTERVAL) - 1);
 
+    /* Reject wrong-typed values rather than silently treating them as absent:
+     * credential fields must be strings and the reload interval must be an integer. */
+    if ((cert_pem && Z_TYPE_P(cert_pem) != IS_STRING) ||
+        (key_pem && Z_TYPE_P(key_pem) != IS_STRING) ||
+        (cert_path && Z_TYPE_P(cert_path) != IS_STRING) ||
+        (key_path && Z_TYPE_P(key_path) != IS_STRING) ||
+        (interval_zv && Z_TYPE_P(interval_zv) != IS_LONG)) {
+        const char* type_error =
+            "mTLS credential fields (client_cert, client_key, client_cert_path, client_key_path) "
+            "must be strings and cert_reload_interval_seconds must be an integer.";
+        VALKEY_LOG_ERROR("tls_config_mtls", type_error);
+        zend_throw_exception(get_valkey_glide_exception_ce(), type_error, 0);
+        return false;
+    }
+
     bool has_cert_pem  = cert_pem && Z_TYPE_P(cert_pem) == IS_STRING;
     bool has_key_pem   = key_pem && Z_TYPE_P(key_pem) == IS_STRING;
     bool has_cert_path = cert_path && Z_TYPE_P(cert_path) == IS_STRING;

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -459,7 +459,9 @@ int valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_pa
     // Raise an exception if mTLS client credentials are provided but TLS is not enabled
     if (!config->use_tls && config->advanced_config && config->advanced_config->tls_config &&
         (config->advanced_config->tls_config->client_cert ||
-         config->advanced_config->tls_config->client_key)) {
+         config->advanced_config->tls_config->client_key ||
+         config->advanced_config->tls_config->client_cert_path ||
+         config->advanced_config->tls_config->client_key_path)) {
         VALKEY_LOG_ERROR("mtls_with_tls_disabled",
                          "Cannot configure mTLS client certificate when TLS is disabled.");
         valkey_glide_cleanup_client_config(config);
@@ -863,6 +865,14 @@ void valkey_glide_cleanup_client_config(valkey_glide_base_client_configuration_t
             if (config->advanced_config->tls_config->client_key) {
                 efree(config->advanced_config->tls_config->client_key);
                 config->advanced_config->tls_config->client_key = NULL;
+            }
+            if (config->advanced_config->tls_config->client_cert_path) {
+                efree(config->advanced_config->tls_config->client_cert_path);
+                config->advanced_config->tls_config->client_cert_path = NULL;
+            }
+            if (config->advanced_config->tls_config->client_key_path) {
+                efree(config->advanced_config->tls_config->client_key_path);
+                config->advanced_config->tls_config->client_key_path = NULL;
             }
             efree(config->advanced_config->tls_config);
             config->advanced_config->tls_config = NULL;
@@ -1855,110 +1865,135 @@ static void _free_advanced_tls_config(valkey_glide_tls_advanced_configuration_t*
     if (tls_config->client_key) {
         efree(tls_config->client_key);
     }
+    if (tls_config->client_cert_path) {
+        efree(tls_config->client_cert_path);
+    }
+    if (tls_config->client_key_path) {
+        efree(tls_config->client_key_path);
+    }
     efree(tls_config);
 }
 
 /**
- * Resolves a single piece of mTLS material (client certificate or client key) from the
- * advanced TLS config array, supporting either inline PEM bytes or a file path.
+ * Parses and validates the mutual TLS (mTLS) configuration from the advanced TLS config array
+ * into the given tls_config struct.
  *
- * On success, writes an emalloc'd buffer to *out_data and its length to *out_len (or leaves
- * them untouched when neither key is present). On validation failure, throws a
- * ValkeyGlideException and returns false.
+ * Two mutually-exclusive modes are supported (matching the other GLIDE clients):
+ *   - Byte-based: `client_cert` + `client_key` (inline PEM bytes).
+ *   - Path-based: `client_cert_path` + `client_key_path` (+ optional
+ * `cert_reload_interval_seconds`). The core reads the files and periodically reloads them.
  *
- * @param advanced_tls_ht  The tls_config hash table.
- * @param inline_key       Config key for inline PEM bytes (e.g. "client_cert").
- * @param inline_key_len   Length of inline_key (excluding NUL).
- * @param path_key         Config key for a file path (e.g. "client_cert_path").
- * @param path_key_len     Length of path_key (excluding NUL).
- * @param label            Human-readable label for error messages (e.g. "client_cert").
- * @param out_data         Receives the emalloc'd buffer on success.
- * @param out_len          Receives the buffer length on success.
- * @return true on success (including when not provided), false if an exception was thrown.
+ * On validation failure, throws a ValkeyGlideException and returns false.
+ *
+ * @param advanced_tls_ht The tls_config hash table.
+ * @param tls_config      The struct to populate.
+ * @return true on success (including when no mTLS is configured), false if an exception was thrown.
  */
-static bool _resolve_mtls_material(HashTable*  advanced_tls_ht,
-                                   const char* inline_key,
-                                   size_t      inline_key_len,
-                                   const char* path_key,
-                                   size_t      path_key_len,
-                                   const char* label,
-                                   uint8_t**   out_data,
-                                   size_t*     out_len) {
-    zval* inline_val = zend_hash_str_find(advanced_tls_ht, inline_key, inline_key_len);
-    zval* path_val   = zend_hash_str_find(advanced_tls_ht, path_key, path_key_len);
+static bool _parse_mtls_config(HashTable*                                 advanced_tls_ht,
+                               valkey_glide_tls_advanced_configuration_t* tls_config) {
+    zval* cert_pem = zend_hash_str_find(
+        advanced_tls_ht, VALKEY_GLIDE_CLIENT_CERT, sizeof(VALKEY_GLIDE_CLIENT_CERT) - 1);
+    zval* key_pem = zend_hash_str_find(
+        advanced_tls_ht, VALKEY_GLIDE_CLIENT_KEY, sizeof(VALKEY_GLIDE_CLIENT_KEY) - 1);
+    zval* cert_path = zend_hash_str_find(
+        advanced_tls_ht, VALKEY_GLIDE_CLIENT_CERT_PATH, sizeof(VALKEY_GLIDE_CLIENT_CERT_PATH) - 1);
+    zval* key_path = zend_hash_str_find(
+        advanced_tls_ht, VALKEY_GLIDE_CLIENT_KEY_PATH, sizeof(VALKEY_GLIDE_CLIENT_KEY_PATH) - 1);
+    zval* interval_zv = zend_hash_str_find(advanced_tls_ht,
+                                           VALKEY_GLIDE_CERT_RELOAD_INTERVAL,
+                                           sizeof(VALKEY_GLIDE_CERT_RELOAD_INTERVAL) - 1);
 
-    bool has_inline = inline_val && Z_TYPE_P(inline_val) == IS_STRING;
-    bool has_path   = path_val && Z_TYPE_P(path_val) == IS_STRING;
+    bool has_cert_pem  = cert_pem && Z_TYPE_P(cert_pem) == IS_STRING;
+    bool has_key_pem   = key_pem && Z_TYPE_P(key_pem) == IS_STRING;
+    bool has_cert_path = cert_path && Z_TYPE_P(cert_path) == IS_STRING;
+    bool has_key_path  = key_path && Z_TYPE_P(key_path) == IS_STRING;
+    bool has_interval  = interval_zv != NULL;
 
-    /* Reject specifying both inline bytes and a path for the same item. */
-    if (has_inline && has_path) {
-        char error_message[160];
-        snprintf(error_message,
-                 sizeof(error_message),
-                 "Cannot specify both %s and %s; provide only one.",
-                 inline_key,
-                 path_key);
+    const char* error_message = NULL;
+
+    /* Both-or-neither pairing within each mode. */
+    if (has_cert_path != has_key_path) {
+        error_message =
+            "client_cert_path and client_key_path must be provided together; provide both to "
+            "enable path-based mTLS or neither.";
+    } else if (has_cert_pem != has_key_pem) {
+        error_message =
+            "client_cert and client_key must be provided together; provide both to enable "
+            "byte-based mTLS or neither.";
+    }
+    /* Path-based and byte-based modes are mutually exclusive. */
+    else if (has_cert_path && has_cert_pem) {
+        error_message = "path-based and byte-based mTLS are mutually exclusive; choose one.";
+    }
+
+    if (error_message) {
         VALKEY_LOG_ERROR("tls_config_mtls", error_message);
         zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
         return false;
     }
 
-    if (has_inline) {
-        size_t len = Z_STRLEN_P(inline_val);
-        if (len == 0) {
-            char error_message[128];
-            snprintf(error_message,
-                     sizeof(error_message),
-                     "%s cannot be an empty string; omit it if not providing it.",
-                     label);
+    /* Byte-based mTLS: copy inline PEM bytes, rejecting empty/oversized values. */
+    if (has_cert_pem) {
+        size_t cert_len = Z_STRLEN_P(cert_pem);
+        size_t key_len  = Z_STRLEN_P(key_pem);
+        if (cert_len == 0 || key_len == 0) {
+            error_message = "client_cert and client_key must not be empty strings.";
+        } else if (cert_len > VALKEY_GLIDE_CERTIFICATE_MAX_SIZE ||
+                   key_len > VALKEY_GLIDE_CERTIFICATE_MAX_SIZE) {
+            error_message = "client_cert/client_key exceeds the maximum allowed size.";
+        }
+        if (error_message) {
             VALKEY_LOG_ERROR("tls_config_mtls", error_message);
             zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
             return false;
         }
-        if (len > VALKEY_GLIDE_CERTIFICATE_MAX_SIZE) {
-            char error_message[160];
-            snprintf(error_message,
-                     sizeof(error_message),
-                     "%s exceeds the maximum allowed size of %d bytes.",
-                     label,
-                     VALKEY_GLIDE_CERTIFICATE_MAX_SIZE);
-            VALKEY_LOG_ERROR("tls_config_mtls", error_message);
-            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
-            return false;
-        }
-        *out_len  = len;
-        *out_data = emalloc(len);
-        memcpy(*out_data, Z_STRVAL_P(inline_val), len);
-        return true;
+        tls_config->client_cert_len = cert_len;
+        tls_config->client_cert     = emalloc(cert_len);
+        memcpy(tls_config->client_cert, Z_STRVAL_P(cert_pem), cert_len);
+        tls_config->client_key_len = key_len;
+        tls_config->client_key     = emalloc(key_len);
+        memcpy(tls_config->client_key, Z_STRVAL_P(key_pem), key_len);
     }
 
-    if (has_path) {
-        const char* path = Z_STRVAL_P(path_val);
-
-        uint8_t* file_data;
-        size_t   file_len;
-        /* _load_data_from_file bounds the read at VALKEY_GLIDE_CERTIFICATE_MAX_SIZE and
-         * rejects missing (including empty-path), empty, or oversized files. */
-        if (!_load_data_from_file(path, &file_data, &file_len)) {
-            char error_message[224];
-            snprintf(error_message,
-                     sizeof(error_message),
-                     "Failed to load %s from file (file may be missing, empty, or larger than the "
-                     "maximum allowed size of %d bytes): %s",
-                     label,
-                     VALKEY_GLIDE_CERTIFICATE_MAX_SIZE,
-                     path);
+    /* Path-based mTLS: store the path strings unread (the core reads and reloads them). */
+    if (has_cert_path) {
+        if (Z_STRLEN_P(cert_path) == 0 || Z_STRLEN_P(key_path) == 0) {
+            error_message = "client_cert_path and client_key_path must not be empty strings.";
             VALKEY_LOG_ERROR("tls_config_mtls", error_message);
             zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
             return false;
         }
-
-        *out_data = file_data;
-        *out_len  = file_len;
-        return true;
+        tls_config->client_cert_path = estrdup(Z_STRVAL_P(cert_path));
+        tls_config->client_key_path  = estrdup(Z_STRVAL_P(key_path));
     }
 
-    /* Not provided; leave outputs untouched. */
+    /* Reload interval: only valid with path-based mTLS; positive and within uint32. */
+    if (has_interval) {
+        if (!has_cert_path) {
+            error_message =
+                "cert_reload_interval_seconds may only be set when path-based mTLS is configured "
+                "(both client_cert_path and client_key_path).";
+        } else {
+            zend_long interval = zval_get_long(interval_zv);
+            if (interval <= 0) {
+                error_message =
+                    "cert_reload_interval_seconds must be positive; omit it to use the default "
+                    "reload cadence.";
+            } else if ((uint64_t) interval > UINT32_MAX) {
+                error_message =
+                    "cert_reload_interval_seconds must be a positive integer no greater than "
+                    "4294967295.";
+            } else {
+                tls_config->cert_reload_interval = (int64_t) interval;
+            }
+        }
+        if (error_message) {
+            VALKEY_LOG_ERROR("tls_config_mtls", error_message);
+            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+            return false;
+        }
+    }
+
     return true;
 }
 
@@ -1968,6 +2003,8 @@ static valkey_glide_tls_advanced_configuration_t* _build_advanced_tls_config(
     // 0/NULL/false without explicit assignment.
     valkey_glide_tls_advanced_configuration_t* tls_advanced_config =
         ecalloc(1, sizeof(valkey_glide_tls_advanced_configuration_t));
+    // cert_reload_interval defaults to -1 (unset -> core default).
+    tls_advanced_config->cert_reload_interval = -1;
 
     // TLS configuration can be specified either from
     // the stream context or from the advanced TLS config.
@@ -2037,47 +2074,10 @@ static valkey_glide_tls_advanced_configuration_t* _build_advanced_tls_config(
             memcpy(tls_advanced_config->root_certs, Z_STRVAL_P(root_certs), cert_len);
         }
 
-        // Client certificate (mTLS) - inline PEM bytes or file path.
-        if (!_resolve_mtls_material(advanced_tls_ht,
-                                    VALKEY_GLIDE_CLIENT_CERT,
-                                    sizeof(VALKEY_GLIDE_CLIENT_CERT) - 1,
-                                    VALKEY_GLIDE_CLIENT_CERT_PATH,
-                                    sizeof(VALKEY_GLIDE_CLIENT_CERT_PATH) - 1,
-                                    VALKEY_GLIDE_CLIENT_CERT,
-                                    &tls_advanced_config->client_cert,
-                                    &tls_advanced_config->client_cert_len)) {
+        // Mutual TLS (mTLS): byte-based (client_cert/client_key) or path-based
+        // (client_cert_path/client_key_path + optional cert_reload_interval_seconds).
+        if (!_parse_mtls_config(advanced_tls_ht, tls_advanced_config)) {
             _free_advanced_tls_config(tls_advanced_config);
-            return NULL;
-        }
-
-        // Client private key (mTLS) - inline PEM bytes or file path.
-        if (!_resolve_mtls_material(advanced_tls_ht,
-                                    VALKEY_GLIDE_CLIENT_KEY,
-                                    sizeof(VALKEY_GLIDE_CLIENT_KEY) - 1,
-                                    VALKEY_GLIDE_CLIENT_KEY_PATH,
-                                    sizeof(VALKEY_GLIDE_CLIENT_KEY_PATH) - 1,
-                                    VALKEY_GLIDE_CLIENT_KEY,
-                                    &tls_advanced_config->client_key,
-                                    &tls_advanced_config->client_key_len)) {
-            _free_advanced_tls_config(tls_advanced_config);
-            return NULL;
-        }
-
-        // mTLS requires both the client certificate and the client key to be provided together.
-        if (tls_advanced_config->client_cert && !tls_advanced_config->client_key) {
-            const char* error_message =
-                "client_cert is provided but client_key not provided. mTLS requires both.";
-            VALKEY_LOG_ERROR("tls_config_mtls", error_message);
-            _free_advanced_tls_config(tls_advanced_config);
-            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
-            return NULL;
-        }
-        if (tls_advanced_config->client_key && !tls_advanced_config->client_cert) {
-            const char* error_message =
-                "client_key is provided but client_cert not provided. mTLS requires both.";
-            VALKEY_LOG_ERROR("tls_config_mtls", error_message);
-            _free_advanced_tls_config(tls_advanced_config);
-            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
             return NULL;
         }
     }

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -456,6 +456,19 @@ int valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_pa
         return FAILURE;
     }
 
+    // Raise an exception if mTLS client credentials are provided but TLS is not enabled
+    if (!config->use_tls && config->advanced_config && config->advanced_config->tls_config &&
+        (config->advanced_config->tls_config->client_cert ||
+         config->advanced_config->tls_config->client_key)) {
+        VALKEY_LOG_ERROR("mtls_with_tls_disabled",
+                         "Cannot configure mTLS client certificate when TLS is disabled.");
+        valkey_glide_cleanup_client_config(config);
+        zend_throw_exception(get_valkey_glide_exception_ce(),
+                             "Cannot configure mTLS client certificate when TLS is disabled.",
+                             0);
+        return FAILURE;
+    }
+
     /* Process compression configuration if provided */
     if (params->compression && Z_TYPE_P(params->compression) == IS_ARRAY) {
         HashTable* compression_ht = Z_ARRVAL_P(params->compression);
@@ -1879,12 +1892,12 @@ static bool _resolve_mtls_material(HashTable*  advanced_tls_ht,
 
     /* Reject specifying both inline bytes and a path for the same item. */
     if (has_inline && has_path) {
-        char error_message[128];
+        char error_message[160];
         snprintf(error_message,
                  sizeof(error_message),
-                 "Cannot specify both %s and %s_path; provide only one.",
-                 label,
-                 label);
+                 "Cannot specify both %s and %s; provide only one.",
+                 inline_key,
+                 path_key);
         VALKEY_LOG_ERROR("tls_config_mtls", error_message);
         zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
         return false;
@@ -1923,10 +1936,8 @@ static bool _resolve_mtls_material(HashTable*  advanced_tls_ht,
         const char* path = Z_STRVAL_P(path_val);
         if (Z_STRLEN_P(path_val) == 0) {
             char error_message[128];
-            snprintf(error_message,
-                     sizeof(error_message),
-                     "%s_path cannot be an empty string.",
-                     label);
+            snprintf(
+                error_message, sizeof(error_message), "%s cannot be an empty string.", path_key);
             VALKEY_LOG_ERROR("tls_config_mtls", error_message);
             zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
             return false;

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -843,6 +843,14 @@ void valkey_glide_cleanup_client_config(valkey_glide_base_client_configuration_t
                 efree(config->advanced_config->tls_config->root_certs);
                 config->advanced_config->tls_config->root_certs = NULL;
             }
+            if (config->advanced_config->tls_config->client_cert) {
+                efree(config->advanced_config->tls_config->client_cert);
+                config->advanced_config->tls_config->client_cert = NULL;
+            }
+            if (config->advanced_config->tls_config->client_key) {
+                efree(config->advanced_config->tls_config->client_key);
+                config->advanced_config->tls_config->client_key = NULL;
+            }
             efree(config->advanced_config->tls_config);
             config->advanced_config->tls_config = NULL;
         }
@@ -1818,6 +1826,149 @@ static bool _determine_use_tls(valkey_glide_php_common_constructor_params_t* par
  * @param is_cluster Whether this is a cluster client
  * @return           Pointer to the constructed TLS advanced configuration structure.
  */
+/**
+ * Frees a TLS advanced configuration structure and any buffers it owns.
+ */
+static void _free_advanced_tls_config(valkey_glide_tls_advanced_configuration_t* tls_config) {
+    if (!tls_config) {
+        return;
+    }
+    if (tls_config->root_certs) {
+        efree(tls_config->root_certs);
+    }
+    if (tls_config->client_cert) {
+        efree(tls_config->client_cert);
+    }
+    if (tls_config->client_key) {
+        efree(tls_config->client_key);
+    }
+    efree(tls_config);
+}
+
+/**
+ * Resolves a single piece of mTLS material (client certificate or client key) from the
+ * advanced TLS config array, supporting either inline PEM bytes or a file path.
+ *
+ * On success, writes an emalloc'd buffer to *out_data and its length to *out_len (or leaves
+ * them untouched when neither key is present). On validation failure, throws a
+ * ValkeyGlideException and returns false.
+ *
+ * @param advanced_tls_ht  The tls_config hash table.
+ * @param inline_key       Config key for inline PEM bytes (e.g. "client_cert").
+ * @param inline_key_len   Length of inline_key (excluding NUL).
+ * @param path_key         Config key for a file path (e.g. "client_cert_path").
+ * @param path_key_len     Length of path_key (excluding NUL).
+ * @param label            Human-readable label for error messages (e.g. "client_cert").
+ * @param out_data         Receives the emalloc'd buffer on success.
+ * @param out_len          Receives the buffer length on success.
+ * @return true on success (including when not provided), false if an exception was thrown.
+ */
+static bool _resolve_mtls_material(HashTable*  advanced_tls_ht,
+                                   const char* inline_key,
+                                   size_t      inline_key_len,
+                                   const char* path_key,
+                                   size_t      path_key_len,
+                                   const char* label,
+                                   uint8_t**   out_data,
+                                   size_t*     out_len) {
+    zval* inline_val = zend_hash_str_find(advanced_tls_ht, inline_key, inline_key_len);
+    zval* path_val   = zend_hash_str_find(advanced_tls_ht, path_key, path_key_len);
+
+    bool has_inline = inline_val && Z_TYPE_P(inline_val) == IS_STRING;
+    bool has_path   = path_val && Z_TYPE_P(path_val) == IS_STRING;
+
+    /* Reject specifying both inline bytes and a path for the same item. */
+    if (has_inline && has_path) {
+        char error_message[128];
+        snprintf(error_message,
+                 sizeof(error_message),
+                 "Cannot specify both %s and %s_path; provide only one.",
+                 label,
+                 label);
+        VALKEY_LOG_ERROR("tls_config_mtls", error_message);
+        zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+        return false;
+    }
+
+    if (has_inline) {
+        size_t len = Z_STRLEN_P(inline_val);
+        if (len == 0) {
+            char error_message[128];
+            snprintf(error_message,
+                     sizeof(error_message),
+                     "%s cannot be an empty string; omit it if not providing it.",
+                     label);
+            VALKEY_LOG_ERROR("tls_config_mtls", error_message);
+            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+            return false;
+        }
+        if (len > VALKEY_GLIDE_CERTIFICATE_MAX_SIZE) {
+            char error_message[160];
+            snprintf(error_message,
+                     sizeof(error_message),
+                     "%s exceeds the maximum allowed size of %d bytes.",
+                     label,
+                     VALKEY_GLIDE_CERTIFICATE_MAX_SIZE);
+            VALKEY_LOG_ERROR("tls_config_mtls", error_message);
+            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+            return false;
+        }
+        *out_len  = len;
+        *out_data = emalloc(len);
+        memcpy(*out_data, Z_STRVAL_P(inline_val), len);
+        return true;
+    }
+
+    if (has_path) {
+        const char* path = Z_STRVAL_P(path_val);
+        if (Z_STRLEN_P(path_val) == 0) {
+            char error_message[128];
+            snprintf(error_message,
+                     sizeof(error_message),
+                     "%s_path cannot be an empty string.",
+                     label);
+            VALKEY_LOG_ERROR("tls_config_mtls", error_message);
+            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+            return false;
+        }
+
+        uint8_t* file_data;
+        size_t   file_len;
+        if (!_load_data_from_file(path, &file_data, &file_len)) {
+            char error_message[192];
+            snprintf(error_message,
+                     sizeof(error_message),
+                     "Failed to load %s from file: %s",
+                     label,
+                     path);
+            VALKEY_LOG_ERROR("tls_config_mtls", error_message);
+            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+            return false;
+        }
+
+        if (file_len > VALKEY_GLIDE_CERTIFICATE_MAX_SIZE) {
+            efree(file_data);
+            char error_message[192];
+            snprintf(error_message,
+                     sizeof(error_message),
+                     "%s file exceeds the maximum allowed size of %d bytes: %s",
+                     label,
+                     VALKEY_GLIDE_CERTIFICATE_MAX_SIZE,
+                     path);
+            VALKEY_LOG_ERROR("tls_config_mtls", error_message);
+            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+            return false;
+        }
+
+        *out_data = file_data;
+        *out_len  = file_len;
+        return true;
+    }
+
+    /* Not provided; leave outputs untouched. */
+    return true;
+}
+
 static valkey_glide_tls_advanced_configuration_t* _build_advanced_tls_config(
     valkey_glide_php_common_constructor_params_t* params, bool is_cluster) {
     // Allocate memory with default values.
@@ -1827,6 +1978,10 @@ static valkey_glide_tls_advanced_configuration_t* _build_advanced_tls_config(
     tls_advanced_config->use_insecure_tls = false;
     tls_advanced_config->root_certs       = NULL;
     tls_advanced_config->root_certs_len   = 0;
+    tls_advanced_config->client_cert      = NULL;
+    tls_advanced_config->client_cert_len  = 0;
+    tls_advanced_config->client_key       = NULL;
+    tls_advanced_config->client_key_len   = 0;
 
     // TLS configuration can be specified either from
     // the stream context or from the advanced TLS config.
@@ -1838,7 +1993,7 @@ static valkey_glide_tls_advanced_configuration_t* _build_advanced_tls_config(
         const char* error_msg =
             "At most one of stream context or advanced TLS config can be specified.";
         VALKEY_LOG_ERROR("tls_config_conflict", error_msg);
-        efree(tls_advanced_config);
+        _free_advanced_tls_config(tls_advanced_config);
         zend_throw_exception(get_valkey_glide_exception_ce(), error_msg, 0);
         return NULL;
     }
@@ -1867,7 +2022,7 @@ static valkey_glide_tls_advanced_configuration_t* _build_advanced_tls_config(
             } else {
                 const char* error_message = "Failed to load root certificate from file";
                 VALKEY_LOG_ERROR("tls_config_cafile", error_message);
-                efree(tls_advanced_config);
+                _free_advanced_tls_config(tls_advanced_config);
                 zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
                 return NULL;
             }
@@ -1894,6 +2049,50 @@ static valkey_glide_tls_advanced_configuration_t* _build_advanced_tls_config(
             tls_advanced_config->root_certs_len = cert_len;
             tls_advanced_config->root_certs     = emalloc(cert_len);
             memcpy(tls_advanced_config->root_certs, Z_STRVAL_P(root_certs), cert_len);
+        }
+
+        // Client certificate (mTLS) - inline PEM bytes or file path.
+        if (!_resolve_mtls_material(advanced_tls_ht,
+                                    VALKEY_GLIDE_CLIENT_CERT,
+                                    sizeof(VALKEY_GLIDE_CLIENT_CERT) - 1,
+                                    VALKEY_GLIDE_CLIENT_CERT_PATH,
+                                    sizeof(VALKEY_GLIDE_CLIENT_CERT_PATH) - 1,
+                                    VALKEY_GLIDE_CLIENT_CERT,
+                                    &tls_advanced_config->client_cert,
+                                    &tls_advanced_config->client_cert_len)) {
+            _free_advanced_tls_config(tls_advanced_config);
+            return NULL;
+        }
+
+        // Client private key (mTLS) - inline PEM bytes or file path.
+        if (!_resolve_mtls_material(advanced_tls_ht,
+                                    VALKEY_GLIDE_CLIENT_KEY,
+                                    sizeof(VALKEY_GLIDE_CLIENT_KEY) - 1,
+                                    VALKEY_GLIDE_CLIENT_KEY_PATH,
+                                    sizeof(VALKEY_GLIDE_CLIENT_KEY_PATH) - 1,
+                                    VALKEY_GLIDE_CLIENT_KEY,
+                                    &tls_advanced_config->client_key,
+                                    &tls_advanced_config->client_key_len)) {
+            _free_advanced_tls_config(tls_advanced_config);
+            return NULL;
+        }
+
+        // mTLS requires both the client certificate and the client key to be provided together.
+        if (tls_advanced_config->client_cert && !tls_advanced_config->client_key) {
+            const char* error_message =
+                "client_cert is provided but client_key not provided. mTLS requires both.";
+            VALKEY_LOG_ERROR("tls_config_mtls", error_message);
+            _free_advanced_tls_config(tls_advanced_config);
+            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+            return NULL;
+        }
+        if (tls_advanced_config->client_key && !tls_advanced_config->client_cert) {
+            const char* error_message =
+                "client_key is provided but client_cert not provided. mTLS requires both.";
+            VALKEY_LOG_ERROR("tls_config_mtls", error_message);
+            _free_advanced_tls_config(tls_advanced_config);
+            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+            return NULL;
         }
     }
 

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -167,7 +167,7 @@ static valkey_glide_advanced_base_client_configuration_t* _build_advanced_config
 
 static void _initialize_open_telemetry(valkey_glide_php_common_constructor_params_t* params,
                                        bool                                          is_cluster);
-static bool _load_data_from_file(const char* path, uint8_t** data, size_t* length, size_t max_size);
+static bool _load_data_from_file(const char* path, uint8_t** data, size_t* length);
 
 void valkey_glide_init_common_constructor_params(
     valkey_glide_php_common_constructor_params_t* params) {
@@ -1934,20 +1934,12 @@ static bool _resolve_mtls_material(HashTable*  advanced_tls_ht,
 
     if (has_path) {
         const char* path = Z_STRVAL_P(path_val);
-        if (Z_STRLEN_P(path_val) == 0) {
-            char error_message[128];
-            snprintf(
-                error_message, sizeof(error_message), "%s cannot be an empty string.", path_key);
-            VALKEY_LOG_ERROR("tls_config_mtls", error_message);
-            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
-            return false;
-        }
 
         uint8_t* file_data;
         size_t   file_len;
-        /* Bound the read at the maximum certificate size so an oversized/incorrect
-         * file is rejected before being loaded entirely into memory. */
-        if (!_load_data_from_file(path, &file_data, &file_len, VALKEY_GLIDE_CERTIFICATE_MAX_SIZE)) {
+        /* _load_data_from_file bounds the read at VALKEY_GLIDE_CERTIFICATE_MAX_SIZE and
+         * rejects missing (including empty-path), empty, or oversized files. */
+        if (!_load_data_from_file(path, &file_data, &file_len)) {
             char error_message[224];
             snprintf(error_message,
                      sizeof(error_message),
@@ -1972,17 +1964,10 @@ static bool _resolve_mtls_material(HashTable*  advanced_tls_ht,
 
 static valkey_glide_tls_advanced_configuration_t* _build_advanced_tls_config(
     valkey_glide_php_common_constructor_params_t* params, bool is_cluster) {
-    // Allocate memory with default values.
+    // Allocate zero-initialized memory (ecalloc), so all fields default to
+    // 0/NULL/false without explicit assignment.
     valkey_glide_tls_advanced_configuration_t* tls_advanced_config =
         ecalloc(1, sizeof(valkey_glide_tls_advanced_configuration_t));
-
-    tls_advanced_config->use_insecure_tls = false;
-    tls_advanced_config->root_certs       = NULL;
-    tls_advanced_config->root_certs_len   = 0;
-    tls_advanced_config->client_cert      = NULL;
-    tls_advanced_config->client_cert_len  = 0;
-    tls_advanced_config->client_key       = NULL;
-    tls_advanced_config->client_key_len   = 0;
 
     // TLS configuration can be specified either from
     // the stream context or from the advanced TLS config.
@@ -2017,8 +2002,7 @@ static valkey_glide_tls_advanced_configuration_t* _build_advanced_tls_config(
             uint8_t*    cert_data;
             size_t      cert_len;
 
-            if (_load_data_from_file(
-                    cafile_path, &cert_data, &cert_len, VALKEY_GLIDE_CERTIFICATE_MAX_SIZE)) {
+            if (_load_data_from_file(cafile_path, &cert_data, &cert_len)) {
                 tls_advanced_config->root_certs     = cert_data;
                 tls_advanced_config->root_certs_len = cert_len;
             } else {
@@ -2175,10 +2159,7 @@ static void _initialize_open_telemetry(valkey_glide_php_common_constructor_param
  * @param length Pointer to store the data length
  * @return       true if successful, false otherwise
  */
-static bool _load_data_from_file(const char* path,
-                                 uint8_t**   data,
-                                 size_t*     length,
-                                 size_t      max_size) {
+static bool _load_data_from_file(const char* path, uint8_t** data, size_t* length) {
     /* Open the file */
     FILE* f = fopen(path, "rb");
     if (!f)
@@ -2191,9 +2172,9 @@ static bool _load_data_from_file(const char* path,
         return false;
     }
 
-    /* Reject files larger than max_size (0 means no limit) before allocating,
+    /* Reject files larger than the maximum certificate size before allocating,
      * so an oversized/incorrect file is not read entirely into memory. */
-    if (max_size > 0 && (size_t) st.st_size > max_size) {
+    if ((size_t) st.st_size > VALKEY_GLIDE_CERTIFICATE_MAX_SIZE) {
         fclose(f);
         return false;
     }

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -376,14 +376,20 @@ class ValkeyGlide
      *                                    ['tls_config' => [
      *                                        'root_certs' => string,        // PEM CA certificate(s)
      *                                        'use_insecure_tls' => bool,    // Skip certificate verification
-     *                                        'client_cert' => string,       // PEM client certificate bytes (mTLS)
-     *                                        'client_key' => string,        // PEM client private key bytes (mTLS)
-     *                                        'client_cert_path' => string,  // Path to PEM client certificate file (mTLS)
-     *                                        'client_key_path' => string,   // Path to PEM client private key file (mTLS)
+     *                                        // Byte-based mTLS (static): inline PEM bytes.
+     *                                        'client_cert' => string,       // PEM client certificate bytes
+     *                                        'client_key' => string,        // PEM client private key bytes
+     *                                        // Path-based mTLS (with automatic reload): file paths read by the core.
+     *                                        'client_cert_path' => string,  // Path to PEM client certificate file
+     *                                        'client_key_path' => string,   // Path to PEM client private key file
+     *                                        'cert_reload_interval_seconds' => int, // Optional reload cadence (path-based only)
      *                                    ]]
-     *                                    For mutual TLS (mTLS), both a client certificate and a client key must be
-     *                                    provided. Each may be given inline (client_cert/client_key) or as a file
-     *                                    path (client_cert_path/client_key_path), but not both for the same item.
+     *                                    For mutual TLS (mTLS), provide EITHER byte-based (client_cert + client_key)
+     *                                    OR path-based (client_cert_path + client_key_path) credentials — the two
+     *                                    modes are mutually exclusive, and each requires both of its fields.
+     *                                    Path-based mTLS lets the core read and periodically reload the files so a
+     *                                    rotated certificate is adopted on the next reconnect; 'cert_reload_interval_seconds'
+     *                                    overrides the reload cadence and is only valid with path-based mTLS.
      *                                    mTLS is only supported via this 'tls_config' path; client certificates
      *                                    provided through the $context stream context are not used.
      * @param bool|null $lazy_connect Defer connection until first command (default: false)

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -371,7 +371,19 @@ class ValkeyGlide
      * @param int|null $database_id Database number (0-15 for standalone)
      * @param string|null $client_name Client identifier for debugging
      * @param string|null $client_az Availability zone for routing
-     * @param array|null $advanced_config Advanced TLS/connection settings
+     * @param array|null $advanced_config Advanced TLS/connection settings.
+     *                                    TLS options under the 'tls_config' key:
+     *                                    ['tls_config' => [
+     *                                        'root_certs' => string,        // PEM CA certificate(s)
+     *                                        'use_insecure_tls' => bool,    // Skip certificate verification
+     *                                        'client_cert' => string,       // PEM client certificate bytes (mTLS)
+     *                                        'client_key' => string,        // PEM client private key bytes (mTLS)
+     *                                        'client_cert_path' => string,  // Path to PEM client certificate file (mTLS)
+     *                                        'client_key_path' => string,   // Path to PEM client private key file (mTLS)
+     *                                    ]]
+     *                                    For mutual TLS (mTLS), both a client certificate and a client key must be
+     *                                    provided. Each may be given inline (client_cert/client_key) or as a file
+     *                                    path (client_cert_path/client_key_path), but not both for the same item.
      * @param bool|null $lazy_connect Defer connection until first command (default: false)
      * @param resource|array|null $context Stream context resource or array for TLS configuration
      * @param array|null $compression Compression configuration: ['enabled' => true, 'backend' => COMPRESSION_BACKEND_ZSTD, 'compression_level' => 3, 'min_compression_size' => 64]

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -384,8 +384,13 @@ class ValkeyGlide
      *                                    For mutual TLS (mTLS), both a client certificate and a client key must be
      *                                    provided. Each may be given inline (client_cert/client_key) or as a file
      *                                    path (client_cert_path/client_key_path), but not both for the same item.
+     *                                    mTLS is only supported via this 'tls_config' path; client certificates
+     *                                    provided through the $context stream context are not used.
      * @param bool|null $lazy_connect Defer connection until first command (default: false)
-     * @param resource|array|null $context Stream context resource or array for TLS configuration
+     * @param resource|array|null $context Stream context resource or array for TLS configuration.
+     *                                     Supports 'verify_peer' and 'cafile' SSL options. Note: mutual TLS
+     *                                     (client certificate/key) is not supported here; use $advanced_config's
+     *                                     'tls_config' instead.
      * @param array|null $compression Compression configuration: ['enabled' => true, 'backend' => COMPRESSION_BACKEND_ZSTD, 'compression_level' => 3, 'min_compression_size' => 64]
      * @param array|null $client_side_cache Client-side cache configuration array from ClientSideCache::toArray():
      *                                      ['cache_id' => string, 'max_cache_kb' => int, 'entry_ttl_ms' => int,

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -207,7 +207,10 @@ class ValkeyGlideCluster
      * @param float|null $read_timeout          Read timeout in seconds.
      * @param bool|null $persistent             Persistent connection (not supported).
      * @param mixed $auth                       Authentication - string (password) or array ['user', 'pass'].
-     * @param resource|array|null $context      Stream context resource or array.
+     * @param resource|array|null $context      Stream context resource or array. Supports 'verify_peer'
+     *                                          and 'cafile' SSL options. Note: mutual TLS (client
+     *                                          certificate/key) is not supported here; use $advanced_config's
+     *                                          'tls_config' instead.
      *
      * ValkeyGlide-style parameters (positions 7-18):
      * @param array|null $addresses             Array of server addresses [['host' => '127.0.0.1', 'port' => 7001], ...].
@@ -240,7 +243,8 @@ class ValkeyGlideCluster
      *                                            ]
      *                                            For mutual TLS (mTLS), both a client certificate and a client key must be
      *                                            provided. Each may be given inline or as a file path, but not both for
-     *                                            the same item.
+     *                                            the same item. mTLS is only supported via this 'tls_config' path;
+     *                                            client certificates provided through the $context stream context are not used.
      *                                          - 'refresh_topology_from_initial_nodes' => false (default: false)
      *                                            When true, topology updates use only initial nodes instead of internal cluster view.
      *                                          - 'otel' => OpenTelemetryConfig::builder()

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -236,14 +236,20 @@ class ValkeyGlideCluster
      *                                          - 'tls_config' => [
      *                                                'root_certs' => string,       // PEM CA certificate(s)
      *                                                'use_insecure_tls' => false,  // Skip certificate verification
-     *                                                'client_cert' => string,      // PEM client certificate bytes (mTLS)
-     *                                                'client_key' => string,       // PEM client private key bytes (mTLS)
-     *                                                'client_cert_path' => string, // Path to PEM client certificate file (mTLS)
-     *                                                'client_key_path' => string,  // Path to PEM client private key file (mTLS)
+     *                                                // Byte-based mTLS (static): inline PEM bytes.
+     *                                                'client_cert' => string,      // PEM client certificate bytes
+     *                                                'client_key' => string,       // PEM client private key bytes
+     *                                                // Path-based mTLS (with automatic reload): file paths read by the core.
+     *                                                'client_cert_path' => string, // Path to PEM client certificate file
+     *                                                'client_key_path' => string,  // Path to PEM client private key file
+     *                                                'cert_reload_interval_seconds' => int, // Optional reload cadence (path-based only)
      *                                            ]
-     *                                            For mutual TLS (mTLS), both a client certificate and a client key must be
-     *                                            provided. Each may be given inline or as a file path, but not both for
-     *                                            the same item. mTLS is only supported via this 'tls_config' path;
+     *                                            For mutual TLS (mTLS), provide EITHER byte-based (client_cert + client_key)
+     *                                            OR path-based (client_cert_path + client_key_path) credentials — the two
+     *                                            modes are mutually exclusive, and each requires both of its fields.
+     *                                            Path-based mTLS lets the core read and periodically reload the files;
+     *                                            'cert_reload_interval_seconds' overrides the cadence and is path-based only.
+     *                                            mTLS is only supported via this 'tls_config' path;
      *                                            client certificates provided through the $context stream context are not used.
      *                                          - 'refresh_topology_from_initial_nodes' => false (default: false)
      *                                            When true, topology updates use only initial nodes instead of internal cluster view.

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -230,7 +230,17 @@ class ValkeyGlideCluster
      * @param string|null $client_az            Client availability zone.
      * @param array|null $advanced_config       Advanced configuration options:
      *                                          - 'connection_timeout' => 5000 (milliseconds)
-     *                                          - 'tls_config' => ['use_insecure_tls' => false]
+     *                                          - 'tls_config' => [
+     *                                                'root_certs' => string,       // PEM CA certificate(s)
+     *                                                'use_insecure_tls' => false,  // Skip certificate verification
+     *                                                'client_cert' => string,      // PEM client certificate bytes (mTLS)
+     *                                                'client_key' => string,       // PEM client private key bytes (mTLS)
+     *                                                'client_cert_path' => string, // Path to PEM client certificate file (mTLS)
+     *                                                'client_key_path' => string,  // Path to PEM client private key file (mTLS)
+     *                                            ]
+     *                                            For mutual TLS (mTLS), both a client certificate and a client key must be
+     *                                            provided. Each may be given inline or as a file path, but not both for
+     *                                            the same item.
      *                                          - 'refresh_topology_from_initial_nodes' => false (default: false)
      *                                            When true, topology updates use only initial nodes instead of internal cluster view.
      *                                          - 'otel' => OpenTelemetryConfig::builder()

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -111,7 +111,9 @@ uint8_t* create_connection_request(size_t*                                   len
     }
 
     /* Set root certificates */
-    ProtobufCBinaryData root_cert_data;
+    ProtobufCBinaryData                       root_cert_data;
+    ConnectionRequest__ClientCertReloadConfig cert_reload_msg =
+        CONNECTION_REQUEST__CLIENT_CERT_RELOAD_CONFIG__INIT;
     if (config->advanced_config && config->advanced_config->tls_config) {
         valkey_glide_tls_advanced_configuration_t* tls_config = config->advanced_config->tls_config;
 
@@ -122,7 +124,7 @@ uint8_t* create_connection_request(size_t*                                   len
             conn_req.root_certs   = &root_cert_data;
         }
 
-        /* Set client certificate and key for mutual TLS (mTLS) */
+        /* Byte-based mTLS: inline PEM bytes. */
         if (tls_config->client_cert && tls_config->client_cert_len > 0) {
             conn_req.client_cert =
                 (ProtobufCBinaryData){tls_config->client_cert_len, tls_config->client_cert};
@@ -130,6 +132,18 @@ uint8_t* create_connection_request(size_t*                                   len
         if (tls_config->client_key && tls_config->client_key_len > 0) {
             conn_req.client_key =
                 (ProtobufCBinaryData){tls_config->client_key_len, tls_config->client_key};
+        }
+
+        /* Path-based mTLS: file paths, with core-side reload. */
+        if (tls_config->client_cert_path && tls_config->client_key_path) {
+            conn_req.client_cert_path = tls_config->client_cert_path;
+            conn_req.client_key_path  = tls_config->client_key_path;
+
+            cert_reload_msg.enabled = true;
+            if (tls_config->cert_reload_interval >= 0) {
+                cert_reload_msg.interval_seconds = (uint32_t) tls_config->cert_reload_interval;
+            }
+            conn_req.cert_reload = &cert_reload_msg;
         }
     }
 

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -121,6 +121,16 @@ uint8_t* create_connection_request(size_t*                                   len
             conn_req.n_root_certs = 1;
             conn_req.root_certs   = &root_cert_data;
         }
+
+        /* Set client certificate and key for mutual TLS (mTLS) */
+        if (tls_config->client_cert && tls_config->client_cert_len > 0) {
+            conn_req.client_cert =
+                (ProtobufCBinaryData){tls_config->client_cert_len, tls_config->client_cert};
+        }
+        if (tls_config->client_key && tls_config->client_key_len > 0) {
+            conn_req.client_key =
+                (ProtobufCBinaryData){tls_config->client_key_len, tls_config->client_key};
+        }
     }
 
     conn_req.cluster_mode_enabled = is_cluster;


### PR DESCRIPTION
### Summary

Adds mutual TLS (mTLS) client certificate support to the Valkey GLIDE PHP client for both standalone (`ValkeyGlide`) and cluster (`ValkeyGlideCluster`) clients, at feature parity with the Java, Python, Node.js, and C# clients. Non-breaking addition — new optional keys under `advanced_config['tls_config']`.

### Issue link

This Pull Request is linked to issue: [feat(config): add mTLS (mutual TLS) support](https://github.com/valkey-io/valkey-glide-php/issues/288)
Closes #288

### Features / Behaviour Changes

Two mutually-exclusive mTLS modes under `tls_config` (matching the other GLIDE clients):

- **Byte-based** (static): `client_cert` + `client_key` — inline PEM bytes.
- **Path-based** (with automatic reload): `client_cert_path` + `client_key_path` — the core reads the files and periodically re-reads them, so a rotated certificate is adopted on the next reconnect. Optional `cert_reload_interval_seconds` overrides the reload cadence.

Validation (mirroring the Python reference): each mode requires both of its fields; the two modes are mutually exclusive; byte values must be non-empty and within the max size; paths must be non-empty; `cert_reload_interval_seconds` is path-mode-only, positive, and within uint32; mTLS credentials are rejected when TLS is disabled.

Example usage:

```php
// Byte-based mTLS
$client->connect(
    addresses: [['host' => 'localhost', 'port' => 6379]],
    use_tls: true,
    advanced_config: ['tls_config' => [
        'root_certs'  => file_get_contents('ca-cert.pem'),
        'client_cert' => file_get_contents('client-cert.pem'),
        'client_key'  => file_get_contents('client-key.pem'),
    ]]
);

// Path-based mTLS with automatic reload
$client->connect(
    addresses: [['host' => 'localhost', 'port' => 6379]],
    use_tls: true,
    advanced_config: ['tls_config' => [
        'root_certs'                   => file_get_contents('ca-cert.pem'),
        'client_cert_path'             => 'client-cert.pem',
        'client_key_path'              => 'client-key.pem',
        'cert_reload_interval_seconds' => 300, // optional
    ]]
);
```

### Implementation

- `common.h`: Extended `valkey_glide_tls_advanced_configuration_t` with byte fields (`client_cert`/`client_key`), path fields (`client_cert_path`/`client_key_path`), and `cert_reload_interval` (-1 = unset). Added the config-key constants and `VALKEY_GLIDE_CERTIFICATE_MAX_SIZE` (10 MiB, matching C#'s `CertificateMaxSize`, applied to byte-mode values).
- `valkey_glide.c`: `_parse_mtls_config` implements the two-mode validation from the Python reference (`_validate_mtls_config`): both-or-neither pairing per mode, mode exclusivity, empty/oversized byte rejection, empty-path rejection, and interval range checks. Byte material is copied into buffers; path strings are stored unread (the core reads and reloads them). mTLS with TLS disabled is rejected alongside the existing insecure-TLS guard. Buffers/strings are freed in cleanup.
- `valkey_glide_core_commands.c`: Serializes byte-mode into `client_cert`/`client_key`, and path-mode into `client_cert_path`/`client_key_path` plus a `cert_reload` message (`enabled = true`, optional `interval_seconds`) — matching the Go/Python serialization.
- Updated `valkey_glide.stub.php` and `valkey_glide_cluster.stub.php` docblocks (no signature changes).

Depends on the `valkey-glide` submodule bump (#325), which provides the native `client_cert_path` / `client_key_path` / `cert_reload` protobuf fields.

### Limitations

- mTLS is only configurable via `advanced_config['tls_config']`. Client certificates/keys supplied through a stream context (`context: stream_context_create([...])`) are not used for mTLS. (PHP-specific, since the stream-context TLS path does not exist in the other clients.)

### Behavior notes (consistent with the other GLIDE clients)

- Byte-based mTLS is static (no reload). Automatic certificate rotation is only available with path-based mTLS, where the GLIDE core reads and reloads the files.
- Path-based credentials are validated for presence/pairing at config time, but the files themselves are read by the GLIDE core at connection time — a missing/unreadable/empty path surfaces as a connection error, not a constructor exception.

### Testing

- Unit tests (`tests/ConnectionRequestTest.php`): assert the serialized request for byte-mode (`client_cert`/`client_key`, no reload) and path-mode (`client_cert_path`/`client_key_path` + `cert_reload{enabled, interval}`), plus all validation errors — byte/path both-or-neither, mode exclusivity, empty/oversized byte (cert and key), empty path (cert and key), interval without path mode, interval zero/negative/overflow, and mTLS with TLS disabled. Test matrix mirrors the C#/Python suites. All 81 ConnectionRequest tests pass.
- mTLS handshake integration tests against a client-cert-verifying server, for both standalone (`tests/ValkeyGlideTlsTest.php`, port 6405) and cluster (`tests/ValkeyGlideClusterTlsTest.php`, ports 8101-8106): a successful authenticated connection with byte-based credentials, a successful authenticated connection with path-based credentials, and a rejected connection when no client certificate is presented. The test harness (`tests/start_valkey_with_replicas.sh`, `tests/create-valkey-cluster.sh`) starts the verifying servers via `cluster_manager.py --tls --tls-auth-clients`. This mirrors the Python/other clients' standalone+cluster handshake coverage.
- Verified locally end-to-end: byte- and path-based mTLS produce an authenticated `ping` against a `--tls-auth-clients` server/cluster, and a missing client certificate is rejected.
- `make` builds cleanly with `-Werror`; `./lint-c.sh` (clang-format 18) and `./lint-php.sh` pass.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.



