### PR TITLE
feat(standalone): add NodeDiscoveryMode support for standalone clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* Add `NodeDiscoveryMode` configuration (`STANDARD`, `STATIC`, `DISCOVER_ALL`) for standalone client ([#302](https://github.com/valkey-io/valkey-glide-php/issues/302))
 * Add `CONFIG` command for cluster client ([#284](https://github.com/valkey-io/valkey-glide-php/issues/284))
 * Add `MONITOR` command for standalone client ([#309](https://github.com/valkey-io/valkey-glide-php/pull/309))
 * Add `LOLWUT` command for standalone and cluster clients ([#314](https://github.com/valkey-io/valkey-glide-php/pull/314))

--- a/README.md
+++ b/README.md
@@ -379,6 +379,30 @@ $client->connect(
 )
 ```
 
+### Node Discovery Mode (Standalone)
+
+For standalone clients, `node_discovery_mode` controls how the client discovers node roles and topology. It is only applicable to standalone clients (`ValkeyGlide`).
+
+- `ValkeyGlide::NODE_DISCOVERY_MODE_STANDARD` (default): Verifies node roles via `INFO REPLICATION` and uses only the provided addresses.
+- `ValkeyGlide::NODE_DISCOVERY_MODE_STATIC`: Skips role detection. Trusts the provided addresses as-is (the first address is treated as the primary). Enables connectivity through proxies (e.g., Envoy, HAProxy) that do not support `INFO`. Do not set `client_name` when using this mode with a proxy.
+- `ValkeyGlide::NODE_DISCOVERY_MODE_DISCOVER_ALL`: Auto-discovers the full topology (primary + all replicas) from any single starting node (primary or replica).
+
+```php
+// STATIC: trust provided addresses, skip role detection (e.g., behind a proxy)
+$client = new ValkeyGlide();
+$client->connect(
+    addresses: [['host' => 'proxy-host', 'port' => 6379]],
+    node_discovery_mode: ValkeyGlide::NODE_DISCOVERY_MODE_STATIC
+);
+
+// DISCOVER_ALL: discover the full topology from any single node
+$client = new ValkeyGlide();
+$client->connect(
+    addresses: [['host' => 'localhost', 'port' => 6379]],
+    node_discovery_mode: ValkeyGlide::NODE_DISCOVERY_MODE_DISCOVER_ALL
+);
+```
+
 ### Cluster Valkey
 
 ```php

--- a/common.h
+++ b/common.h
@@ -56,6 +56,13 @@ typedef enum {
     VALKEY_GLIDE_PERIODIC_CHECKS_DISABLED        = 1
 } valkey_glide_periodic_checks_status_t;
 
+/* Controls how the client discovers node roles and topology in standalone mode. */
+typedef enum {
+    VALKEY_GLIDE_NODE_DISCOVERY_MODE_STANDARD     = 0,
+    VALKEY_GLIDE_NODE_DISCOVERY_MODE_STATIC       = 1,
+    VALKEY_GLIDE_NODE_DISCOVERY_MODE_DISCOVER_ALL = 2
+} valkey_glide_node_discovery_mode_t;
+
 /* ValkeyGlide Configuration Structures */
 typedef struct {
     char* host;
@@ -214,6 +221,7 @@ typedef struct {
     valkey_glide_client_side_cache_config_t*           client_side_cache;  /* NULL if not set */
     valkey_glide_circuit_breaker_config_t*             circuit_breaker;    /* NULL if not set */
     valkey_glide_read_from_t                           read_from;
+    valkey_glide_node_discovery_mode_t                 node_discovery_mode;
     int                                                addresses_count;
     int                                                request_timeout;         /* -1 if not set */
     int                                                inflight_requests_limit; /* -1 if not set */
@@ -253,7 +261,8 @@ typedef struct {
     char*     client_az;
     size_t    client_name_len;
     size_t    client_az_len;
-    zend_long read_from; /* PRIMARY by default */
+    zend_long read_from;           /* PRIMARY by default */
+    zend_long node_discovery_mode; /* STANDARD by default */
     zend_long request_timeout;
     zend_long database_id;
     zend_bool use_tls;

--- a/src/client_constructor_mock.c
+++ b/src/client_constructor_mock.c
@@ -92,7 +92,7 @@ PHP_METHOD(ClientConstructorMock, simulate_standalone_constructor) {
     valkey_glide_php_common_constructor_params_t common_params;
     valkey_glide_init_common_constructor_params(&common_params);
 
-    ZEND_PARSE_PARAMETERS_START(0, 16)
+    ZEND_PARSE_PARAMETERS_START(0, 17)
     Z_PARAM_OPTIONAL
     Z_PARAM_ARRAY_OR_NULL(common_params.addresses)
     Z_PARAM_BOOL(common_params.use_tls)
@@ -111,6 +111,7 @@ PHP_METHOD(ClientConstructorMock, simulate_standalone_constructor) {
     Z_PARAM_ARRAY_OR_NULL(common_params.client_side_cache)
     Z_PARAM_ZVAL_OR_NULL(common_params.address_resolver)
     Z_PARAM_ARRAY_OR_NULL(common_params.circuit_breaker)
+    Z_PARAM_LONG(common_params.node_discovery_mode)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_THROWS());
 
     /* Validate database_id range before setting */

--- a/src/client_constructor_mock.stub.php
+++ b/src/client_constructor_mock.stub.php
@@ -101,6 +101,10 @@ class ClientConstructorMock
      *                                           'compression_level' => 3, 'min_compression_size' => 256].
      * @param array|null $client_side_cache      Client-side cache configuration ['cache_id' => string, 'max_cache_kb' => int,
      *                                           'entry_ttl_ms' => int, 'eviction_policy' => ?int, 'enable_metrics' => bool].
+     * @param int $node_discovery_mode           Node discovery mode (standalone only):
+     *                                           ValkeyGlide::NODE_DISCOVERY_MODE_STANDARD,
+     *                                           ValkeyGlide::NODE_DISCOVERY_MODE_STATIC, or
+     *                                           ValkeyGlide::NODE_DISCOVERY_MODE_DISCOVER_ALL.
      */
     public static function simulate_standalone_constructor(
         ?array $addresses = null,
@@ -119,6 +123,7 @@ class ClientConstructorMock
         ?array $client_side_cache = null,
         ?callable $address_resolver = null,
         ?array $circuit_breaker = null,
+        int $node_discovery_mode = ValkeyGlide::NODE_DISCOVERY_MODE_STANDARD,
     ): \Connection_request\ConnectionRequest;
 
     /**

--- a/tests/ConnectionRequestTest.php
+++ b/tests/ConnectionRequestTest.php
@@ -81,6 +81,7 @@ require_once __DIR__ . "/Connection_request/CompressionConfig.php";
 require_once __DIR__ . "/Connection_request/ConnectionRequest.php";
 require_once __DIR__ . "/Connection_request/ConnectionRetryStrategy.php";
 require_once __DIR__ . "/Connection_request/NodeAddress.php";
+require_once __DIR__ . "/Connection_request/NodeDiscoveryMode.php";
 require_once __DIR__ . "/Connection_request/PeriodicChecksDisabled.php";
 require_once __DIR__ . "/Connection_request/PeriodicChecksManualInterval.php";
 require_once __DIR__ . "/Connection_request/ProtocolVersion.php";
@@ -210,6 +211,36 @@ class ConnectionRequestTest extends \TestSuite
     {
         $request = ClientConstructorMock::simulate_cluster_constructor(read_from: ValkeyGlide::READ_FROM_AZ_AFFINITY_REPLICAS_AND_PRIMARY);
         $this->assertEquals(\Connection_request\ReadFrom::AZAffinityReplicasAndPrimary, $request->getReadFrom());
+    }
+
+    public function testStandaloneNodeDiscoveryModeDefault()
+    {
+        $request = ClientConstructorMock::simulate_standalone_constructor();
+        $this->assertEquals(\Connection_request\NodeDiscoveryMode::Standard, $request->getNodeDiscoveryMode());
+    }
+
+    public function testStandaloneNodeDiscoveryModeStandard()
+    {
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            node_discovery_mode: ValkeyGlide::NODE_DISCOVERY_MODE_STANDARD
+        );
+        $this->assertEquals(\Connection_request\NodeDiscoveryMode::Standard, $request->getNodeDiscoveryMode());
+    }
+
+    public function testStandaloneNodeDiscoveryModeStatic()
+    {
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            node_discovery_mode: ValkeyGlide::NODE_DISCOVERY_MODE_STATIC
+        );
+        $this->assertEquals(\Connection_request\NodeDiscoveryMode::PBStatic, $request->getNodeDiscoveryMode());
+    }
+
+    public function testStandaloneNodeDiscoveryModeDiscoverAll()
+    {
+        $request = ClientConstructorMock::simulate_standalone_constructor(
+            node_discovery_mode: ValkeyGlide::NODE_DISCOVERY_MODE_DISCOVER_ALL
+        );
+        $this->assertEquals(\Connection_request\NodeDiscoveryMode::DiscoverAll, $request->getNodeDiscoveryMode());
     }
 
     public function testStandaloneRequestTimeout()

--- a/tests/ConnectionRequestTest.php
+++ b/tests/ConnectionRequestTest.php
@@ -243,6 +243,13 @@ class ConnectionRequestTest extends \TestSuite
         $this->assertEquals(\Connection_request\NodeDiscoveryMode::DiscoverAll, $request->getNodeDiscoveryMode());
     }
 
+    public function testStandaloneNodeDiscoveryModeInvalidThrows()
+    {
+        $this->assertThrows(ValkeyGlideException::class, function () {
+            ClientConstructorMock::simulate_standalone_constructor(node_discovery_mode: 99);
+        });
+    }
+
     public function testStandaloneRequestTimeout()
     {
         $request = ClientConstructorMock::simulate_standalone_constructor(request_timeout: 999);

--- a/tests/TestValkeyGlide.php
+++ b/tests/TestValkeyGlide.php
@@ -101,6 +101,7 @@ require_once __DIR__ . "/ClientSideCacheTest.php";
 require_once __DIR__ . "/AddressResolverTest.php";
 require_once __DIR__ . "/AddressResolverClusterTest.php";
 require_once __DIR__ . "/ValkeyGlideMonitorTest.php";
+require_once __DIR__ . "/ValkeyGlideNodeDiscoveryModeTest.php";
 
 function getClassArray($classes)
 {
@@ -141,6 +142,7 @@ function getTestClass($class)
         'addressresolver' => 'AddressResolverTest',
         'addressresolvercluster' => 'AddressResolverClusterTest',
         'valkeyglidemonitor' => 'ValkeyGlideMonitorTest',
+        'valkeyglidenodediscoverymode' => 'ValkeyGlideNodeDiscoveryModeTest',
     ];
 
     /* Return early if the class is one of our built-in ones */

--- a/tests/TestValkeyGlide.php
+++ b/tests/TestValkeyGlide.php
@@ -192,6 +192,7 @@ $default_classes = implode(',', [
     'addressresolver',
     'addressresolvercluster',
     'valkeyglidemonitor',
+    'valkeyglidenodediscoverymode',
 ]);
 
 $classes = getClassArray($opt['class'] ?? $default_classes);

--- a/tests/ValkeyGlideNodeDiscoveryModeTest.php
+++ b/tests/ValkeyGlideNodeDiscoveryModeTest.php
@@ -76,6 +76,34 @@ class ValkeyGlideNodeDiscoveryModeTest extends ValkeyGlideBaseTest
     }
 
     /* ----------------------------------------------------------------------
+     * STANDARD mode (default)
+     * ------------------------------------------------------------------- */
+
+    public function testStandardModeConnectsAndReads()
+    {
+        // STANDARD is the default mode: it verifies node roles via INFO REPLICATION
+        // and uses only the provided addresses. Connecting to the primary should
+        // succeed and allow reads and writes.
+        $client = new ValkeyGlide();
+        $client->connect(
+            addresses: [['host' => '127.0.0.1', 'port' => self::PRIMARY_PORT]],
+            request_timeout: 2000,
+            node_discovery_mode: ValkeyGlide::NODE_DISCOVERY_MODE_STANDARD
+        );
+
+        $this->assertConnected($client);
+
+        $key = 'ndm_standard_' . uniqid();
+        try {
+            $this->assertTrue($client->set($key, 'value'));
+            $this->assertEquals('value', $client->get($key));
+        } finally {
+            $client->del($key);
+            $client->close();
+        }
+    }
+
+    /* ----------------------------------------------------------------------
      * STATIC mode
      * ------------------------------------------------------------------- */
 
@@ -88,7 +116,11 @@ class ValkeyGlideNodeDiscoveryModeTest extends ValkeyGlideBaseTest
             node_discovery_mode: ValkeyGlide::NODE_DISCOVERY_MODE_STATIC
         );
 
-        // A missing key returns the client's nil value (false for this client).
+        // STATIC mode skips INFO REPLICATION role detection; verify the client can
+        // still connect and execute a read command against the trusted address.
+        $this->assertConnected($client);
+
+        // A read round-trips successfully; a missing key returns the client's nil value.
         $this->assertEquals($this->getNilValue(), $client->get('nonexistent_' . uniqid()));
 
         $client->close();

--- a/tests/ValkeyGlideNodeDiscoveryModeTest.php
+++ b/tests/ValkeyGlideNodeDiscoveryModeTest.php
@@ -1,0 +1,212 @@
+<?php
+
+defined('VALKEY_GLIDE_PHP_TESTRUN') or die("Use TestValkeyGlide.php to run tests!\n");
+
+require_once __DIR__ . '/ValkeyGlideBaseTest.php';
+
+/**
+ * Integration tests for the standalone NodeDiscoveryMode configuration option.
+ *
+ * These tests rely on the primary/replica topology started by
+ * tests/start_valkey_with_replicas.sh:
+ *   - Primary:  127.0.0.1:6379
+ *   - Replica:  127.0.0.1:6380 (REPLICAOF 6379)
+ *   - Replica:  127.0.0.1:6381 (REPLICAOF 6379)
+ *
+ * See the reference implementations in the core repository under
+ * python/tests/.../test_node_discovery_mode and node/tests/NodeDiscoveryMode.test.ts.
+ */
+class ValkeyGlideNodeDiscoveryModeTest extends ValkeyGlideBaseTest
+{
+    private const PRIMARY_PORT  = 6379;
+    private const REPLICA0_PORT = 6380;
+    private const REPLICA1_PORT = 6381;
+
+    /**
+     * These tests require a real primary/replica topology on the well-known
+     * ports and are not applicable to TLS-only runs.
+     */
+    public function setUp()
+    {
+        // Intentionally do not call parent::setUp(); each test creates its own client.
+        $this->skipIfTlsEnabled();
+        $this->skipIfReplicasUnavailable();
+    }
+
+    public function tearDown()
+    {
+        // No shared client to close.
+    }
+
+    /**
+     * Skips the test if the replica topology is not reachable.
+     */
+    private function skipIfReplicasUnavailable(): void
+    {
+        foreach ([self::PRIMARY_PORT, self::REPLICA0_PORT, self::REPLICA1_PORT] as $port) {
+            $conn = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.5);
+            if ($conn === false) {
+                $this->markTestSkipped(
+                    "Replica topology not available on port {$port}. " .
+                    "Run tests/start_valkey_with_replicas.sh to enable NodeDiscoveryMode tests."
+                );
+            }
+            fclose($conn);
+        }
+    }
+
+    /**
+     * Connects a probe client directly to a single node (typically a replica).
+     *
+     * STATIC mode is used so the client trusts the provided address as-is and
+     * skips role detection (a plain STANDARD connection to a replica-only address
+     * would fail with "No primary node found").
+     *
+     * @param int $port The node port to connect the probe to.
+     */
+    private function connectProbe(int $port): ValkeyGlide
+    {
+        $probe = new ValkeyGlide();
+        $probe->connect(
+            addresses: [['host' => '127.0.0.1', 'port' => $port]],
+            request_timeout: 2000,
+            node_discovery_mode: ValkeyGlide::NODE_DISCOVERY_MODE_STATIC
+        );
+        return $probe;
+    }
+
+    /* ----------------------------------------------------------------------
+     * STATIC mode
+     * ------------------------------------------------------------------- */
+
+    public function testStaticModeConnectsAndReads()
+    {
+        $client = new ValkeyGlide();
+        $client->connect(
+            addresses: [['host' => '127.0.0.1', 'port' => self::PRIMARY_PORT]],
+            request_timeout: 2000,
+            node_discovery_mode: ValkeyGlide::NODE_DISCOVERY_MODE_STATIC
+        );
+
+        // A missing key returns the client's nil value (false for this client).
+        $this->assertEquals($this->getNilValue(), $client->get('nonexistent_' . uniqid()));
+
+        $client->close();
+    }
+
+    public function testStaticModeAllowsWrites()
+    {
+        // Use only the primary address with STATIC mode; the first address is
+        // treated as the primary, so writes must succeed.
+        $client = new ValkeyGlide();
+        $client->connect(
+            addresses: [['host' => '127.0.0.1', 'port' => self::PRIMARY_PORT]],
+            request_timeout: 2000,
+            node_discovery_mode: ValkeyGlide::NODE_DISCOVERY_MODE_STATIC
+        );
+
+        $key = 'ndm_static_write_' . uniqid();
+        try {
+            $this->assertTrue($client->set($key, 'value'));
+            $this->assertEquals('value', $client->get($key));
+        } finally {
+            $client->del($key);
+            $client->close();
+        }
+    }
+
+    /* ----------------------------------------------------------------------
+     * DISCOVER_ALL mode
+     * ------------------------------------------------------------------- */
+
+    public function testDiscoverAllFromPrimary()
+    {
+        $uniqueName = 'ndm_discover_primary_' . uniqid();
+
+        $client = new ValkeyGlide();
+        $client->connect(
+            addresses: [['host' => '127.0.0.1', 'port' => self::PRIMARY_PORT]],
+            request_timeout: 2000,
+            client_name: $uniqueName,
+            node_discovery_mode: ValkeyGlide::NODE_DISCOVERY_MODE_DISCOVER_ALL
+        );
+
+        // A separate probe connected directly to a replica should observe the
+        // discovery client's connection, proving the topology was discovered.
+        $probe = $this->connectProbe(self::REPLICA0_PORT);
+
+        try {
+            $this->waitFor(function () use ($probe, $uniqueName) {
+                $clientList = (string) $probe->rawcommand('CLIENT', 'LIST');
+                return str_contains($clientList, $uniqueName);
+            }, 10, "Discovery client '{$uniqueName}' was not found on the replica");
+        } finally {
+            $probe->close();
+            $client->close();
+        }
+    }
+
+    public function testDiscoverAllFromReplica()
+    {
+        $uniqueName = 'ndm_discover_replica_' . uniqid();
+
+        // Start discovery from a replica address; the client should discover the
+        // primary and connect to the full topology.
+        $client = new ValkeyGlide();
+        $client->connect(
+            addresses: [['host' => '127.0.0.1', 'port' => self::REPLICA0_PORT]],
+            request_timeout: 2000,
+            client_name: $uniqueName,
+            node_discovery_mode: ValkeyGlide::NODE_DISCOVERY_MODE_DISCOVER_ALL
+        );
+
+        $key = 'ndm_discover_replica_key_' . uniqid();
+
+        $probe = $this->connectProbe(self::REPLICA0_PORT);
+
+        try {
+            // Writes must be routed to the discovered primary.
+            $this->assertTrue($client->set($key, 'value'));
+            $this->assertEquals('value', $client->get($key));
+
+            $this->waitFor(function () use ($probe, $uniqueName) {
+                $clientList = (string) $probe->rawcommand('CLIENT', 'LIST');
+                return str_contains($clientList, $uniqueName);
+            }, 10, "Discovery client '{$uniqueName}' was not found on the replica");
+        } finally {
+            $client->del($key);
+            $probe->close();
+            $client->close();
+        }
+    }
+
+    public function testDiscoverAllFromPartialAddresses()
+    {
+        $uniqueName = 'ndm_discover_partial_' . uniqid();
+
+        // Provide a subset of addresses (primary + one replica); the client must
+        // still discover and connect to the remaining replica.
+        $client = new ValkeyGlide();
+        $client->connect(
+            addresses: [
+                ['host' => '127.0.0.1', 'port' => self::PRIMARY_PORT],
+                ['host' => '127.0.0.1', 'port' => self::REPLICA0_PORT],
+            ],
+            request_timeout: 2000,
+            client_name: $uniqueName,
+            node_discovery_mode: ValkeyGlide::NODE_DISCOVERY_MODE_DISCOVER_ALL
+        );
+
+        $probe = $this->connectProbe(self::REPLICA1_PORT);
+
+        try {
+            $this->waitFor(function () use ($probe, $uniqueName) {
+                $clientList = (string) $probe->rawcommand('CLIENT', 'LIST');
+                return str_contains($clientList, $uniqueName);
+            }, 10, "Discovery client '{$uniqueName}' was not found on the second replica");
+        } finally {
+            $probe->close();
+            $client->close();
+        }
+    }
+}

--- a/tests/ValkeyGlideNodeDiscoveryModeTest.php
+++ b/tests/ValkeyGlideNodeDiscoveryModeTest.php
@@ -76,6 +76,37 @@ class ValkeyGlideNodeDiscoveryModeTest extends ValkeyGlideBaseTest
     }
 
     /* ----------------------------------------------------------------------
+     * Type validation for the node_discovery_mode parameter
+     * ------------------------------------------------------------------- */
+
+    /**
+     * The public API declares node_discovery_mode as ?int. Non-null, non-integer
+     * values must be rejected rather than silently coerced (e.g. false -> 0/STANDARD)
+     * or misread through the wrong zval union member.
+     */
+    public function testNodeDiscoveryModeRejectsNonIntegerTypes()
+    {
+        $invalidValues = [
+            'boolean' => false,
+            'string'  => 'static',
+            'float'   => 1.5,
+            'array'   => [1],
+            'object'  => new stdClass(),
+        ];
+
+        foreach ($invalidValues as $type => $value) {
+            $this->assertThrows(ValkeyGlideException::class, function () use ($value) {
+                $client = new ValkeyGlide();
+                $client->connect(
+                    addresses: [['host' => '127.0.0.1', 'port' => self::PRIMARY_PORT]],
+                    request_timeout: 2000,
+                    node_discovery_mode: $value
+                );
+            });
+        }
+    }
+
+    /* ----------------------------------------------------------------------
      * STANDARD mode (default)
      * ------------------------------------------------------------------- */
 

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -219,6 +219,9 @@ int valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_pa
 
     /* Map read_from enum value to client's ReadFrom enum */
     switch (params->read_from) {
+        case 0: /* PRIMARY */
+            config->read_from = VALKEY_GLIDE_READ_FROM_PRIMARY;
+            break;
         case 1: /* PREFER_REPLICA */
             config->read_from = VALKEY_GLIDE_READ_FROM_PREFER_REPLICA;
             break;
@@ -228,24 +231,31 @@ int valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_pa
         case 3: /* AZ_AFFINITY_REPLICAS_AND_PRIMARY */
             config->read_from = VALKEY_GLIDE_READ_FROM_AZ_AFFINITY_REPLICAS_AND_PRIMARY;
             break;
-        case 0: /* PRIMARY */
-        default:
-            config->read_from = VALKEY_GLIDE_READ_FROM_PRIMARY;
-            break;
+        default: {
+            const char* error_message = "Invalid read_from value.";
+            VALKEY_LOG_ERROR("valkey_glide_build_client_config_base", error_message);
+            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+            return FAILURE;
+        }
     }
 
     /* Map node_discovery_mode enum value to client's NodeDiscoveryMode enum */
     switch (params->node_discovery_mode) {
+        case 0: /* STANDARD */
+            config->node_discovery_mode = VALKEY_GLIDE_NODE_DISCOVERY_MODE_STANDARD;
+            break;
         case 1: /* STATIC */
             config->node_discovery_mode = VALKEY_GLIDE_NODE_DISCOVERY_MODE_STATIC;
             break;
         case 2: /* DISCOVER_ALL */
             config->node_discovery_mode = VALKEY_GLIDE_NODE_DISCOVERY_MODE_DISCOVER_ALL;
             break;
-        case 0: /* STANDARD */
-        default:
-            config->node_discovery_mode = VALKEY_GLIDE_NODE_DISCOVERY_MODE_STANDARD;
-            break;
+        default: {
+            const char* error_message = "Invalid node_discovery_mode value.";
+            VALKEY_LOG_ERROR("valkey_glide_build_client_config_base", error_message);
+            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+            return FAILURE;
+        }
     }
 
     /* Process addresses array - handle multiple addresses

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -1235,9 +1235,25 @@ PHP_METHOD(ValkeyGlide, connect) {
     zend_long port = (port_zval && Z_TYPE_P(port_zval) != IS_NULL) ? Z_LVAL_P(port_zval) : 6379;
     double    timeout =
         (timeout_zval && Z_TYPE_P(timeout_zval) != IS_NULL) ? Z_DVAL_P(timeout_zval) : 0.0;
-    zend_bool use_tls   = (use_tls_zval && Z_TYPE_P(use_tls_zval) != IS_NULL)
-                              ? (Z_TYPE_P(use_tls_zval) == IS_TRUE)
-                              : false;
+    zend_bool use_tls = (use_tls_zval && Z_TYPE_P(use_tls_zval) != IS_NULL)
+                            ? (Z_TYPE_P(use_tls_zval) == IS_TRUE)
+                            : false;
+    /* read_from and node_discovery_mode are declared as ?int in the public API.
+     * Z_PARAM_ZVAL_OR_NULL accepts any type, so enforce the integer contract here
+     * and reject non-null, non-integer values instead of misreading the zval union. */
+    if (read_from_zval && Z_TYPE_P(read_from_zval) != IS_NULL &&
+        Z_TYPE_P(read_from_zval) != IS_LONG) {
+        zend_throw_exception(
+            get_valkey_glide_exception_ce(), "read_from must be an integer or null.", 0);
+        RETURN_FALSE;
+    }
+    if (node_discovery_mode_zval && Z_TYPE_P(node_discovery_mode_zval) != IS_NULL &&
+        Z_TYPE_P(node_discovery_mode_zval) != IS_LONG) {
+        zend_throw_exception(
+            get_valkey_glide_exception_ce(), "node_discovery_mode must be an integer or null.", 0);
+        RETURN_FALSE;
+    }
+
     zend_long read_from = (read_from_zval && Z_TYPE_P(read_from_zval) != IS_NULL)
                               ? Z_LVAL_P(read_from_zval)
                               : VALKEY_GLIDE_READ_FROM_PRIMARY;

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -988,7 +988,6 @@ static int valkey_glide_create_connection(valkey_glide_object* valkey_glide,
                                           zend_bool            use_tls,
                                           zval*                credentials,
                                           zend_long            read_from,
-                                          zend_long            node_discovery_mode,
                                           zval*                request_timeout_zval,
                                           zval*                reconnect_strategy,
                                           zval*                database_id_zval,
@@ -1002,7 +1001,8 @@ static int valkey_glide_create_connection(valkey_glide_object* valkey_glide,
                                           zval*                compression,
                                           zval*                client_side_cache,
                                           zval*                address_resolver,
-                                          zval*                circuit_breaker) {
+                                          zval*                circuit_breaker,
+                                          zend_long            node_discovery_mode) {
     valkey_glide_php_common_constructor_params_t common_params;
     valkey_glide_init_common_constructor_params(&common_params);
 
@@ -1157,7 +1157,6 @@ PHP_METHOD(ValkeyGlide, connect) {
     zval*  read_timeout_zval        = NULL;
     zval*  use_tls_zval             = NULL;
     zval*  read_from_zval           = NULL;
-    zval*  node_discovery_mode_zval = NULL;
     zval*  request_timeout_zval     = NULL;
     zval*  reconnect_strategy       = NULL;
     zval*  database_id_zval         = NULL;
@@ -1172,6 +1171,7 @@ PHP_METHOD(ValkeyGlide, connect) {
     zval*  client_side_cache        = NULL;
     zval*  address_resolver         = NULL;
     zval*  circuit_breaker          = NULL;
+    zval*  node_discovery_mode_zval = NULL;
 
     ZEND_PARSE_PARAMETERS_START(0, 23)
     Z_PARAM_OPTIONAL
@@ -1263,7 +1263,6 @@ PHP_METHOD(ValkeyGlide, connect) {
                                                 use_tls,
                                                 credentials,
                                                 read_from,
-                                                node_discovery_mode,
                                                 request_timeout_zval,
                                                 reconnect_strategy,
                                                 database_id_zval,
@@ -1277,7 +1276,8 @@ PHP_METHOD(ValkeyGlide, connect) {
                                                 compression,
                                                 client_side_cache,
                                                 address_resolver,
-                                                circuit_breaker);
+                                                circuit_breaker,
+                                                node_discovery_mode);
 
     /* Clean up temporary addresses array if we created it */
     if (host != NULL) {

--- a/valkey_glide.c
+++ b/valkey_glide.c
@@ -175,6 +175,7 @@ void valkey_glide_init_common_constructor_params(
     params->use_tls                 = 0;
     params->credentials             = NULL;
     params->read_from               = 0; /* PRIMARY by default */
+    params->node_discovery_mode     = 0; /* STANDARD by default */
     params->request_timeout         = 0;
     params->request_timeout_is_null = 1;
     params->reconnect_strategy      = NULL;
@@ -230,6 +231,20 @@ int valkey_glide_build_client_config_base(valkey_glide_php_common_constructor_pa
         case 0: /* PRIMARY */
         default:
             config->read_from = VALKEY_GLIDE_READ_FROM_PRIMARY;
+            break;
+    }
+
+    /* Map node_discovery_mode enum value to client's NodeDiscoveryMode enum */
+    switch (params->node_discovery_mode) {
+        case 1: /* STATIC */
+            config->node_discovery_mode = VALKEY_GLIDE_NODE_DISCOVERY_MODE_STATIC;
+            break;
+        case 2: /* DISCOVER_ALL */
+            config->node_discovery_mode = VALKEY_GLIDE_NODE_DISCOVERY_MODE_DISCOVER_ALL;
+            break;
+        case 0: /* STANDARD */
+        default:
+            config->node_discovery_mode = VALKEY_GLIDE_NODE_DISCOVERY_MODE_STANDARD;
             break;
     }
 
@@ -963,6 +978,7 @@ static int valkey_glide_create_connection(valkey_glide_object* valkey_glide,
                                           zend_bool            use_tls,
                                           zval*                credentials,
                                           zend_long            read_from,
+                                          zend_long            node_discovery_mode,
                                           zval*                request_timeout_zval,
                                           zval*                reconnect_strategy,
                                           zval*                database_id_zval,
@@ -991,10 +1007,11 @@ static int valkey_glide_create_connection(valkey_glide_object* valkey_glide,
     VALKEY_LOG_DEBUG("valkey_glide_create_connection", "Establishing server connection");
 
     /* Set parameters */
-    common_params.addresses   = addresses;
-    common_params.use_tls     = use_tls;
-    common_params.credentials = credentials;
-    common_params.read_from   = read_from;
+    common_params.addresses           = addresses;
+    common_params.use_tls             = use_tls;
+    common_params.credentials         = credentials;
+    common_params.read_from           = read_from;
+    common_params.node_discovery_mode = node_discovery_mode;
 
     if (request_timeout_zval != NULL && Z_TYPE_P(request_timeout_zval) != IS_NULL) {
         common_params.request_timeout         = Z_LVAL_P(request_timeout_zval);
@@ -1118,34 +1135,35 @@ static int valkey_glide_create_connection(valkey_glide_object* valkey_glide,
    (host/port) and ValkeyGlide-style (addresses array) parameters.
    Returns true on success, false on failure. */
 PHP_METHOD(ValkeyGlide, connect) {
-    char*  host                 = NULL;
-    size_t host_len             = 0;
-    char*  persistent_id        = NULL;
-    size_t persistent_id_len    = 0;
-    zval*  addresses            = NULL;
-    zval*  credentials          = NULL;
-    zval*  port_zval            = NULL;
-    zval*  timeout_zval         = NULL;
-    zval*  retry_interval_zval  = NULL;
-    zval*  read_timeout_zval    = NULL;
-    zval*  use_tls_zval         = NULL;
-    zval*  read_from_zval       = NULL;
-    zval*  request_timeout_zval = NULL;
-    zval*  reconnect_strategy   = NULL;
-    zval*  database_id_zval     = NULL;
-    char*  client_name          = NULL;
-    size_t client_name_len      = 0;
-    char*  client_az            = NULL;
-    size_t client_az_len        = 0;
-    zval*  advanced_config      = NULL;
-    zval*  lazy_connect_zval    = NULL;
-    zval*  context              = NULL;
-    zval*  compression          = NULL;
-    zval*  client_side_cache    = NULL;
-    zval*  address_resolver     = NULL;
-    zval*  circuit_breaker      = NULL;
+    char*  host                     = NULL;
+    size_t host_len                 = 0;
+    char*  persistent_id            = NULL;
+    size_t persistent_id_len        = 0;
+    zval*  addresses                = NULL;
+    zval*  credentials              = NULL;
+    zval*  port_zval                = NULL;
+    zval*  timeout_zval             = NULL;
+    zval*  retry_interval_zval      = NULL;
+    zval*  read_timeout_zval        = NULL;
+    zval*  use_tls_zval             = NULL;
+    zval*  read_from_zval           = NULL;
+    zval*  node_discovery_mode_zval = NULL;
+    zval*  request_timeout_zval     = NULL;
+    zval*  reconnect_strategy       = NULL;
+    zval*  database_id_zval         = NULL;
+    char*  client_name              = NULL;
+    size_t client_name_len          = 0;
+    char*  client_az                = NULL;
+    size_t client_az_len            = 0;
+    zval*  advanced_config          = NULL;
+    zval*  lazy_connect_zval        = NULL;
+    zval*  context                  = NULL;
+    zval*  compression              = NULL;
+    zval*  client_side_cache        = NULL;
+    zval*  address_resolver         = NULL;
+    zval*  circuit_breaker          = NULL;
 
-    ZEND_PARSE_PARAMETERS_START(0, 22)
+    ZEND_PARSE_PARAMETERS_START(0, 23)
     Z_PARAM_OPTIONAL
     Z_PARAM_STRING_OR_NULL(host, host_len)
     Z_PARAM_ZVAL_OR_NULL(port_zval)
@@ -1169,6 +1187,7 @@ PHP_METHOD(ValkeyGlide, connect) {
     Z_PARAM_ARRAY_OR_NULL(client_side_cache)
     Z_PARAM_ZVAL_OR_NULL(address_resolver)
     Z_PARAM_ARRAY_OR_NULL(circuit_breaker)
+    Z_PARAM_ZVAL_OR_NULL(node_discovery_mode_zval)
     ZEND_PARSE_PARAMETERS_END_EX(RETURN_THROWS());
 
     /* Apply defaults for nullable parameters */
@@ -1181,6 +1200,10 @@ PHP_METHOD(ValkeyGlide, connect) {
     zend_long read_from = (read_from_zval && Z_TYPE_P(read_from_zval) != IS_NULL)
                               ? Z_LVAL_P(read_from_zval)
                               : VALKEY_GLIDE_READ_FROM_PRIMARY;
+    zend_long node_discovery_mode =
+        (node_discovery_mode_zval && Z_TYPE_P(node_discovery_mode_zval) != IS_NULL)
+            ? Z_LVAL_P(node_discovery_mode_zval)
+            : VALKEY_GLIDE_NODE_DISCOVERY_MODE_STANDARD;
 
     /* Validate conflicting parameters */
     if (host != NULL && addresses != NULL) {
@@ -1230,6 +1253,7 @@ PHP_METHOD(ValkeyGlide, connect) {
                                                 use_tls,
                                                 credentials,
                                                 read_from,
+                                                node_discovery_mode,
                                                 request_timeout_zval,
                                                 reconnect_strategy,
                                                 database_id_zval,

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -195,6 +195,30 @@ class ValkeyGlide
            */
     public const  READ_FROM_AZ_AFFINITY_REPLICAS_AND_PRIMARY = 3;
 
+          /**
+           *  @var int
+           * Default node discovery mode. Verifies node roles via INFO REPLICATION and uses
+           * only the provided addresses.
+           */
+    public const  NODE_DISCOVERY_MODE_STANDARD = 0;
+
+          /**
+           *  @var int
+           * Skips role detection entirely. Trusts the provided addresses as-is; the first
+           * address is treated as the primary. Use when connecting through a proxy (e.g. Envoy,
+           * HAProxy) that does not support INFO, or when the topology is known and static.
+           * Note: Do not set client_name when using this mode with a proxy.
+           */
+    public const  NODE_DISCOVERY_MODE_STATIC = 1;
+
+          /**
+           *  @var int
+           * Auto-discovers the full topology (primary + all replicas) from any single starting
+           * node (primary or replica). Provide any single node address and the client will find
+           * and connect to all other nodes.
+           */
+    public const  NODE_DISCOVERY_MODE_DISCOVER_ALL = 2;
+
     /**
      * @var string
      * COPY command option key for replacing existing destination key
@@ -382,6 +406,10 @@ class ValkeyGlide
      *                                    ['window_size_ms' => int, 'failure_rate_threshold' => float,
      *                                     'min_errors' => int, 'open_timeout_ms' => int,
      *                                     'count_timeouts' => bool, 'consecutive_successes' => int]
+     * @param int|null $node_discovery_mode Standalone node discovery strategy (standalone only):
+     *                                      NODE_DISCOVERY_MODE_STANDARD (default),
+     *                                      NODE_DISCOVERY_MODE_STATIC, or
+     *                                      NODE_DISCOVERY_MODE_DISCOVER_ALL
      * @return bool True on successful connection, false on failure
      *
      * @throws ValkeyGlideException If conflicting parameters are specified or connection fails
@@ -417,6 +445,7 @@ class ValkeyGlide
         ?array $client_side_cache = null,
         ?callable $address_resolver = null,
         ?array $circuit_breaker = null,
+        ?int $node_discovery_mode = null,
     ): bool;
 
     public function __destruct();

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -140,24 +140,36 @@ uint8_t* create_connection_request(size_t*                                   len
 
     conn_req.lazy_connect = config->lazy_connect;
     /* Map read_from configuration */
-    if (config->read_from == VALKEY_GLIDE_READ_FROM_PREFER_REPLICA) {
+    if (config->read_from == VALKEY_GLIDE_READ_FROM_PRIMARY) {
+        conn_req.read_from = CONNECTION_REQUEST__READ_FROM__Primary;
+    } else if (config->read_from == VALKEY_GLIDE_READ_FROM_PREFER_REPLICA) {
         conn_req.read_from = CONNECTION_REQUEST__READ_FROM__PreferReplica;
     } else if (config->read_from == VALKEY_GLIDE_READ_FROM_AZ_AFFINITY) {
         conn_req.read_from = CONNECTION_REQUEST__READ_FROM__AZAffinity;
     } else if (config->read_from == VALKEY_GLIDE_READ_FROM_AZ_AFFINITY_REPLICAS_AND_PRIMARY) {
         conn_req.read_from = CONNECTION_REQUEST__READ_FROM__AZAffinityReplicasAndPrimary;
     } else {
-        conn_req.read_from = CONNECTION_REQUEST__READ_FROM__Primary;
+        const char* error_message = "Invalid read_from value.";
+        VALKEY_LOG_ERROR("create_connection_request", error_message);
+        zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+        *len = 0;
+        return NULL;
     }
 
     /* Map node_discovery_mode configuration (standalone only). */
     if (!is_cluster) {
-        if (config->node_discovery_mode == VALKEY_GLIDE_NODE_DISCOVERY_MODE_STATIC) {
+        if (config->node_discovery_mode == VALKEY_GLIDE_NODE_DISCOVERY_MODE_STANDARD) {
+            conn_req.node_discovery_mode = CONNECTION_REQUEST__NODE_DISCOVERY_MODE__Standard;
+        } else if (config->node_discovery_mode == VALKEY_GLIDE_NODE_DISCOVERY_MODE_STATIC) {
             conn_req.node_discovery_mode = CONNECTION_REQUEST__NODE_DISCOVERY_MODE__Static;
         } else if (config->node_discovery_mode == VALKEY_GLIDE_NODE_DISCOVERY_MODE_DISCOVER_ALL) {
             conn_req.node_discovery_mode = CONNECTION_REQUEST__NODE_DISCOVERY_MODE__DiscoverAll;
         } else {
-            conn_req.node_discovery_mode = CONNECTION_REQUEST__NODE_DISCOVERY_MODE__Standard;
+            const char* error_message = "Invalid node_discovery_mode value.";
+            VALKEY_LOG_ERROR("create_connection_request", error_message);
+            zend_throw_exception(get_valkey_glide_exception_ce(), error_message, 0);
+            *len = 0;
+            return NULL;
         }
     }
 

--- a/valkey_glide_core_commands.c
+++ b/valkey_glide_core_commands.c
@@ -150,6 +150,17 @@ uint8_t* create_connection_request(size_t*                                   len
         conn_req.read_from = CONNECTION_REQUEST__READ_FROM__Primary;
     }
 
+    /* Map node_discovery_mode configuration (standalone only). */
+    if (!is_cluster) {
+        if (config->node_discovery_mode == VALKEY_GLIDE_NODE_DISCOVERY_MODE_STATIC) {
+            conn_req.node_discovery_mode = CONNECTION_REQUEST__NODE_DISCOVERY_MODE__Static;
+        } else if (config->node_discovery_mode == VALKEY_GLIDE_NODE_DISCOVERY_MODE_DISCOVER_ALL) {
+            conn_req.node_discovery_mode = CONNECTION_REQUEST__NODE_DISCOVERY_MODE__DiscoverAll;
+        } else {
+            conn_req.node_discovery_mode = CONNECTION_REQUEST__NODE_DISCOVERY_MODE__Standard;
+        }
+    }
+
     /* Set database ID for standalone clients if it is valid. */
     if (config->database_id >= 0) {
         conn_req.database_id = config->database_id;


### PR DESCRIPTION
### Summary

Exposes the `NodeDiscoveryMode` configuration option for standalone clients, bringing the PHP client in line with Java, Python, Node, Go, and C#. This controls how the client discovers node roles and topology in standalone mode.

### Issue link

This Pull Request is linked to issue:
Closes #302

### Features / Behaviour Changes

Adds a `node_discovery_mode` parameter to `ValkeyGlide::connect()` and three new class constants:

- `ValkeyGlide::NODE_DISCOVERY_MODE_STANDARD` (default) — Verifies node roles via `INFO REPLICATION` and uses only the provided addresses. Existing behaviour; no change for current users.
- `ValkeyGlide::NODE_DISCOVERY_MODE_STATIC` — Skips role detection and trusts the provided addresses as-is (first address treated as primary). Enables connectivity through proxies such as Envoy/HAProxy that do not support `INFO`.
- `ValkeyGlide::NODE_DISCOVERY_MODE_DISCOVER_ALL` — Auto-discovers the full topology (primary + all replicas) from any single starting node (primary or replica).

The parameter is optional and defaults to `STANDARD`, so this change is fully backward compatible.

### Implementation

- Added `valkey_glide_node_discovery_mode_t` enum and a `node_discovery_mode` field to the base client configuration and constructor-params structs (`common.h`).
- Parsed the new `node_discovery_mode` argument in `ValkeyGlide::connect()` and mapped it into the client configuration (`valkey_glide.c`).
- Wired the configuration to the protobuf `node_discovery_mode` field on `ConnectionRequest` in `create_connection_request()`, standalone-only (`valkey_glide_core_commands.c`).
- Exposed the constants and the `connect()` parameter in the PHP stub (`valkey_glide.stub.php`); arginfo is regenerated by the build.
- Extended `ClientConstructorMock::simulate_standalone_constructor()` to support the option for serialization tests.

Notes:
- The protobuf field is `node_discovery_mode = 28` on `ConnectionRequest` (field 27 is `client_side_cache`), not field 27 as stated in the issue.
- The generated protobuf PHP class `tests/Connection_request/NodeDiscoveryMode.php` already existed in the repo (the proto had been regenerated previously), so it does not appear in this diff.

### Limitations

- `NodeDiscoveryMode` applies to standalone clients only; it is intentionally not set for cluster clients. This matches the reference clients (confirmed in glide-core, where only the standalone client path reads the field) and the C# client, whose docs state the option is "ignored in cluster mode".
- The PHP client does not expose a `read_only` connection flag, so the `read_only` + `DISCOVER_ALL` rejection test present in the Java/Python/Node suites is not applicable here and was not ported. Adding `read_only` support is tracked separately in #323.

### Testing

- 4 protobuf serialization tests in `ConnectionRequestTest` verifying each mode maps to the correct `ConnectionRequest.node_discovery_mode` value (plus the default). These mirror the C# unit tests in `ConnectionConfigurationTests.cs`.
- 5 integration tests in a new `ValkeyGlideNodeDiscoveryModeTest` covering STATIC (connect/read, writes) and DISCOVER_ALL (from primary, from replica, from partial addresses), using the primary/replica topology from `tests/start_valkey_with_replicas.sh`. Coverage matches the Java/Python/Node discovery suites. The tests self-skip when the topology or TLS-only runs make them inapplicable.
- Cross-checked the implementation against the C# client (`valkey-io/valkey-glide-csharp`): enum discriminants (`Standard=0`, `Static=1`, `DiscoverAll=2`), standalone-only scoping, and default behaviour all match.
- Verified locally: build passes with `-Werror`; C lint passes (clang-format 18); PHP lint passes; ConnectionRequest suite 64/64; NodeDiscoveryMode integration 5/5; existing constructor/connect tests 21/21.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.

