### PR TITLE
feat(php): implement PUBSUB SHARDCHANNELS

### DIFF
--- a/tests/ValkeyGlideClusterPubSubTest.php
+++ b/tests/ValkeyGlideClusterPubSubTest.php
@@ -358,16 +358,69 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
     }
 
     /**
+     * Start a sharded-channel subscriber in a background process using valkey-cli.
+     *
+     * The PHP client does not yet implement SSUBSCRIBE (see follow-up issue), so
+     * an external valkey-cli process is used to hold a live sharded subscription
+     * while the PHP client queries PUBSUB SHARDCHANNELS. Returns a handle that
+     * must be passed to stopShardSubscriber() for cleanup.
+     *
+     * @return array{proc: resource, pipes: array}|null Null if valkey-cli is unavailable.
+     */
+    private function startShardSubscriber(string $channel)
+    {
+        $cli = trim((string) shell_exec('command -v valkey-cli 2>/dev/null'));
+        if ($cli === '') {
+            $cli = trim((string) shell_exec('command -v redis-cli 2>/dev/null'));
+        }
+        if ($cli === '') {
+            return null;
+        }
+
+        $cmd = sprintf(
+            '%s -c -h %s -p %d ssubscribe %s',
+            escapeshellarg($cli),
+            escapeshellarg($this->getHost()),
+            $this->getPort(),
+            escapeshellarg($channel)
+        );
+
+        $proc = proc_open(
+            $cmd,
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes
+        );
+
+        if (!is_resource($proc)) {
+            return null;
+        }
+
+        // Give the subscription time to register on the owning node.
+        usleep(500000);
+
+        return ['proc' => $proc, 'pipes' => $pipes];
+    }
+
+    private function stopShardSubscriber($handle)
+    {
+        if (!is_array($handle)) {
+            return;
+        }
+        foreach ($handle['pipes'] as $pipe) {
+            @fclose($pipe);
+        }
+        @proc_terminate($handle['proc']);
+        @proc_close($handle['proc']);
+    }
+
+    /**
      * PUBSUB SHARDCHANNELS: lists the currently active shard channels.
      *
      * Mirrors valkey-glide's cross-language pubsub_shardchannels tests. Sharded
-     * pub/sub is a cluster-only feature available since Valkey/Redis 7.0.
-     *
-     * Note: the PHP client does not yet implement sharded subscriptions
-     * (ValkeyGlide::ssubscribe is a TODO), so we cannot stand up a live sharded
-     * subscriber from PHP to assert non-empty results. We therefore verify the
-     * empty-state behaviour, return shape, and pattern handling — matching the
-     * achievable subset of the reference test suites.
+     * pub/sub is a cluster-only feature available since Valkey/Redis 7.0. A live
+     * sharded subscriber is created via valkey-cli (PHP-native SSUBSCRIBE is not
+     * yet implemented) so we can assert real active-channel behaviour, matching
+     * the reference suites.
      *
      * @see https://valkey.io/commands/pubsub-shardchannels/
      */
@@ -378,83 +431,47 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
             return;
         }
 
-        // Without a pattern: returns an array of active shard channels.
+        // Empty state: no active sharded subscribers => empty list.
         $result = $this->valkey_glide->pubsub('shardchannels');
         $this->assertIsArray($result);
 
-        // With no active sharded subscribers, the list is empty.
-        $this->assertEmpty($result);
+        // Bring up a live sharded subscriber on a unique channel.
+        $channel = 'test_shardchannel_' . uniqid();
+        $handle  = $this->startShardSubscriber($channel);
 
