### PR TITLE
Update submodule glide core

### DIFF
--- a/utils/patch_proto_and_rust.py
+++ b/utils/patch_proto_and_rust.py
@@ -173,6 +173,68 @@ def patch_rust_types_rs(rust_types_file):
             needs_patching = True
             log_message("Applied eviction_policy patch")
 
+        # Fix client_cert_path: changed from Option<Chars> to Chars (proto3 optional stripped).
+        # The generated field is now a plain `Chars`, so treat an empty string as "unset".
+        client_cert_path_pattern = (
+            r'let client_cert_path = value\s*'
+            r'\.client_cert_path\s*'
+            r'\.as_ref\(\)\s*'
+            r'\.filter\(\|p\| !p\.is_empty\(\)\)\s*'
+            r'\.map\(\|p\| p\.to_string\(\)\);'
+        )
+        client_cert_path_replacement = (
+            'let client_cert_path = Some(value.client_cert_path.to_string())'
+            '.filter(|p| !p.is_empty());'
+        )
+        if re.search(client_cert_path_pattern, new_content, re.DOTALL):
+            if not needs_patching:
+                create_backup(rust_types_file)
+            new_content = re.sub(
+                client_cert_path_pattern, client_cert_path_replacement, new_content, flags=re.DOTALL)
+            needs_patching = True
+            log_message("Applied client_cert_path patch")
+
+        # Fix client_key_path: changed from Option<Chars> to Chars (proto3 optional stripped).
+        client_key_path_pattern = (
+            r'let client_key_path = value\s*'
+            r'\.client_key_path\s*'
+            r'\.as_ref\(\)\s*'
+            r'\.filter\(\|p\| !p\.is_empty\(\)\)\s*'
+            r'\.map\(\|p\| p\.to_string\(\)\);'
+        )
+        client_key_path_replacement = (
+            'let client_key_path = Some(value.client_key_path.to_string())'
+            '.filter(|p| !p.is_empty());'
+        )
+        if re.search(client_key_path_pattern, new_content, re.DOTALL):
+            if not needs_patching:
+                create_backup(rust_types_file)
+            new_content = re.sub(
+                client_key_path_pattern, client_key_path_replacement, new_content, flags=re.DOTALL)
+            needs_patching = True
+            log_message("Applied client_key_path patch")
+
+        # Fix cert_reload.interval_seconds: changed from Option<u32> to u32.
+        cert_reload_interval_pattern = r'interval_seconds: proto_reload\.interval_seconds\.filter\(\|&s\| s != 0\),'
+        cert_reload_interval_replacement = 'interval_seconds: none_if_zero(proto_reload.interval_seconds),'
+        if re.search(cert_reload_interval_pattern, new_content):
+            if not needs_patching:
+                create_backup(rust_types_file)
+            new_content = re.sub(
+                cert_reload_interval_pattern, cert_reload_interval_replacement, new_content)
+            needs_patching = True
+            log_message("Applied cert_reload.interval_seconds patch")
+
+        # Fix recovery_requests_queue_size: changed from Option<u32> to u32.
+        recovery_queue_pattern = r'let recovery_requests_queue_size = value\.recovery_requests_queue_size;'
+        recovery_queue_replacement = 'let recovery_requests_queue_size = none_if_zero(value.recovery_requests_queue_size);'
+        if re.search(recovery_queue_pattern, new_content):
+            if not needs_patching:
+                create_backup(rust_types_file)
+            new_content = re.sub(recovery_queue_pattern, recovery_queue_replacement, new_content)
+            needs_patching = True
+            log_message("Applied recovery_requests_queue_size patch")
+
         if needs_patching:
             with open(rust_types_file, 'w') as f:
                 f.write(new_content)
@@ -201,10 +263,16 @@ def verify_rust_patch(rust_types_file):
         compression_fixed = 'Some(proto_config.compression_level)' in content
         max_decompressed_fixed = 'if proto_config.max_decompressed_size != 0' in content
         eviction_fixed = '.enum_value()' in content and '.and_then(|enum_or_unknown|' not in content
+        client_cert_path_fixed = 'Some(value.client_cert_path.to_string()).filter(|p| !p.is_empty())' in content
+        client_key_path_fixed = 'Some(value.client_key_path.to_string()).filter(|p| !p.is_empty())' in content
+        cert_reload_interval_fixed = 'interval_seconds: none_if_zero(proto_reload.interval_seconds)' in content
+        recovery_queue_fixed = 'let recovery_requests_queue_size = none_if_zero(value.recovery_requests_queue_size);' in content
 
         all_fixed = (tcp_nodelay_fixed and pubsub_fixed and jitter_fixed and
                      refresh_fixed and compression_fixed and read_only_fixed and
-                     max_decompressed_fixed and eviction_fixed)
+                     max_decompressed_fixed and eviction_fixed and
+                     client_cert_path_fixed and client_key_path_fixed and
+                     cert_reload_interval_fixed and recovery_queue_fixed)
 
         if all_fixed:
             log_message("Rust patch verification: SUCCESS")
@@ -227,6 +295,14 @@ def verify_rust_patch(rust_types_file):
                 missing.append("max_decompressed_size fix")
             if not eviction_fixed:
                 missing.append("eviction_policy fix")
+            if not client_cert_path_fixed:
+                missing.append("client_cert_path fix")
+            if not client_key_path_fixed:
+                missing.append("client_key_path fix")
+            if not cert_reload_interval_fixed:
+                missing.append("cert_reload.interval_seconds fix")
+            if not recovery_queue_fixed:
+                missing.append("recovery_requests_queue_size fix")
             log_message(f"Rust patch verification: FAILED - Missing: {', '.join(missing)}", "ERROR")
             return False
 


### PR DESCRIPTION
### Summary

Bumps the `valkey-glide` submodule from `1b0ffb14` to `d3feeaaf0` (upstream `main`) to keep the PHP client aligned with the current GLIDE core, and updates `utils/patch_proto_and_rust.py` so the newer core compiles.

### Issue link

Closes #324

### Features / Behaviour Changes

- No user-facing API changes — core/tooling update only.

### Implementation

`patch_proto_and_rust.py` strips proto3 `optional` (required by the vendored `protobuf-c` path) and re-patches the generated Rust (`glide-core/src/client/types.rs`) to keep those fields `Option<...>`. The newer core added `optional` fields not in the script's hardcoded list, breaking the build. Added patch rules + verification for the newly added fields: `client_cert_path`, `client_key_path`, `cert_reload.interval_seconds`, and `recovery_requests_queue_size`.

Note: two commits are intentional (pointer bump; tooling fix). The submodule's in-tree edits are regenerated at build time and not committed — only the submodule commit pointer is tracked.

### Limitations

- Bumps the core and fixes the build only; no new client features are exposed in this PR.

### Testing

- Clean regeneration + Rust FFI build + PHP extension build (`-Werror`) succeed; `ConnectionRequest` tests pass (60/60). Full `make test` matrix should run in CI given the core jump.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