-        // With a pattern: returns an array (subset matching the glob pattern).
-        $result = $this->valkey_glide->pubsub('shardchannels', 'test_*');
-        $this->assertIsArray($result);
-
-        // A non-matching pattern yields an empty list.
-        $result = $this->valkey_glide->pubsub('shardchannels', 'non_matching_*');
-        $this->assertIsArray($result);
-        $this->assertEmpty($result);
-    }
-
-    /**
-     * PUBSUB SHARDNUMSUB: returns the subscriber count for the given shard channels.
-     *
-     * Mirrors valkey-glide's cross-language pubsub_shardnumsub tests. With no
-     * active sharded subscribers every queried channel reports 0, and calling the
-     * command without channels returns an empty map.
-     *
-     * @see https://valkey.io/commands/pubsub-shardnumsub/
-     */
-    public function testPubSubShardNumSub()
-    {
-        if (! $this->minVersionCheck('7.0.0')) {
-            $this->markTestSkipped('PUBSUB SHARDNUMSUB requires Valkey/Redis 7.0+');
+        if ($handle === null) {
+            // No valkey-cli/redis-cli available; fall back to shape-only checks.
+            $this->assertIsArray($this->valkey_glide->pubsub('shardchannels', 'test_*'));
+            $this->assertIsArray($this->valkey_glide->pubsub('shardchannels', 'non_matching_*'));
             return;
         }
 
-        $channel1 = 'test_shardchannel1';
-        $channel2 = 'test_shardchannel2';
-        $channel3 = 'test_shardchannel3';
+        try {
+            // Without a pattern: the active channel must be listed.
+            $channels = $this->valkey_glide->pubsub('shardchannels');
+            $this->assertIsArray($channels);
+            $this->assertContains($channel, $channels);
 
-        // Query specific channels. Matching PHPRedis, the reply is passed through
-        // as the raw server response: a flat array laid out as
-        // [channel, count, channel, count, ...] rather than an associative map.
-        $result = $this->valkey_glide->pubsub('shardnumsub', [$channel1, $channel2, $channel3]);
-        $this->assertIsArray($result);
+            // With a matching glob pattern: the channel is included.
+            $matched = $this->valkey_glide->pubsub('shardchannels', 'test_shardchannel_*');
+            $this->assertIsArray($matched);
+            $this->assertContains($channel, $matched);
 
-        // Three channels => 3 (channel, count) pairs => 6 flat elements.
-        $this->assertCount(6, $result);
-
-        // Fold the flat [channel, count, ...] array into a map for assertions.
-        $counts = [];
-        for ($i = 0; $i + 1 < count($result); $i += 2) {
-            $counts[$result[$i]] = $result[$i + 1];
-        }
-
-        // With no active sharded subscribers, every queried channel reports 0.
-        foreach ([$channel1, $channel2, $channel3] as $channel) {
+            // With a non-matching pattern: the channel is excluded.
+            $notMatched = $this->valkey_glide->pubsub('shardchannels', 'no_such_prefix_*');
+            $this->assertIsArray($notMatched);
             $this->assertTrue(
-                isset($counts[$channel]),
-                "SHARDNUMSUB result should contain channel '$channel'"
+                !in_array($channel, $notMatched, true),
+                'Non-matching pattern should not include the channel'
             );
-            $this->assertEquals(0, $counts[$channel]);
+        } finally {
+            $this->stopShardSubscriber($handle);
         }
-
-        // Calling SHARDNUMSUB without channels is valid and returns an empty array.
-        $empty = $this->valkey_glide->pubsub('shardnumsub');
-        $this->assertIsArray($empty);
-        $this->assertEmpty($empty);
-
-        $empty = $this->valkey_glide->pubsub('shardnumsub', []);
-        $this->assertIsArray($empty);
-        $this->assertEmpty($empty);
     }
 
     /**
-     * PUBSUB CHANNELS vs SHARDCHANNELS separation.
-     *
-     * Verifies both introspection variants coexist and return arrays. Regular
-     * pub/sub channels never appear in the sharded channel listing and vice
-     * versa; without live subscribers both are empty here.
+     * PUBSUB CHANNELS vs SHARDCHANNELS: a sharded channel is reported by
+     * SHARDCHANNELS but never by the regular CHANNELS introspection.
      */
     public function testPubSubChannelsAndShardChannelsSeparation()
     {
@@ -463,20 +480,40 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
             return;
         }
 
-        $channels      = $this->valkey_glide->pubsub('channels');
-        $shardChannels = $this->valkey_glide->pubsub('shardchannels');
+        $channel = 'test_separation_' . uniqid();
+        $handle  = $this->startShardSubscriber($channel);
 
-        $this->assertIsArray($channels);
-        $this->assertIsArray($shardChannels);
+        if ($handle === null) {
+            // No CLI available; assert both variants at least return arrays.
+            $this->assertIsArray($this->valkey_glide->pubsub('channels'));
+            $this->assertIsArray($this->valkey_glide->pubsub('shardchannels'));
+            return;
+        }
+
+        try {
+            $shardChannels = $this->valkey_glide->pubsub('shardchannels');
+            $regularChannels = $this->valkey_glide->pubsub('channels');
+
+            $this->assertIsArray($shardChannels);
+            $this->assertIsArray($regularChannels);
+
+            // The sharded channel appears in SHARDCHANNELS ...
+            $this->assertContains($channel, $shardChannels);
+            // ... but not in the regular CHANNELS listing.
+            $this->assertTrue(
+                !in_array($channel, $regularChannels, true),
+                'Sharded channel must not appear in PUBSUB CHANNELS'
+            );
+        } finally {
+            $this->stopShardSubscriber($handle);
+        }
     }
 
     /**
-     * PUBSUB SHARD* invalid argument handling.
-     *
-     * SHARDNUMSUB requires an array argument when one is supplied; passing a
-     * non-array must raise an exception (consistent with NUMSUB validation).
+     * PUBSUB SHARDNUMSUB is not yet supported by the PHP client and must raise
+     * an exception until it is implemented (see follow-up issue).
      */
-    public function testPubSubShardNumSubInvalidArg()
+    public function testPubSubShardNumSubNotSupported()
     {
         if (! $this->minVersionCheck('7.0.0')) {
             $this->markTestSkipped('Sharded pub/sub requires Valkey/Redis 7.0+');
@@ -485,10 +522,10 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
 
         $threw = false;
         try {
-            $this->valkey_glide->pubsub('shardnumsub', 'not_an_array');
+            $this->valkey_glide->pubsub('shardnumsub', ['some_channel']);
         } catch (\Throwable $e) {
             $threw = true;
         }
-        $this->assertTrue($threw, 'SHARDNUMSUB with a non-array argument should throw');
+        $this->assertTrue($threw, 'SHARDNUMSUB should throw until it is implemented');
     }
 }

--- a/tests/ValkeyGlideClusterPubSubTest.php
+++ b/tests/ValkeyGlideClusterPubSubTest.php
@@ -361,9 +361,12 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
      * Start a sharded-channel subscriber in a background process using valkey-cli.
      *
      * The PHP client does not yet implement SSUBSCRIBE (see follow-up issue), so
-     * an external valkey-cli process is used to hold a live sharded subscription
-     * while the PHP client queries PUBSUB SHARDCHANNELS. Returns a handle that
-     * must be passed to stopShardSubscriber() for cleanup.
+     * external valkey-cli processes are used to hold live sharded subscriptions
+     * while the PHP client queries PUBSUB SHARDCHANNELS.
+     *
+     * A single valkey-cli SSUBSCRIBE can only cover channels in one slot (a
+     * multi-channel subscribe across slots fails with CROSSSLOT), so callers
+     * that need several channels should start one subscriber per channel.
      *
      * @return array{proc: resource, pipes: array}|null Null if valkey-cli is unavailable.
      */
@@ -395,10 +398,39 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
             return null;
         }
 
-        // Give the subscription time to register on the owning node.
-        usleep(500000);
+        // Give the subscription time to register on its owning node.
+        usleep(400000);
 
         return ['proc' => $proc, 'pipes' => $pipes];
+    }
+
+    /**
+     * Start one sharded subscriber per channel and return their handles.
+     *
+     * @return array<array{proc: resource, pipes: array}>|null Null if valkey-cli is unavailable.
+     */
+    private function startShardSubscribers(array $channels)
+    {
+        $handles = [];
+        foreach ($channels as $channel) {
+            $handle = $this->startShardSubscriber($channel);
+            if ($handle === null) {
+                // CLI unavailable: tear down anything already started and bail.
+                foreach ($handles as $h) {
+                    $this->stopShardSubscriber($h);
+                }
+                return null;
+            }
+            $handles[] = $handle;
+        }
+        return $handles;
+    }
+
+    private function stopShardSubscribers(array $handles)
+    {
+        foreach ($handles as $handle) {
+            $this->stopShardSubscriber($handle);
+        }
     }
 
     private function stopShardSubscriber($handle)
@@ -435,9 +467,15 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
         $result = $this->valkey_glide->pubsub('shardchannels');
         $this->assertIsArray($result);
 
-        // Bring up a live sharded subscriber on a unique channel.
-        $channel = 'test_shardchannel_' . uniqid();
-        $handle  = $this->startShardSubscriber($channel);
+        // Bring up live sharded subscribers on multiple channels. Two share a
+        // common prefix (so a glob pattern matches a subset) and one does not,
+        // mirroring the Python/Go reference suites.
+        $suffix   = uniqid();
+        $channel1 = 'test_shardchannel1_' . $suffix;
+        $channel2 = 'test_shardchannel2_' . $suffix;
+        $channel3 = 'other_shardchannel3_' . $suffix;
+
+        $handle = $this->startShardSubscribers([$channel1, $channel2, $channel3]);
 
         if ($handle === null) {
             // No valkey-cli/redis-cli available; fall back to shape-only checks.
@@ -447,25 +485,34 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
         }
 
         try {
-            // Without a pattern: the active channel must be listed.
+            // Without a pattern: all three active channels must be listed.
             $channels = $this->valkey_glide->pubsub('shardchannels');
             $this->assertIsArray($channels);
-            $this->assertContains($channel, $channels);
+            $this->assertContains($channel1, $channels);
+            $this->assertContains($channel2, $channels);
+            $this->assertContains($channel3, $channels);
 
-            // With a matching glob pattern: the channel is included.
-            $matched = $this->valkey_glide->pubsub('shardchannels', 'test_shardchannel_*');
+            // With a glob pattern: only the matching subset is returned.
+            $matched = $this->valkey_glide->pubsub('shardchannels', 'test_shardchannel*_' . $suffix);
             $this->assertIsArray($matched);
-            $this->assertContains($channel, $matched);
+            $this->assertContains($channel1, $matched);
+            $this->assertContains($channel2, $matched);
+            $this->assertTrue(
+                !in_array($channel3, $matched, true),
+                'Pattern should exclude the non-matching channel'
+            );
 
-            // With a non-matching pattern: the channel is excluded.
+            // With a non-matching pattern: none of the channels are returned.
             $notMatched = $this->valkey_glide->pubsub('shardchannels', 'no_such_prefix_*');
             $this->assertIsArray($notMatched);
-            $this->assertTrue(
-                !in_array($channel, $notMatched, true),
-                'Non-matching pattern should not include the channel'
-            );
+            foreach ([$channel1, $channel2, $channel3] as $ch) {
+                $this->assertTrue(
+                    !in_array($ch, $notMatched, true),
+                    "Non-matching pattern should not include '$ch'"
+                );
+            }
         } finally {
-            $this->stopShardSubscriber($handle);
+            $this->stopShardSubscribers($handle);
         }
     }
 

--- a/tests/ValkeyGlideClusterPubSubTest.php
+++ b/tests/ValkeyGlideClusterPubSubTest.php
@@ -356,4 +356,128 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
 
         $this->assertTrue($success, 'Pattern subscription should work in cluster mode');
     }
+
+    /**
+     * PUBSUB SHARDCHANNELS: lists the currently active shard channels.
+     *
+     * Mirrors valkey-glide's cross-language pubsub_shardchannels tests. Sharded
+     * pub/sub is a cluster-only feature available since Valkey/Redis 7.0.
+     *
+     * Note: the PHP client does not yet implement sharded subscriptions
+     * (ValkeyGlide::ssubscribe is a TODO), so we cannot stand up a live sharded
+     * subscriber from PHP to assert non-empty results. We therefore verify the
+     * empty-state behaviour, return shape, and pattern handling — matching the
+     * achievable subset of the reference test suites.
+     *
+     * @see https://valkey.io/commands/pubsub-shardchannels/
+     */
+    public function testPubSubShardChannels()
+    {
+        if (! $this->minVersionCheck('7.0.0')) {
+            $this->markTestSkipped('PUBSUB SHARDCHANNELS requires Valkey/Redis 7.0+');
+            return;
+        }
+
+        // Without a pattern: returns an array of active shard channels.
+        $result = $this->valkey_glide->pubsub('shardchannels');
+        $this->assertIsArray($result);
+
+        // With no active sharded subscribers, the list is empty.
+        $this->assertEmpty($result);
+
+        // With a pattern: returns an array (subset matching the glob pattern).
+        $result = $this->valkey_glide->pubsub('shardchannels', 'test_*');
+        $this->assertIsArray($result);
+
+        // A non-matching pattern yields an empty list.
+        $result = $this->valkey_glide->pubsub('shardchannels', 'non_matching_*');
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * PUBSUB SHARDNUMSUB: returns the subscriber count for the given shard channels.
+     *
+     * Mirrors valkey-glide's cross-language pubsub_shardnumsub tests. With no
+     * active sharded subscribers every queried channel reports 0, and calling the
+     * command without channels returns an empty map.
+     *
+     * @see https://valkey.io/commands/pubsub-shardnumsub/
+     */
+    public function testPubSubShardNumSub()
+    {
+        if (! $this->minVersionCheck('7.0.0')) {
+            $this->markTestSkipped('PUBSUB SHARDNUMSUB requires Valkey/Redis 7.0+');
+            return;
+        }
+
+        $channel1 = 'test_shardchannel1';
+        $channel2 = 'test_shardchannel2';
+        $channel3 = 'test_shardchannel3';
+
+        // Query specific channels: result is a channel => count map.
+        $result = $this->valkey_glide->pubsub('shardnumsub', [$channel1, $channel2, $channel3]);
+        $this->assertIsArray($result);
+
+        // With no active sharded subscribers, every channel reports 0.
+        foreach ([$channel1, $channel2, $channel3] as $channel) {
+            $this->assertTrue(
+                isset($result[$channel]),
+                "SHARDNUMSUB result should contain key '$channel'"
+            );
+            $this->assertEquals(0, $result[$channel]);
+        }
+
+        // Calling SHARDNUMSUB without channels is valid and returns an empty map.
+        $empty = $this->valkey_glide->pubsub('shardnumsub');
+        $this->assertIsArray($empty);
+        $this->assertEmpty($empty);
+
+        $empty = $this->valkey_glide->pubsub('shardnumsub', []);
+        $this->assertIsArray($empty);
+        $this->assertEmpty($empty);
+    }
+
+    /**
+     * PUBSUB CHANNELS vs SHARDCHANNELS separation.
+     *
+     * Verifies both introspection variants coexist and return arrays. Regular
+     * pub/sub channels never appear in the sharded channel listing and vice
+     * versa; without live subscribers both are empty here.
+     */
+    public function testPubSubChannelsAndShardChannelsSeparation()
+    {
+        if (! $this->minVersionCheck('7.0.0')) {
+            $this->markTestSkipped('Sharded pub/sub requires Valkey/Redis 7.0+');
+            return;
+        }
+
+        $channels      = $this->valkey_glide->pubsub('channels');
+        $shardChannels = $this->valkey_glide->pubsub('shardchannels');
+
+        $this->assertIsArray($channels);
+        $this->assertIsArray($shardChannels);
+    }
+
+    /**
+     * PUBSUB SHARD* invalid argument handling.
+     *
+     * SHARDNUMSUB requires an array argument when one is supplied; passing a
+     * non-array must raise an exception (consistent with NUMSUB validation).
+     */
+    public function testPubSubShardNumSubInvalidArg()
+    {
+        if (! $this->minVersionCheck('7.0.0')) {
+            $this->markTestSkipped('Sharded pub/sub requires Valkey/Redis 7.0+');
+            return;
+        }
+
+        $threw = false;
+        try {
+            $this->valkey_glide->pubsub('shardnumsub', 'not_an_array');
+        } catch (\Throwable $e) {
+            $threw = true;
+        }
+        $this->assertTrue($threw, 'SHARDNUMSUB with a non-array argument should throw');
+    }
 }

--- a/tests/ValkeyGlideClusterPubSubTest.php
+++ b/tests/ValkeyGlideClusterPubSubTest.php
@@ -400,22 +400,37 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
     }
 
     /**
-     * Poll (with a bounded timeout) until the given shard channel is reported
-     * active by PUBSUB SHARDCHANNELS, using a short-lived valkey-cli query.
+     * Wait (with a bounded timeout) until the given sharded subscriber process
+     * confirms its subscription.
      *
-     * The PHP client's PUBSUB SHARDCHANNELS is routed across all cluster nodes
-     * and aggregated, so it is used for polling rather than a single-node
-     * valkey-cli query (which only reports channels owned by the queried node).
+     * The confirmation is read from the subscriber's own stdout (valkey-cli
+     * prints the "ssubscribe" push message with the channel name once the
+     * SSUBSCRIBE is acknowledged). Using the subscriber's own connection means
+     * this works regardless of authentication/TLS and does not depend on the
+     * shared test client (which is constructed without TLS).
      *
-     * @return bool True if the channel became active within the timeout.
+     * @param resource $stdout       The subscriber's stdout pipe (non-blocking).
+     * @return bool True if the subscription was confirmed within the timeout.
      */
-    private function waitForShardChannel(string $channel, float $timeoutSec = 5.0)
+    private function waitForShardSubscription($stdout, string $channel, float $timeoutSec = 5.0)
     {
+        if (!is_resource($stdout)) {
+            return false;
+        }
+
+        $seen     = '';
         $deadline = microtime(true) + $timeoutSec;
         do {
-            $active = $this->valkey_glide->pubsub('shardchannels');
-            if (is_array($active) && in_array($channel, $active, true)) {
-                return true;
+            $chunk = fread($stdout, 8192);
+            if ($chunk !== false && $chunk !== '') {
+                $seen .= $chunk;
+                // valkey-cli prints the channel name on its own line as part of
+                // the ssubscribe confirmation push.
+                foreach (explode("\n", $seen) as $line) {
+                    if (trim($line) === $channel) {
+                        return true;
+                    }
+                }
             }
             usleep(100000);
         } while (microtime(true) < $deadline);
@@ -477,8 +492,10 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
 
         $handle = ['proc' => $proc, 'pipes' => $pipes];
 
-        // Wait for the subscription to register (bounded), instead of a fixed sleep.
-        if (!$this->waitForShardChannel($channel)) {
+        // Wait for the subscriber's own SSUBSCRIBE confirmation (bounded), rather
+        // than a fixed sleep. Reading the subscriber's stdout avoids depending on
+        // the shared (non-TLS) test client for the readiness check.
+        if (!$this->waitForShardSubscription($pipes[1], $channel)) {
             // Capture whatever child stderr is available without blocking, then
             // tear the process down.
             $stderr = is_resource($pipes[2]) ? (string) stream_get_contents($pipes[2]) : '';

--- a/tests/ValkeyGlideClusterPubSubTest.php
+++ b/tests/ValkeyGlideClusterPubSubTest.php
@@ -415,20 +415,31 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
         $channel2 = 'test_shardchannel2';
         $channel3 = 'test_shardchannel3';
 
-        // Query specific channels: result is a channel => count map.
+        // Query specific channels. Matching PHPRedis, the reply is passed through
+        // as the raw server response: a flat array laid out as
+        // [channel, count, channel, count, ...] rather than an associative map.
         $result = $this->valkey_glide->pubsub('shardnumsub', [$channel1, $channel2, $channel3]);
         $this->assertIsArray($result);
 
-        // With no active sharded subscribers, every channel reports 0.
-        foreach ([$channel1, $channel2, $channel3] as $channel) {
-            $this->assertTrue(
-                isset($result[$channel]),
-                "SHARDNUMSUB result should contain key '$channel'"
-            );
-            $this->assertEquals(0, $result[$channel]);
+        // Three channels => 3 (channel, count) pairs => 6 flat elements.
+        $this->assertCount(6, $result);
+
+        // Fold the flat [channel, count, ...] array into a map for assertions.
+        $counts = [];
+        for ($i = 0; $i + 1 < count($result); $i += 2) {
+            $counts[$result[$i]] = $result[$i + 1];
         }
 
-        // Calling SHARDNUMSUB without channels is valid and returns an empty map.
+        // With no active sharded subscribers, every queried channel reports 0.
+        foreach ([$channel1, $channel2, $channel3] as $channel) {
+            $this->assertTrue(
+                isset($counts[$channel]),
+                "SHARDNUMSUB result should contain channel '$channel'"
+            );
+            $this->assertEquals(0, $counts[$channel]);
+        }
+
+        // Calling SHARDNUMSUB without channels is valid and returns an empty array.
         $empty = $this->valkey_glide->pubsub('shardnumsub');
         $this->assertIsArray($empty);
         $this->assertEmpty($empty);

--- a/tests/ValkeyGlideClusterPubSubTest.php
+++ b/tests/ValkeyGlideClusterPubSubTest.php
@@ -358,6 +358,72 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
     }
 
     /**
+     * Build the common valkey-cli connection arguments (host, port, and — when
+     * the fixture has them enabled — authentication and TLS options).
+     *
+     * @return string Shell-escaped option string, or null if no CLI is available.
+     */
+    private function shardCliBase(&$cli)
+    {
+        $cli = trim((string) shell_exec('command -v valkey-cli 2>/dev/null'));
+        if ($cli === '') {
+            $cli = trim((string) shell_exec('command -v redis-cli 2>/dev/null'));
+        }
+        if ($cli === '') {
+            return null;
+        }
+
+        $opts = sprintf(
+            '-c -h %s -p %d',
+            escapeshellarg($this->getHost()),
+            $this->getPort()
+        );
+
+        // Authentication (ACL username/password or password-only), if configured.
+        $this->getAuthParts($user, $pass);
+        if ($user !== null && $user !== '') {
+            $opts .= ' --user ' . escapeshellarg($user);
+        }
+        if ($pass !== null && $pass !== '') {
+            $opts .= ' -a ' . escapeshellarg($pass) . ' --no-auth-warning';
+        }
+
+        // TLS, if the fixture is running against a TLS endpoint.
+        if ($this->getTLS()) {
+            $opts .= ' --tls';
+            if (defined('static::TLS_CERTIFICATE_PATH') && is_file(static::TLS_CERTIFICATE_PATH)) {
+                $opts .= ' --cacert ' . escapeshellarg(static::TLS_CERTIFICATE_PATH);
+            }
+        }
+
+        return $opts;
+    }
+
+    /**
+     * Poll (with a bounded timeout) until the given shard channel is reported
+     * active by PUBSUB SHARDCHANNELS, using a short-lived valkey-cli query.
+     *
+     * The PHP client's PUBSUB SHARDCHANNELS is routed across all cluster nodes
+     * and aggregated, so it is used for polling rather than a single-node
+     * valkey-cli query (which only reports channels owned by the queried node).
+     *
+     * @return bool True if the channel became active within the timeout.
+     */
+    private function waitForShardChannel(string $channel, float $timeoutSec = 5.0)
+    {
+        $deadline = microtime(true) + $timeoutSec;
+        do {
+            $active = $this->valkey_glide->pubsub('shardchannels');
+            if (is_array($active) && in_array($channel, $active, true)) {
+                return true;
+            }
+            usleep(100000);
+        } while (microtime(true) < $deadline);
+
+        return false;
+    }
+
+    /**
      * Start a sharded-channel subscriber in a background process using valkey-cli.
      *
      * The PHP client does not yet implement SSUBSCRIBE (see follow-up issue), so
@@ -368,23 +434,25 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
      * multi-channel subscribe across slots fails with CROSSSLOT), so callers
      * that need several channels should start one subscriber per channel.
      *
-     * @return array{proc: resource, pipes: array}|null Null if valkey-cli is unavailable.
+     * Authentication and TLS options from the fixture are forwarded to the CLI so
+     * the subscriber can connect on secured deployments, and the method waits
+     * (with a bounded timeout) for the subscription to actually register rather
+     * than relying on a fixed sleep.
+     *
+     * @return array{proc: resource, pipes: array}|null Null if the CLI is
+     *         unavailable or the subscription did not register in time.
      */
     private function startShardSubscriber(string $channel)
     {
-        $cli = trim((string) shell_exec('command -v valkey-cli 2>/dev/null'));
-        if ($cli === '') {
-            $cli = trim((string) shell_exec('command -v redis-cli 2>/dev/null'));
-        }
-        if ($cli === '') {
+        $baseOpts = $this->shardCliBase($cli);
+        if ($baseOpts === null) {
             return null;
         }
 
         $cmd = sprintf(
-            '%s -c -h %s -p %d ssubscribe %s',
+            '%s %s ssubscribe %s',
             escapeshellarg($cli),
-            escapeshellarg($this->getHost()),
-            $this->getPort(),
+            $baseOpts,
             escapeshellarg($channel)
         );
 
@@ -398,10 +466,32 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
             return null;
         }
 
-        // Give the subscription time to register on its owning node.
-        usleep(400000);
+        // Never block on the child's stdout/stderr pipes (the subscriber runs
+        // indefinitely and keeps them open).
+        if (is_resource($pipes[1])) {
+            stream_set_blocking($pipes[1], false);
+        }
+        if (is_resource($pipes[2])) {
+            stream_set_blocking($pipes[2], false);
+        }
 
-        return ['proc' => $proc, 'pipes' => $pipes];
+        $handle = ['proc' => $proc, 'pipes' => $pipes];
+
+        // Wait for the subscription to register (bounded), instead of a fixed sleep.
+        if (!$this->waitForShardChannel($channel)) {
+            // Capture whatever child stderr is available without blocking, then
+            // tear the process down.
+            $stderr = is_resource($pipes[2]) ? (string) stream_get_contents($pipes[2]) : '';
+            $this->stopShardSubscriber($handle);
+            $this->assertTrue(
+                false,
+                "Sharded subscriber for '$channel' did not register in time"
+                . ($stderr !== '' ? " (stderr: " . trim($stderr) . ")" : '')
+            );
+            return null;
+        }
+
+        return $handle;
     }
 
     /**

--- a/tests/ValkeyGlideClusterPubSubTest.php
+++ b/tests/ValkeyGlideClusterPubSubTest.php
@@ -492,6 +492,14 @@ class ValkeyGlideClusterPubSubTest extends ValkeyGlideClusterBaseTest
             $this->assertContains($channel2, $channels);
             $this->assertContains($channel3, $channels);
 
+            // Explicit null must behave like an omitted pattern (the declared
+            // default is null), not like an empty-string pattern.
+            $nullArg = $this->valkey_glide->pubsub('shardchannels', null);
+            $this->assertIsArray($nullArg);
+            $this->assertContains($channel1, $nullArg);
+            $this->assertContains($channel2, $nullArg);
+            $this->assertContains($channel3, $nullArg);
+
             // With a glob pattern: only the matching subset is returned.
             $matched = $this->valkey_glide->pubsub('shardchannels', 'test_shardchannel*_' . $suffix);
             $this->assertIsArray($matched);

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -2668,23 +2668,21 @@ class ValkeyGlide
      *
      * @param string $command The PUBSUB subcommand (case-insensitive). One of:
      *                        <code>"channels"</code>, <code>"numsub"</code>, <code>"numpat"</code>,
-     *                        <code>"shardchannels"</code>, <code>"shardnumsub"</code>.
+     *                        <code>"shardchannels"</code>.
      * @param mixed  $arg     Depends on the subcommand:
      *                        <code>
      *                        channels / shardchannels - optional glob-style pattern string.
-     *                        numsub / shardnumsub      - optional array of channel names.
+     *                        numsub                    - optional array of channel names.
      *                        numpat                    - no argument.
      *                        </code>
      *
      * @return mixed For <code>channels</code>/<code>shardchannels</code> an array of active
-     *               channels; for <code>numsub</code>/<code>shardnumsub</code> a map of
-     *               channel => subscriber count; for <code>numpat</code> an integer.
+     *               channels; for <code>numsub</code> a flat array of channel/count pairs;
+     *               for <code>numpat</code> an integer.
      *
      * @see https://valkey.io/commands/pubsub-shardchannels/
-     * @see https://valkey.io/commands/pubsub-shardnumsub/
      *
      * @example $valkey_glide->pubsub('shardchannels', 'news.*');
-     * @example $valkey_glide->pubsub('shardnumsub', ['news.sports', 'news.tech']);
      */
     public function pubsub(string $command, mixed $arg = null): mixed;
 

--- a/valkey_glide.stub.php
+++ b/valkey_glide.stub.php
@@ -2661,6 +2661,31 @@ class ValkeyGlide
      */
     public function publish(string $channel, string $message): int;
 
+    /**
+     * Inspect the state of the Pub/Sub subsystem.
+     *
+     * PHPRedis-compatible generic entry point for the PUBSUB command family.
+     *
+     * @param string $command The PUBSUB subcommand (case-insensitive). One of:
+     *                        <code>"channels"</code>, <code>"numsub"</code>, <code>"numpat"</code>,
+     *                        <code>"shardchannels"</code>, <code>"shardnumsub"</code>.
+     * @param mixed  $arg     Depends on the subcommand:
+     *                        <code>
+     *                        channels / shardchannels - optional glob-style pattern string.
+     *                        numsub / shardnumsub      - optional array of channel names.
+     *                        numpat                    - no argument.
+     *                        </code>
+     *
+     * @return mixed For <code>channels</code>/<code>shardchannels</code> an array of active
+     *               channels; for <code>numsub</code>/<code>shardnumsub</code> a map of
+     *               channel => subscriber count; for <code>numpat</code> an integer.
+     *
+     * @see https://valkey.io/commands/pubsub-shardchannels/
+     * @see https://valkey.io/commands/pubsub-shardnumsub/
+     *
+     * @example $valkey_glide->pubsub('shardchannels', 'news.*');
+     * @example $valkey_glide->pubsub('shardnumsub', ['news.sports', 'news.tech']);
+     */
     public function pubsub(string $command, mixed $arg = null): mixed;
 
     /**

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1183,7 +1183,16 @@ class ValkeyGlideCluster
     public function publish(string $channel, string $message): int;
 
     /**
+     * Inspect the state of the Pub/Sub subsystem.
+     *
+     * In addition to the standard subcommands, cluster clients support the sharded
+     * introspection subcommands <code>"shardchannels"</code> and <code>"shardnumsub"</code>
+     * (Valkey/Redis 7.0+). PUBSUB replies in a cluster report information from the queried
+     * node's Pub/Sub context rather than the entire cluster.
+     *
      * @see ValkeyGlide::pubsub
+     * @see https://valkey.io/commands/pubsub-shardchannels/
+     * @see https://valkey.io/commands/pubsub-shardnumsub/
      */
     public function pubsub(string $command, mixed $arg = null): mixed;
 

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1186,9 +1186,11 @@ class ValkeyGlideCluster
      * Inspect the state of the Pub/Sub subsystem.
      *
      * In addition to the standard subcommands, cluster clients support the sharded
-     * introspection subcommand <code>"shardchannels"</code> (Valkey/Redis 7.0+).
-     * PUBSUB replies in a cluster report information from the queried node's Pub/Sub
-     * context rather than the entire cluster.
+     * introspection subcommand <code>"shardchannels"</code> (requires cluster mode and
+     * Valkey/Redis 7.0+). Unlike the non-sharded <code>"channels"</code>/<code>"numsub"</code>
+     * subcommands, <code>"shardchannels"</code> is routed to all cluster nodes and the
+     * per-node results are combined, so the returned list is a cluster-wide view of the
+     * active shard channels rather than a single node's context.
      *
      * @see ValkeyGlide::pubsub
      * @see https://valkey.io/commands/pubsub-shardchannels/

--- a/valkey_glide_cluster.stub.php
+++ b/valkey_glide_cluster.stub.php
@@ -1186,13 +1186,12 @@ class ValkeyGlideCluster
      * Inspect the state of the Pub/Sub subsystem.
      *
      * In addition to the standard subcommands, cluster clients support the sharded
-     * introspection subcommands <code>"shardchannels"</code> and <code>"shardnumsub"</code>
-     * (Valkey/Redis 7.0+). PUBSUB replies in a cluster report information from the queried
-     * node's Pub/Sub context rather than the entire cluster.
+     * introspection subcommand <code>"shardchannels"</code> (Valkey/Redis 7.0+).
+     * PUBSUB replies in a cluster report information from the queried node's Pub/Sub
+     * context rather than the entire cluster.
      *
      * @see ValkeyGlide::pubsub
      * @see https://valkey.io/commands/pubsub-shardchannels/
-     * @see https://valkey.io/commands/pubsub-shardnumsub/
      */
     public function pubsub(string $command, mixed $arg = null): mixed;
 

--- a/valkey_glide_pubsub_introspection.c
+++ b/valkey_glide_pubsub_introspection.c
@@ -118,11 +118,14 @@ void valkey_glide_pubsub_impl(INTERNAL_FUNCTION_PARAMETERS, const void* connecti
         }
     } else if (strcasecmp(cmd, "shardchannels") == 0) {
         // PUBSUB SHARDCHANNELS [pattern]
-        uint32_t       argc     = arg ? 1 : 0;
-        uintptr_t*     args     = argc ? emalloc(argc * sizeof(uintptr_t)) : NULL;
-        unsigned long* args_len = argc ? emalloc(argc * sizeof(unsigned long)) : NULL;
+        // Treat an explicit PHP null the same as an omitted argument so that
+        // pubsub('shardchannels', null) matches pubsub('shardchannels').
+        bool           has_pattern = arg && Z_TYPE_P(arg) != IS_NULL;
+        uint32_t       argc        = has_pattern ? 1 : 0;
+        uintptr_t*     args        = argc ? emalloc(argc * sizeof(uintptr_t)) : NULL;
+        unsigned long* args_len    = argc ? emalloc(argc * sizeof(unsigned long)) : NULL;
 
-        if (arg) {
+        if (has_pattern) {
             convert_to_string(arg);
             args[0]     = (uintptr_t) Z_STRVAL_P(arg);
             args_len[0] = Z_STRLEN_P(arg);

--- a/valkey_glide_pubsub_introspection.c
+++ b/valkey_glide_pubsub_introspection.c
@@ -158,67 +158,14 @@ void valkey_glide_pubsub_impl(INTERNAL_FUNCTION_PARAMETERS, const void* connecti
             RETURN_FALSE;
         }
     } else if (strcasecmp(cmd, "shardnumsub") == 0) {
-        // PUBSUB SHARDNUMSUB [shardchannel ...]
-        // Note: it is valid to call this command without channels; the server
-        // then returns an empty map.
-        HashTable* channels_ht   = NULL;
-        uint32_t   channel_count = 0;
-
-        if (arg) {
-            if (Z_TYPE_P(arg) != IS_ARRAY) {
-                zend_throw_exception(
-                    get_valkey_glide_exception_ce(), "SHARDNUMSUB requires array of channels", 0);
-                RETURN_FALSE;
-            }
-            channels_ht   = Z_ARRVAL_P(arg);
-            channel_count = zend_hash_num_elements(channels_ht);
-        }
-
-        uint32_t       argc     = channel_count;
-        uintptr_t*     args     = argc ? emalloc(argc * sizeof(uintptr_t)) : NULL;
-        unsigned long* args_len = argc ? emalloc(argc * sizeof(unsigned long)) : NULL;
-
-        if (channels_ht) {
-            uint32_t i = 0;
-            zval*    channel_zv;
-            ZEND_HASH_FOREACH_VAL(channels_ht, channel_zv) {
-                convert_to_string(channel_zv);
-                args[i]     = (uintptr_t) Z_STRVAL_P(channel_zv);
-                args_len[i] = Z_STRLEN_P(channel_zv);
-                i++;
-            }
-            ZEND_HASH_FOREACH_END();
-        }
-
-        struct CommandResult* result =
-            command(connection,
-                    0,
-                    (enum RequestType) COMMAND_REQUEST__REQUEST_TYPE__PubSubShardNumSub,
-                    argc,
-                    args,
-                    args_len,
-                    NULL,
-                    0,
-                    0);
-        if (args)
-            efree(args);
-        if (args_len)
-            efree(args_len);
-
-        if (result && result->response && !result->command_error) {
-            command_response_to_zval(result->response, return_value, 0, false);
-            free_command_result(result);
-        } else {
-            const char* error_msg =
-                result && result->command_error && result->command_error->command_error_message
-                    ? result->command_error->command_error_message
-                    : "PUBSUB SHARDNUMSUB command failed";
-            VALKEY_LOG_ERROR("pubsub_shardnumsub", error_msg);
-            if (result)
-                free_command_result(result);
-            zend_throw_exception(get_valkey_glide_exception_ce(), error_msg, 0);
-            RETURN_FALSE;
-        }
+        // PUBSUB SHARDNUMSUB is intentionally not implemented yet. See the
+        // follow-up issue: subscriber counts require investigation of the
+        // cluster response handling, and PHP-native sharded subscriptions
+        // (SSUBSCRIBE) are not implemented, which blocks behavioral testing.
+        zend_throw_exception(get_valkey_glide_exception_ce(),
+                             "PUBSUB SHARDNUMSUB is not yet supported",
+                             0);
+        RETURN_FALSE;
     } else if (strcasecmp(cmd, "numpat") == 0) {
         // PUBSUB NUMPAT
         struct CommandResult* result =

--- a/valkey_glide_pubsub_introspection.c
+++ b/valkey_glide_pubsub_introspection.c
@@ -162,9 +162,8 @@ void valkey_glide_pubsub_impl(INTERNAL_FUNCTION_PARAMETERS, const void* connecti
         // follow-up issue: subscriber counts require investigation of the
         // cluster response handling, and PHP-native sharded subscriptions
         // (SSUBSCRIBE) are not implemented, which blocks behavioral testing.
-        zend_throw_exception(get_valkey_glide_exception_ce(),
-                             "PUBSUB SHARDNUMSUB is not yet supported",
-                             0);
+        zend_throw_exception(
+            get_valkey_glide_exception_ce(), "PUBSUB SHARDNUMSUB is not yet supported", 0);
         RETURN_FALSE;
     } else if (strcasecmp(cmd, "numpat") == 0) {
         // PUBSUB NUMPAT

--- a/valkey_glide_pubsub_introspection.c
+++ b/valkey_glide_pubsub_introspection.c
@@ -116,6 +116,109 @@ void valkey_glide_pubsub_impl(INTERNAL_FUNCTION_PARAMETERS, const void* connecti
             zend_throw_exception(get_valkey_glide_exception_ce(), error_msg, 0);
             RETURN_FALSE;
         }
+    } else if (strcasecmp(cmd, "shardchannels") == 0) {
+        // PUBSUB SHARDCHANNELS [pattern]
+        uint32_t       argc     = arg ? 1 : 0;
+        uintptr_t*     args     = argc ? emalloc(argc * sizeof(uintptr_t)) : NULL;
+        unsigned long* args_len = argc ? emalloc(argc * sizeof(unsigned long)) : NULL;
+
+        if (arg) {
+            convert_to_string(arg);
+            args[0]     = (uintptr_t) Z_STRVAL_P(arg);
+            args_len[0] = Z_STRLEN_P(arg);
+        }
+
+        struct CommandResult* result =
+            command(connection,
+                    0,
+                    (enum RequestType) COMMAND_REQUEST__REQUEST_TYPE__PubSubShardChannels,
+                    argc,
+                    args,
+                    args_len,
+                    NULL,
+                    0,
+                    0);
+        if (args)
+            efree(args);
+        if (args_len)
+            efree(args_len);
+
+        if (result && result->response && !result->command_error) {
+            command_response_to_zval(result->response, return_value, 0, false);
+            free_command_result(result);
+        } else {
+            const char* error_msg =
+                result && result->command_error && result->command_error->command_error_message
+                    ? result->command_error->command_error_message
+                    : "PUBSUB SHARDCHANNELS command failed";
+            VALKEY_LOG_ERROR("pubsub_shardchannels", error_msg);
+            if (result)
+                free_command_result(result);
+            zend_throw_exception(get_valkey_glide_exception_ce(), error_msg, 0);
+            RETURN_FALSE;
+        }
+    } else if (strcasecmp(cmd, "shardnumsub") == 0) {
+        // PUBSUB SHARDNUMSUB [shardchannel ...]
+        // Note: it is valid to call this command without channels; the server
+        // then returns an empty map.
+        HashTable* channels_ht   = NULL;
+        uint32_t   channel_count = 0;
+
+        if (arg) {
+            if (Z_TYPE_P(arg) != IS_ARRAY) {
+                zend_throw_exception(
+                    get_valkey_glide_exception_ce(), "SHARDNUMSUB requires array of channels", 0);
+                RETURN_FALSE;
+            }
+            channels_ht   = Z_ARRVAL_P(arg);
+            channel_count = zend_hash_num_elements(channels_ht);
+        }
+
+        uint32_t       argc     = channel_count;
+        uintptr_t*     args     = argc ? emalloc(argc * sizeof(uintptr_t)) : NULL;
+        unsigned long* args_len = argc ? emalloc(argc * sizeof(unsigned long)) : NULL;
+
+        if (channels_ht) {
+            uint32_t i = 0;
+            zval*    channel_zv;
+            ZEND_HASH_FOREACH_VAL(channels_ht, channel_zv) {
+                convert_to_string(channel_zv);
+                args[i]     = (uintptr_t) Z_STRVAL_P(channel_zv);
+                args_len[i] = Z_STRLEN_P(channel_zv);
+                i++;
+            }
+            ZEND_HASH_FOREACH_END();
+        }
+
+        struct CommandResult* result =
+            command(connection,
+                    0,
+                    (enum RequestType) COMMAND_REQUEST__REQUEST_TYPE__PubSubShardNumSub,
+                    argc,
+                    args,
+                    args_len,
+                    NULL,
+                    0,
+                    0);
+        if (args)
+            efree(args);
+        if (args_len)
+            efree(args_len);
+
+        if (result && result->response && !result->command_error) {
+            command_response_to_zval(result->response, return_value, 0, false);
+            free_command_result(result);
+        } else {
+            const char* error_msg =
+                result && result->command_error && result->command_error->command_error_message
+                    ? result->command_error->command_error_message
+                    : "PUBSUB SHARDNUMSUB command failed";
+            VALKEY_LOG_ERROR("pubsub_shardnumsub", error_msg);
+            if (result)
+                free_command_result(result);
+            zend_throw_exception(get_valkey_glide_exception_ce(), error_msg, 0);
+            RETURN_FALSE;
+        }
     } else if (strcasecmp(cmd, "numpat") == 0) {
         // PUBSUB NUMPAT
         struct CommandResult* result =


### PR DESCRIPTION
### Summary

Implements the `PUBSUB SHARDCHANNELS` introspection command for the PHP client, exposed through the existing PHPRedis-compatible generic `pubsub($command, $arg)` method (no new method names).

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide-php/issues/306
Closes #306

### Features / Behaviour Changes

- `pubsub('shardchannels')` — lists active shard channels; optional glob-style pattern argument.

### Implementation

- **`valkey_glide_pubsub_introspection.c`**: added a `shardchannels` branch to `valkey_glide_pubsub_impl()`, dispatching to the FFI request type `PubSubShardChannels` (906), mirroring the existing `channels` branch. The request type already exists in glide-core, so no core/Rust changes were required.
- **Stubs**: documented the supported `pubsub()` subcommands in `valkey_glide.stub.php` and `valkey_glide_cluster.stub.php`.
- **PHPRedis compatibility**: PHPRedis has no dedicated shard methods; it exposes PUBSUB via the generic `pubsub($keyword, $argument)` method. This PR follows the same approach.

### Testing

Added tests in `tests/ValkeyGlideClusterPubSubTest.php` (gated on `minVersionCheck('7.0.0')`):

- `testPubSubShardChannels` — empty state, then a live `valkey-cli` sharded subscriber: asserts the active channel is listed, matches a glob pattern, and is excluded by a non-matching pattern.
- `testPubSubChannelsAndShardChannelsSeparation` — a sharded channel appears in `SHARDCHANNELS` but not in the regular `CHANNELS` listing.

Results (Valkey 9.1.1, 6-node cluster on ports 7001–7006):

```
ValkeyGlideClusterPubSubTest: Passed: 7  Failed: 0  Skipped: 0  Total: 7
```

Build verified with `make` (extension compiles and loads). C and PHP linting pass (`./lint.sh`).

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.

---

**Note:** The remaining sharded Pub/Sub commands (`SHARDNUMSUB`, `SSUBSCRIBE`, `SUNSUBSCRIBE`, `SPUBLISH`) are tracked in a separate issue: #329.
